### PR TITLE
Add Odoo project task helper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,22 @@ This launches an interactive web UI that lets you browse your project, inspect h
 
 Visit `http://localhost:8888` once it's running.
 
+Odoo Project Tasks
+~~~~~~~~~~~~~~~~~~
+
+You can add tasks to your Odoo projects without leaving the terminal.
+
+.. code-block:: bash
+
+    export ODOO_DEFAULT_PROJECT="Internal"
+    gway odoo create-task --customer "Acme Corp" \
+        --phone 5551234567 --notes "Requested callback next week" \
+        --new-customer
+
+Using ``--new-customer`` creates the partner before the task and the phone and
+note details are included in the task description. If ``--title`` is omitted,
+the task title defaults to the customer name.
+
 
 You can use a similar syntax to lunch any .gwr (GWAY Recipe) files you find. You can register them on your OS for automatic execution with the following command (Administrator/root privileges may be required):
 

--- a/tests/test_odoo.py
+++ b/tests/test_odoo.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import patch
+from gway import gw
+
+odoo = gw.load_project("odoo")
+
+
+class TestCreateTask(unittest.TestCase):
+    def test_title_defaults_to_customer(self):
+        calls = {}
+
+        def fake_execute_kw(args, kwargs, *, model, method):
+            if model == 'res.partner' and method == 'create':
+                calls['partner'] = args[0]
+                return 5
+            if model == 'project.task' and method == 'create':
+                calls['task'] = args[0]
+                return 10
+            if model == 'project.task' and method == 'read':
+                return [{**calls['task'], 'id': 10}]
+            return []
+
+        with patch('odoo.execute_kw', side_effect=fake_execute_kw):
+            task = odoo.create_task(
+                project=1,
+                customer='ACME',
+                phone='123',
+                notes='Hello',
+                new_customer=True,
+            )
+        self.assertEqual(task[0]['name'], 'ACME')
+        self.assertEqual(calls['task']['name'], 'ACME')
+        self.assertEqual(calls['task']['project_id'], 1)
+        self.assertEqual(calls['task']['partner_id'], 5)
+        self.assertEqual(task[0]['description'], 'Phone: 123\nHello')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend Odoo integration with helper for project tasks
- document how to create tasks from the CLI using ODOO_DEFAULT_PROJECT
- allow task title to default to the customer name
- test the create_task helper

## Testing
- `pip install -e .[dev]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6868092cef68832691ed10c99b6d87e6