### PR TITLE
Remove unused regex import

### DIFF
--- a/gway/runner.py
+++ b/gway/runner.py
@@ -7,8 +7,6 @@ import hashlib
 import threading
 import requests
 
-from regex import W
-
 
 # Extract all async/thread/coroutine runner logic into Runner,
 # and have Gateway inherit from Runner and Resolver.


### PR DESCRIPTION
## Summary
- clean up `gway/runner.py` by removing an unused import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_686701ab78bc8326aa1c87699fc05357