### PR TITLE
Disable default CI tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,11 @@
 name: tests
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+  # Manual invocation via the GitHub UI
+  workflow_dispatch:
+  # Run on release events to validate packages
+  release:
+    types: [published]
 
 jobs:
   tests:


### PR DESCRIPTION
## Summary
- adjust GitHub Actions workflow
  - remove push/pull triggers
  - allow manual or release-triggered runs only

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest` *(fails: Ran 0 tests)*

------
https://chatgpt.com/codex/tasks/task_e_6867f147b6e48326af71055fc18b03e8