### PR TITLE
Add init_root builtin

### DIFF
--- a/gway/builtins.py
+++ b/gway/builtins.py
@@ -562,7 +562,39 @@ def shell():
     banner = "GWAY interactive shell.\nfrom gway import gw  # Python 3.13 compatible"
     code.interact(banner=banner, local=local_vars)
 
-# TODO: Create an <init_root> builtin that will create a brand new folder structure
-# for GWAY at the 1) given param directory, 2) GWAY_ROOT/GWAY_PATH/BASE_PATH/APP_ROOT
-# as per the README. This should allow users to start using GWAY in library mode
-# by linking their own projects, data, etc.
+
+def init_root(path: str | None = None) -> str:
+    """Create a minimal GWAY workspace at the resolved path."""
+    from pathlib import Path
+    from gway import gw
+
+    target = Path(
+        gw.resolve(
+            path,
+            "[GWAY_ROOT]",
+            "[GWAY_PATH]",
+            "[BASE_PATH]",
+            "[APP_ROOT]",
+            default=".",
+        )
+    ).resolve()
+
+    subdirs = [
+        "envs/clients",
+        "envs/servers",
+        "projects",
+        "data/static",
+        "logs",
+        "work",
+        "recipes",
+    ]
+
+    for sub in subdirs:
+        (target / sub).mkdir(parents=True, exist_ok=True)
+
+    readme = target / "README.rst"
+    if not readme.exists():
+        readme.write_text("# GWAY Workspace\nCreated by `gway init-root`\n")
+
+    gw.info(f"Initialized root at {target}")
+    return str(target)

--- a/gway/console.py
+++ b/gway/console.py
@@ -55,7 +55,7 @@ def cli_main():
         verbose=args.verbose,
         silent=args.silent,
         name=args.username or "gw",
-        projects=args.projects,
+        project_path=args.projects,
         debug=args.debug,
         wizard=args.wizard
     )
@@ -74,7 +74,14 @@ def cli_main():
         sys.exit(1)
 
     # Run commands
-    all_results, last_result = process(command_sources)
+    run_kwargs = {}
+    if args.projects:
+        run_kwargs['project_path'] = args.projects
+    if args.client:
+        run_kwargs['client'] = args.client
+    if args.server:
+        run_kwargs['server'] = args.server
+    all_results, last_result = process(command_sources, **run_kwargs)
 
     # Resolve expression if requested
     if args.expression:

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -8,7 +8,6 @@ import sys
 import io
 import asyncio
 from gway.gateway import gw
-from gway.builtins import *
 
 class GatewayBuiltinsTests(unittest.TestCase):
 

--- a/tests/test_init_root.py
+++ b/tests/test_init_root.py
@@ -1,0 +1,54 @@
+import unittest
+import tempfile
+import subprocess
+import os
+from pathlib import Path
+from gway import gw
+
+class InitRootTests(unittest.TestCase):
+    def test_creates_expected_structure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = gw.init_root(tmp)
+            root_path = Path(result)
+            expected = [
+                'envs/clients',
+                'envs/servers',
+                'projects',
+                'data/static',
+                'logs',
+                'work',
+                'recipes',
+            ]
+            for sub in expected:
+                self.assertTrue((root_path / sub).is_dir(), f"missing {sub}")
+            self.assertTrue((root_path / 'README.rst').is_file())
+
+    def test_cli_runs_project_from_anywhere(self):
+        with tempfile.TemporaryDirectory() as root_tmp, tempfile.TemporaryDirectory() as cwd_tmp:
+            root_path = Path(gw.init_root(root_tmp))
+            project_dir = root_path / 'projects'
+            proj_file = project_dir / 'demo.py'
+            proj_file.write_text('def say_hi(name="World"):\n    print(f"hello {name}")\n')
+
+            env = os.environ.copy()
+            env['GWAY_ROOT'] = str(root_path)
+
+            cmd = [
+                'gway',
+                'demo',
+                'say-hi',
+                'Codex'
+            ]
+            result = subprocess.run(
+                cmd,
+                cwd=cwd_tmp,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                timeout=10
+            )
+            self.assertIn('hello Codex', result.stdout)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- restore original README
- implement `init_root` builtin for creating a basic GWAY workspace
- avoid collecting builtin `test` function by dropping wildcard import
- test the new builtin
- allow `gway -p` to set project path
- verify custom project works from new root
- discover project path automatically via environment variables

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6866ff145b388326aca2154f2bdb00a7