### PR TITLE
Fix resolver default branch

### DIFF
--- a/gway/sigils.py
+++ b/gway/sigils.py
@@ -106,7 +106,8 @@ class Resolver:
             except KeyError as e:
                 gw.verbose(f"Could not resolve sigil(s) in '{arg}': {e}")
                 last_exc = e
-        if default is not '_raise':
+        # return provided fallback unless user passed the '_raise' sentinel
+        if default != '_raise':
             return default
         if last_exc is not None:
             gw.error(f"All sigil resolutions failed: {last_exc}")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -1,0 +1,15 @@
+import unittest
+from gway.sigils import Resolver
+
+class ResolverDefaultTests(unittest.TestCase):
+    def test_resolve_returns_default(self):
+        resolver = Resolver([])
+        self.assertEqual(resolver.resolve('[missing]', default='fallback'), 'fallback')
+
+    def test_resolve_raises_with_sentinel(self):
+        resolver = Resolver([])
+        with self.assertRaises(KeyError):
+            resolver.resolve('[missing]')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix sentinel comparison in `Resolver.resolve`
- add a test for resolver default behaviour

## Testing
- `python -m unittest tests.test_resolver`

------
https://chatgpt.com/codex/tasks/task_e_68672090f03083269820fdbe30fa064b