### PR TITLE
Add max AWG limit to cable finder

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,6 +55,12 @@ Given ``projects/awg.py`` containing logic to calculate cable sizes and conduit 
     # With conduit calculation
     gway awg find-cable --meters 30 --amps 60 --material cu --volts 240 --conduit emt
 
+    # Limit cable size to AWG 6
+    gway awg find-cable --meters 30 --amps 60 --material cu --volts 240 --max-awg 6
+
+    # Specify 90C cable rating
+    gway awg find-cable --meters 30 --amps 60 --material cu --volts 240 --temperature 90
+
 **Chaining Example**
 
 .. code-block:: bash

--- a/data/static/awg/cable_finder.css
+++ b/data/static/awg/cable_finder.css
@@ -1,0 +1,30 @@
+/* file: data/static/awg/cable_finder.css */
+.cable-form {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(160px, 1fr));
+    gap: 8px 18px;
+    margin-bottom: 1em;
+}
+.cable-form label {
+    display: flex;
+    flex-direction: column;
+    font-weight: 500;
+}
+.cable-form input,
+.cable-form select {
+    margin-top: 3px;
+    padding: 4px 6px;
+    font-size: 1em;
+}
+@media (max-width: 600px) {
+    .cable-form {
+        grid-template-columns: 1fr;
+    }
+}
+.warning {
+    background: #fee;
+    color: #b00;
+    padding: 0.6em 0.8em;
+    border-radius: 4px;
+    margin-top: 0.6em;
+}

--- a/projects/awg.py
+++ b/projects/awg.py
@@ -23,8 +23,10 @@ def find_awg(
     amps: Union[int, str] = "40",
     volts: Union[int, str] = "220",
     material: Literal["cu", "al", "?"] = "cu",
+    max_awg: Optional[Union[int, str]] = None,
     max_lines: Union[int, str] = "1",
     phases: Literal["1", "3", 1, 3] = "2",
+    temperature: Union[int, str, None] = None,
     conduit: Optional[Union[str, bool]] = None,
     ground: Union[int, str] = "1"
 ):
@@ -36,8 +38,13 @@ def find_awg(
         amps: Load in Amperes. Default: 40 A.
         volts: System voltage. Default: 220 V.
         material: 'cu' (copper) or 'al' (aluminum). Default: cu.
+        max_awg: Optional maximum gauge number allowed. If provided,
+            cables thicker than this won't be considered. Example: ``6`` or ``1/0``.
         max_lines: Maximum number of line conductors allowed. Default: 1
         phases: Number of phases for AC (1, 2 or 3). Default: 2
+        temperature: Conductor temperature rating in Celsius. Use ``60``, ``75``
+            or ``90``. ``None`` (default) selects 60C for loads <=100A and 75C
+            otherwise.
         conduit: Conduit type or None.
         ground: Number of ground wires.
     Returns:
@@ -50,7 +57,10 @@ def find_awg(
     meters = int(meters)
     volts = int(volts)
     max_lines = int(max_lines)
+    if max_awg is not None:
+        max_awg = AWG(max_awg)
     phases = int(phases)
+    temperature = None if temperature in (None, "", "auto") else int(temperature)
     ground = int(ground)
 
     assert amps >= 10, f"Minimum load for this calculator is 15 Amps.  Yours: {amps=}."
@@ -59,6 +69,8 @@ def find_awg(
     assert 110 <= volts <= 460, f"Volt range supported must be between 110-460. Yours: {volts=}"
     assert material in ("cu", "al"), "Material must be 'cu' (copper) or 'al' (aluminum)."
     assert phases in (1, 2, 3), "AC phases 1, 2 or 3 to calculate for. DC not supported."
+    if temperature is not None:
+        assert temperature in (60, 75, 90), "Temperature must be 60, 75 or 90"
 
     with gw.sql.open_connection(autoload=True) as cursor:
 
@@ -68,13 +80,18 @@ def find_awg(
         else:
             expr = "2 * :meters * :amps * k_ohm_km / 1000"
 
+        if temperature is None:
+            amp_clause = "(amps_75c >= :amps AND :amps > 100) OR (amps_60c >= :amps AND :amps <= 100)"
+        else:
+            amp_clause = f"amps_{temperature}c >= :amps"
+
         sql = f"""
             SELECT awg_size, line_num, {expr} AS vdrop
             FROM awg_cable_size
             WHERE (material = :material OR :material = '?')
-              AND ((amps_75c >= :amps AND :amps > 100)
-                   OR (amps_60c >= :amps AND :amps <= 100))
+              AND {amp_clause}
               AND line_num <= :max_lines
+              {"" if max_awg is None else "AND awg_size <= :max_awg"}
             ORDER BY awg_size DESC
         """
         params = {
@@ -84,6 +101,8 @@ def find_awg(
             "volts": volts,
             "max_lines": max_lines,
         }
+        if max_awg is not None:
+            params["max_awg"] = int(max_awg)
         gw.debug(f"AWG find-cable SQL candidates: {sql.strip()}, params: {params}")
         cursor.execute(sql, params)
         candidates = cursor.fetchall()
@@ -101,6 +120,7 @@ def find_awg(
                     "meters": meters,
                     "amps": amps,
                     "volts": volts,
+                    "temperature": temperature if temperature is not None else (60 if amps <= 100 else 75),
                     "lines": line_num,
                     "vdrop": vdrop,
                     "vend": volts - vdrop,
@@ -117,8 +137,37 @@ def find_awg(
                 gw.debug(f"Selected cable result: {result}")
                 return result
 
-        # If no suitable cable found, return 'n/a'
-        gw.debug("No cable found within voltage drop limit (3%). Returning 'n/a'.")
+        # If no suitable cable found
+        gw.debug("No cable found within voltage drop limit (3%).")
+        if max_awg is not None and candidates:
+            # Return best effort with warning
+            awg_size, line_num, vdrop = candidates[0]
+            awg_res = AWG(awg_size)
+            perc = vdrop / volts
+            cables = line_num * (phases + ground)
+            result = {
+                "awg": str(awg_res),
+                "meters": meters,
+                "amps": amps,
+                "volts": volts,
+                "temperature": temperature if temperature is not None else (60 if amps <= 100 else 75),
+                "lines": line_num,
+                "vdrop": vdrop,
+                "vend": volts - vdrop,
+                "vdperc": perc * 100,
+                "cables": f"{cables - 1}+{ground}",
+                "total_meters": f"{(cables - 1) * meters}+{meters*ground}",
+                "warning": "Voltage drop exceeds 3% with given max_awg",
+            }
+            if conduit:
+                if conduit is True:
+                    conduit = "emt"
+                fill = find_conduit(awg_res, cables, conduit=conduit)
+                result["conduit"] = conduit
+                result["pipe_inch"] = fill["size_inch"]
+            gw.debug(f"Returning best effort with warning: {result}")
+            return result
+
         return {"awg": "n/a"}
 
 
@@ -147,38 +196,50 @@ def find_conduit(awg, cables, *, conduit="emt"):
 
 
 def view_cable_finder(
-    *, meters=None, amps="40", volts="220", material="cu", 
-    max_lines="3", phases="1", conduit=None, neutral="0", **kwargs
+    *, meters=None, amps="40", volts="220", material="cu",
+    max_lines="3", max_awg=None, phases="1", temperature=None,
+    conduit=None, neutral="0", **kwargs
 ):
     """Page builder for AWG cable finder with HTML form and result."""
     # TODO: Add a image with the sponsor logo on the right side of the result page
     if not meters:
-        return '''<h1>AWG Cable Finder</h1>
-            <form method="post">
-                <label>Meters: <input type="number" name="meters" required min="1" /></label><br/>
-                <label>Amps: <input type="number" name="amps" value="40" /></label><br/>
-                <label>Volts: <input type="number" name="volts" value="220" /></label><br/>
-                <label>Material: 
+        return '''<link rel="stylesheet" href="/static/awg/cable_finder.css">
+            <h1>AWG Cable Finder</h1>
+            <form method="post" class="cable-form">
+                <label>Meters:<input type="number" name="meters" required min="1" /></label>
+                <label>Amps:<input type="number" name="amps" value="40" /></label>
+                <label>Volts:<input type="number" name="volts" value="220" /></label>
+                <label>Material:
                     <select name="material">
                         <option value="cu">Copper (cu)</option>
                         <option value="al">Aluminum (al)</option>
                     </select>
-                </label><br/>
-                <label>Phases: 
+                </label>
+                <label>Phases:
                     <select name="phases">
                         <option value="2">AC Two Phases (2)</option>
                         <option value="1">AC Single Phase (1)</option>
                         <option value="3">AC Three Phases (3)</option>
                     </select>
-                </label><br/>
-                <label>Max Lines: <input type="number" name="max_lines" value="1" /></label><br/>
+                </label>
+                <label>Temperature:
+                    <select name="temperature">
+                        <option value="auto">Auto</option>
+                        <option value="60">60C</option>
+                        <option value="75">75C</option>
+                        <option value="90">90C</option>
+                    </select>
+                </label>
+                <label>Max AWG:<input type="text" name="max_awg" /></label>
+                <label>Max Lines:<input type="number" name="max_lines" value="1" /></label>
                 <button type="submit" class="submit">Find Cable</button>
             </form>
         '''
     try:
         result = find_awg(
             meters=meters, amps=amps, volts=volts,
-            material=material, max_lines=max_lines, phases=phases, 
+            material=material, max_lines=max_lines, phases=phases,
+            max_awg=max_awg, temperature=temperature,
         )
     except Exception as e:
         return f"<p class='error'>Error: {e}</p><p><a href='/awg/cable-finder'>&#8592; Try again</a></p>"
@@ -200,7 +261,9 @@ def view_cable_finder(
             <li><strong>Total Length (m):</strong> {result['total_meters']}</li>
             <li><strong>Voltage Drop:</strong> {result['vdrop']:.2f} V ({result['vdperc']:.2f}%)</li>
             <li><strong>Voltage at End:</strong> {result['vend']:.2f} V</li>
+            <li><strong>Temperature Rating:</strong> {result['temperature']}C</li>
         </ul>
+        {f"<p class='warning'>{result['warning']}</p>" if result.get('warning') else ''}
         <p>
         <em>Special thanks to the expert electrical engineers at <strong>
         <a href="https://www.gelectriic.com">Gelectriic Solutions</a></strong> for their 

--- a/tests/test_awg.py
+++ b/tests/test_awg.py
@@ -1,0 +1,17 @@
+import unittest
+from gway import gw
+
+class TestMaxAwg(unittest.TestCase):
+    def test_warning_when_voltage_drop_exceeds_limit(self):
+        res = gw.awg.find_awg(meters=300, amps=100, volts=240, material="cu", max_lines=1, max_awg=4)
+        self.assertIn("warning", res)
+        self.assertEqual(res["awg"], "1")
+        self.assertGreater(res["vdperc"], 3)
+
+    def test_temperature_selection_affects_awg(self):
+        r60 = gw.awg.find_awg(meters=30, amps=60, volts=240, material="cu", temperature=60)
+        r75 = gw.awg.find_awg(meters=30, amps=60, volts=240, material="cu", temperature=75)
+        self.assertNotEqual(r60["awg"], r75["awg"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow specifying `max_awg` in `find_awg`
- expose `max_awg` in the cable finder web UI
- warn when voltage drop exceeds limit for constrained AWG
- implement temperature selection and style form in two columns
- document `--max-awg` and `--temperature` CLI options
- test max AWG behavior and temperature effect

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867274ea1188326b9c36ec1c142a486