### PR TITLE
Use test recipes with unique ports

### DIFF
--- a/recipes/test/etron/cloud.gwr
+++ b/recipes/test/etron/cloud.gwr
@@ -1,0 +1,20 @@
+# file: recipes/etron/cloud.gwr
+# OCPP 1.6 CSMS Recipe for Central Cloud Server
+
+web app setup-app --project ocpp.csms --home charger-status
+    --project ocpp.csms --home cp-simulator
+    --project web.cookies 
+    --project web.nav
+    --project vbox 
+   
+# Toggle this version to apply the allow list  
+ocpp csms setup-app --allow data/etron/rfids.cdv --location etron_cloud
+
+# Without --allow, all transactions will be allowed by default
+# ocpp csms setup-app --location porsche_centre --deny data/etron/rfids.cdv
+
+web static collect
+web auth config-basic --temp-link
+web server start-app --host 0.0.0.0 --port 18000 --ws-port 19000 
+
+until --file VERSION

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -1,0 +1,25 @@
+# file: recipes/website.gwr
+# Minimal GWAY demo website ingredients
+
+# Lines without a starting command repeat the previous with new params
+
+web app setup-app --home reader
+    --project awg --home cable-finder
+    --project web.nav --home style-switcher
+    --project web.cookies --home cookie-jar
+    --project vbox --home uploads 
+    --project ocpp.csms --auth-required --home charger-status
+    --project ocpp.evcs --auth-required --home cp-simulator
+    --project games.conway --home game-of-life --path conway
+    --project games.mtg --home search-games 
+    --project web.auth 
+
+web static collect
+web auth config-basic --optional --temp-link
+
+ocpp csms setup-app --location simulator
+
+web server start-app --port 18888 --ws-port 19999
+
+# Loop until VERSION or PyPI changes
+until --file VERSION --pypi 

--- a/tests/test_auth_charger.py
+++ b/tests/test_auth_charger.py
@@ -36,14 +36,14 @@ class AuthChargerStatusTests(unittest.TestCase):
         _remove_test_user()
         # Start the server
         cls.proc = subprocess.Popen(
-            ["gway", "-r", "website"],
+            ["gway", "-r", "test/website"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
         )
-        cls._wait_for_port(8888, timeout=18)
+        cls._wait_for_port(18888, timeout=18)
         time.sleep(2)
-        cls.base_url = "http://127.0.0.1:8888"
+        cls.base_url = "http://127.0.0.1:18888"
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_conway_web.py
+++ b/tests/test_conway_web.py
@@ -17,15 +17,15 @@ class ConwayWebTests(unittest.TestCase):
     def setUpClass(cls):
         # Start the demo website (port 8888)
         cls.proc = subprocess.Popen(
-            ["gway", "-r", "website"],
+            ["gway", "-r", "test/website"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
         )
-        cls._wait_for_port(8888, timeout=15)
+        cls._wait_for_port(18888, timeout=15)
         # Give server time to finish startup
         time.sleep(2)
-        cls.base_url = "http://127.0.0.1:8888"
+        cls.base_url = "http://127.0.0.1:18888"
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/test_etron_ws.py
+++ b/tests/test_etron_ws.py
@@ -39,12 +39,12 @@ class EtronWebSocketTests(unittest.TestCase):
 
             # --- START SERVER ---
             cls.proc = subprocess.Popen(
-                ["gway", "-r", "etron/cloud"],
+                ["gway", "-r", "test/etron/cloud"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,
             )
-            cls._wait_for_port(9000, timeout=12)
+            cls._wait_for_port(19000, timeout=12)
         except Exception as e:
             # Read and print whatever the process wrote
             try:
@@ -122,7 +122,7 @@ class EtronWebSocketTests(unittest.TestCase):
 
     def test_websocket_connection(self):
         """Confirm we can connect to the OCPP server and receive BootNotification response."""
-        uri = "ws://localhost:9000/charger123?token=foo"
+        uri = "ws://localhost:19000/charger123?token=foo"
         async def run_ws_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"], open_timeout=15) as websocket:
                 message_id = "boot-test"
@@ -141,7 +141,7 @@ class EtronWebSocketTests(unittest.TestCase):
     def test_authorize_valid_rfid(self):
         """RFID in allowlist with balance >=1 should be Accepted"""
         self._set_balance(KNOWN_GOOD_TAG, 100)
-        uri = "ws://localhost:9000/tester1?token=foo"
+        uri = "ws://localhost:19000/tester1?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-valid"
@@ -158,7 +158,7 @@ class EtronWebSocketTests(unittest.TestCase):
     def test_authorize_with_extra_fields(self):
         """RFID with additional fields in CDV still authorizes correctly"""
         self.__class__.gw_cdv_update(KNOWN_GOOD_TAG, balance="55", foo="bar", baz="qux")
-        uri = "ws://localhost:9000/tester2?token=foo"
+        uri = "ws://localhost:19000/tester2?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-extra"
@@ -175,7 +175,7 @@ class EtronWebSocketTests(unittest.TestCase):
     def test_authorize_low_balance(self):
         """RFID present but balance <1 should be Rejected"""
         self._set_balance(KNOWN_GOOD_TAG, 0)
-        uri = "ws://localhost:9000/tester3?token=foo"
+        uri = "ws://localhost:19000/tester3?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-lowbal"
@@ -192,7 +192,7 @@ class EtronWebSocketTests(unittest.TestCase):
     def test_authorize_admin_tag(self):
         """Admin tag should be accepted (if balance >=1)"""
         self._set_balance(ADMIN_TAG, 150)
-        uri = "ws://localhost:9000/admin?token=foo"
+        uri = "ws://localhost:19000/admin?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-admin"
@@ -208,7 +208,7 @@ class EtronWebSocketTests(unittest.TestCase):
 
     def test_authorize_unknown_rfid(self):
         """Unknown tag must be rejected"""
-        uri = "ws://localhost:9000/unknown?token=foo"
+        uri = "ws://localhost:19000/unknown?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-unknown"
@@ -227,8 +227,8 @@ class EtronWebSocketTests(unittest.TestCase):
         self._set_balance(KNOWN_GOOD_TAG, 100)
         self._set_balance(ADMIN_TAG, 0)
         uris = [
-            "ws://localhost:9000/chargerA?token=foo",
-            "ws://localhost:9000/chargerB?token=foo"
+            "ws://localhost:19000/chargerA?token=foo",
+            "ws://localhost:19000/chargerB?token=foo"
         ]
         async def run_concurrent():
             async def connect_and_auth(uri, idtag):
@@ -250,7 +250,7 @@ class EtronWebSocketTests(unittest.TestCase):
     def test_authorize_missing_balance(self):
         """If balance is missing, should be treated as 0 and Rejected."""
         self.__class__.gw_cdv_update(KNOWN_GOOD_TAG, user="test")  # No balance field!
-        uri = "ws://localhost:9000/missingbal?token=foo"
+        uri = "ws://localhost:19000/missingbal?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-missingbal"
@@ -266,7 +266,7 @@ class EtronWebSocketTests(unittest.TestCase):
 
     def test_server_ignores_callresult_messages(self):
         """Server should ignore valid [3, ...] CALLRESULT messages from client."""
-        uri = "ws://localhost:9000/callresult1?token=foo"
+        uri = "ws://localhost:19000/callresult1?token=foo"
         async def run_ignore_callresult():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "irrelevant-id"
@@ -286,7 +286,7 @@ class EtronWebSocketTests(unittest.TestCase):
 
     def test_server_ignores_callerror_messages(self):
         """Server should ignore valid [4, ...] CALLERROR messages from client."""
-        uri = "ws://localhost:9000/callerror1?token=foo"
+        uri = "ws://localhost:19000/callerror1?token=foo"
         async def run_ignore_callerror():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "irrelevant-id"
@@ -368,7 +368,7 @@ class EtronWebSocketTests(unittest.TestCase):
 
     def test_remote_stop_transaction(self):
         """Dashboard Stop action triggers RemoteStopTransaction on the CP."""
-        uri = "ws://localhost:9000/stopper?token=foo"
+        uri = "ws://localhost:19000/stopper?token=foo"
 
         async def run_stop_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as ws:
@@ -389,7 +389,7 @@ class EtronWebSocketTests(unittest.TestCase):
                 # Issue Stop from dashboard
                 await asyncio.to_thread(
                     requests.post,
-                    "http://127.0.0.1:8000/ocpp/csms/charger-status",
+                    "http://127.0.0.1:18000/ocpp/csms/charger-status",
                     data={"charger_id": "stopper", "action": "remote_stop", "do": "send"},
                     timeout=5,
                 )

--- a/tests/test_nav_styles.py
+++ b/tests/test_nav_styles.py
@@ -12,15 +12,15 @@ class NavStyleTests(unittest.TestCase):
     def setUpClass(cls):
         # Launch the website recipe on a test port (8888)
         cls.proc = subprocess.Popen(
-            ["gway", "-r", "website"],
+            ["gway", "-r", "test/website"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
         )
-        cls._wait_for_port(8888, timeout=15)
+        cls._wait_for_port(18888, timeout=15)
         # Let the server warm up
         time.sleep(2)
-        cls.base_url = "http://127.0.0.1:8888"
+        cls.base_url = "http://127.0.0.1:18888"
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
## Summary
- add test-specific copies of the `website` and `etron/cloud` recipes that listen on high ports
- update tests to run these new recipes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68673fdcc36c8326a95cdc54c0f3aee5