### PR TITLE
Improve OCPP simulator control

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -1,0 +1,13 @@
+Running Tests
+-------------
+
+Install the runtime dependencies first. The simplest approach is:
+
+.. code-block:: bash
+
+   pip install -r requirements.txt
+   pip install -e .
+   pytest -q
+
+This ensures that modules such as ``requests`` and ``websockets`` are
+available to the test suite.

--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -1,0 +1,35 @@
+OCPP Components
+---------------
+
+``projects/ocpp`` contains a minimal OCPP 1.6 demo implementation.
+The submodules are:
+
+- ``csms`` – a simple Central System with a status dashboard.
+- ``evcs`` – a charge point simulator that connects to ``csms``.
+- ``sink`` – a message logger for debugging.
+
+Launch a simulator session pointing at your CSMS with:
+
+.. code-block:: bash
+
+   gway ocpp.evcs simulate --host 127.0.0.1 --ws-port 9000 --cp-path CPX
+
+Open ``/ocpp/csms/charger-status`` in your browser and you can send
+``Stop`` or ``Soft Reset`` commands to see the simulator react.
+
+Etron Recipes
+-------------
+
+``recipes/etron`` contains GWAY recipes used in real EV charging
+demos:
+
+- ``local.gwr`` – start both the CSMS dashboard and a simulator on the
+  same machine for quick testing.
+- ``cloud.gwr`` – run a CSMS instance for cloud deployments with an
+  optional RFID allow list.
+
+Run them via ``gway run <recipe>``. For example:
+
+.. code-block:: bash
+
+   gway run recipes/etron/local.gwr

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -8,7 +8,6 @@ import uuid
 import traceback
 import asyncio
 from datetime import datetime
-from bs4 import BeautifulSoup
 from fastapi import WebSocket, WebSocketDisconnect
 from bottle import request, redirect, HTTPError
 from typing import Dict, Optional
@@ -39,7 +38,7 @@ def setup_app(*,
     email=None,
     auth_required=False,
 ):
-    global _transactions, _active_cons, _abnormal_status
+    # no globals needed here; dictionaries are modified in-place
     email = email if isinstance(email, str) else (gw.resolve('[ADMIN_EMAIL]') if email else email)
 
     oapp = app
@@ -64,7 +63,7 @@ def setup_app(*,
 
     @app.websocket("/{path:path}")
     async def websocket_ocpp(websocket: WebSocket, path: str):
-        global _csms_loop, _abnormal_status
+        global _csms_loop
         if auth_required:
             if not gw.web.auth.check_websocket_auth(websocket):
                 await websocket.close(code=4401, reason="Unauthorized")
@@ -317,7 +316,7 @@ def _render_charger_card(cid, tx, state, raw_hb):
     latest_hb = "-"
     if raw_hb:
         try:
-            from datetime import datetime, timezone
+            from datetime import datetime
             dt = datetime.fromisoformat(raw_hb.replace("Z", "+00:00")).astimezone()
             latest_hb = dt.strftime("%Y-%m-%d %H:%M:%S")
         except Exception:

--- a/projects/ocpp/evcs.py
+++ b/projects/ocpp/evcs.py
@@ -171,7 +171,7 @@ async def simulate_cp(
         ) as ws:
             print(f"[Simulator:{cp_name}] Connected to {uri} (auth={'yes' if headers else 'no'})")
 
-            async def listen_to_csms(stop_event):
+            async def listen_to_csms(stop_event, reset_event):
                 try:
                     while True:
                         raw = await ws.recv()
@@ -187,6 +187,13 @@ async def simulate_cp(
                             if action == "RemoteStopTransaction":
                                 print(f"[Simulator:{cp_name}] Received RemoteStopTransaction → stopping transaction")
                                 stop_event.set()
+                            elif action == "Reset":
+                                reset_type = ""
+                                if len(msg) > 3 and isinstance(msg[3], dict):
+                                    reset_type = msg[3].get("type", "")
+                                print(f"[Simulator:{cp_name}] Received Reset ({reset_type}) → restarting session")
+                                reset_event.set()
+                                stop_event.set()
                         else:
                             print(f"[Simulator:{cp_name}] Notice: Unexpected message format", msg)
                 except websockets.ConnectionClosed:
@@ -196,9 +203,10 @@ async def simulate_cp(
             loop_count = 0
             while loop_count < session_count:
                 stop_event = asyncio.Event()
+                reset_event = asyncio.Event()
 
                 # Start listener for this session
-                listener = asyncio.create_task(listen_to_csms(stop_event))
+                listener = asyncio.create_task(listen_to_csms(stop_event, reset_event))
 
                 # Initial handshake
                 await ws.send(json.dumps([2, "boot", "BootNotification", {
@@ -287,6 +295,10 @@ async def simulate_cp(
                     await listener
                 except asyncio.CancelledError:
                     pass
+
+                if reset_event.is_set():
+                    print(f"[Simulator:{cp_name}] Session reset requested.")
+                    continue
 
                 loop_count += 1
                 if session_count == float('inf'):


### PR DESCRIPTION
## Summary
- clean up OCPP CSMS globals and unused imports
- handle Reset messages in EVCS simulator
- document OCPP components and etron recipes in a new project README
- add TESTING.rst with instructions for installing dependencies

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867151d9b288326b014dd5fb3f7d780