### PR TITLE
Fix ground wires counted per line

### DIFF
--- a/projects/awg.py
+++ b/projects/awg.py
@@ -51,7 +51,7 @@ def find_awg(
             or ``90``. ``None`` (default) selects 60C for loads <=100A and 75C
             otherwise.
         conduit: Conduit type or None.
-        ground: Number of ground wires.
+        ground: Number of ground wires per line.
     Returns:
         dict with cable selection and voltage drop info, or {'awg': 'n/a'} if not possible.
     """
@@ -153,8 +153,8 @@ def find_awg(
                     "vdrop": vdrop,
                     "vend": volts - vdrop,
                     "vdperc": perc * 100,
-                    "cables": f"{n * phases}+{ground}",
-                    "total_meters": f"{n * phases * meters}+{meters * ground}",
+                    "cables": f"{n * phases}+{n * ground}",
+                    "total_meters": f"{n * phases * meters}+{meters * n * ground}",
                 }
                 if perc <= 0.03:
                     if conduit:

--- a/tests/test_awg.py
+++ b/tests/test_awg.py
@@ -16,6 +16,7 @@ class TestMaxAwg(unittest.TestCase):
         self.assertEqual(res["awg"], "4")
         self.assertEqual(res["lines"], 2)
         self.assertLess(res["vdperc"], 3)
+        self.assertEqual(res["cables"], "4+2")
 
     def test_respects_max_awg_limit(self):
         res = gw.awg.find_awg(meters=250, amps=125, volts=240, material="cu", max_awg=4)


### PR DESCRIPTION
## Summary
- ensure cable counts consider one ground per line in AWG finder
- test for ground count in output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868a435c1008326ab341c9af1d9e1e6