### PR TITLE
Fix Unicode search handling in mail

### DIFF
--- a/tests/test_mail_utf8.py
+++ b/tests/test_mail_utf8.py
@@ -1,0 +1,61 @@
+import unittest
+import os
+from unittest.mock import patch
+from email.mime.text import MIMEText
+from gway import gw
+
+class FakeIMAP:
+    instances = []
+    def __init__(self, server, port):
+        self.server = server
+        self.port = port
+        self._encoding = 'ascii'
+        self.utf8_enabled = False
+        FakeIMAP.instances.append(self)
+    def login(self, user, password):
+        pass
+    def enable(self, capability):
+        if capability.upper() == 'UTF8=ACCEPT':
+            self._encoding = 'utf-8'
+            self.utf8_enabled = True
+            return 'OK', [b'enabled']
+        raise Exception('unsupported')
+    def select(self, mailbox):
+        pass
+    def search(self, charset, criteria):
+        if isinstance(criteria, str):
+            criteria.encode(self._encoding)
+        else:
+            criteria.decode(self._encoding)
+        self.last_search = (charset, criteria)
+        return 'OK', [b'1']
+    def fetch(self, mail_id, mode):
+        msg = MIMEText('respuesta')
+        return 'OK', [(None, msg.as_bytes())]
+    def close(self):
+        pass
+    def logout(self):
+        pass
+
+class MailUTF8Tests(unittest.TestCase):
+    def setUp(self):
+        os.environ['MAIL_SENDER'] = 'test@example.com'
+        os.environ['MAIL_PASSWORD'] = 'secret'
+        os.environ['IMAP_SERVER'] = 'imap.example.com'
+        os.environ['IMAP_PORT'] = '993'
+        FakeIMAP.instances.clear()
+
+    def tearDown(self):
+        for var in ['MAIL_SENDER','MAIL_PASSWORD','IMAP_SERVER','IMAP_PORT']:
+            os.environ.pop(var, None)
+
+    def test_unicode_subject_search(self):
+        with patch('imaplib.IMAP4_SSL', FakeIMAP):
+            content, attachments = gw.mail.search('instalación')
+            self.assertEqual(content, 'respuesta')
+            fake = FakeIMAP.instances[0]
+            self.assertTrue(fake.utf8_enabled)
+            self.assertEqual(fake.last_search[0], None)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- handle UTF-8 search criteria in `projects/mail.search`
- add regression test for UTF-8 email searches

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869509a008c8326a7ad2dce70b25e94