### PR TITLE
Add simple CI and testing docs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run tests
+        run: pytest

--- a/README.rst
+++ b/README.rst
@@ -347,7 +347,20 @@ If there is *not* only one good way to do it, then you should have **three**.
 
 One way implies clarity. Two implies division. Three implies depth. Five implies confusion, and confusion leads to bugs. When offering choices — in interface, design, or abstraction — ensure there are no more than three strong forms. The third may be unexpected, but it must still be necessary.
 
+
 Beyond that, you're just multiplying uncertainty. This same principle applies to other aspects of coding. A simple function fits a single IDE screen. A complex one may span three. Five means: refactor this.
+
+
+Running Tests
+-------------
+
+The unit tests in ``tests/`` rely on the runtime requirements listed in
+``requirements.txt``. Install them first and then run ``pytest``:
+
+.. code-block:: bash
+
+    pip install -r requirements.txt
+    pytest
 
 
 License


### PR DESCRIPTION
## Summary
- document how to run tests and install runtime deps
- add a minimal CI workflow that installs requirements before running tests

## Testing
- `pytest tests/test_auth_charger.py::AuthChargerStatusTests::test_unauthenticated_blocked_on_charger_status -vv -s`
- `pytest tests/test_etron_ws.py::EtronWebSocketTests::test_websocket_connection -vv -s`


------
https://chatgpt.com/codex/tasks/task_e_686716066e588326862faf5842ebf8d2