### PR TITLE
Remove builtin wildcard import

### DIFF
--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -8,6 +8,7 @@ import sys
 import io
 import asyncio
 from gway.gateway import gw
+import gway.builtins as builtins
 
 class GatewayBuiltinsTests(unittest.TestCase):
 
@@ -23,7 +24,7 @@ class GatewayBuiltinsTests(unittest.TestCase):
     def test_builtins_functions(self):
         # Test if the builtins can be accessed directly and are callable
         try:
-            gw.hello_world()
+            builtins.hello_world()
         except AttributeError as e:
             self.fail(f"AttributeError occurred: {e}")
 


### PR DESCRIPTION
## Summary
- import `gway.builtins` explicitly in builtins tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68672069a1448326a73b50e31c68e66e