### PR TITLE
Add repair option to installers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,13 @@ To run GWAY automatically as a service using a recipe:
     sudo ./install.sh <recipe>   # On Linux/macOS
     install.bat <recipe>         # On Windows
 
+To apply updated service definitions to all installed services:
+
+.. code-block:: bash
+
+    sudo ./install.sh --repair   # On Linux/macOS
+    install.bat --repair         # On Windows
+
 On Windows, the installed service will automatically restart if it exits
 unexpectedly.
 

--- a/install.bat
+++ b/install.bat
@@ -4,6 +4,17 @@ setlocal
 rem Ensure the script runs from its own directory
 cd /d "%~dp0"
 
+rem Repair previously installed services
+if "%~1"=="--repair" (
+    echo Repairing installed gway services...
+    for /f "usebackq delims=" %%R in (
+        `powershell -NoProfile -Command "Get-Service | Where-Object { $_.Name -like 'gway-*' } | ForEach-Object { sc.exe qc $_.Name | Select-String '-r ' | ForEach-Object { if (\$_ -match '-r\\s+([^\"\\s]+)') { $matches[1] } } }"`
+    ) do (
+        call "%~f0" %%R
+    )
+    goto :eof
+)
+
 rem Create .venv and install package if not present
 if not exist ".venv" (
     echo Creating virtual environment...
@@ -24,6 +35,8 @@ if "%~1"=="" (
     echo GWAY has been set up in .venv.
     echo To install a Windows service for a recipe, run:
     echo   install.bat ^<recipe^>
+    echo To repair all existing services, run:
+    echo   install.bat --repair
     goto :eof
 )
 


### PR DESCRIPTION
## Summary
- add `--repair` flag to `install.sh`
- add `--repair` flag to `install.bat`
- document how to repair services in README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686969690cfc8326bb6c16389dac0715