### PR TITLE
Add service listing option to installers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -174,6 +174,13 @@ To run GWAY automatically as a service using a recipe:
     sudo ./install.sh <recipe>   # On Linux/macOS
     install.bat <recipe>         # On Windows
 
+List installed services:
+
+.. code-block:: bash
+
+    sudo ./install.sh --show
+    install.bat --show
+
 On Windows, the installed service will automatically restart if it exits
 unexpectedly.
 

--- a/install.bat
+++ b/install.bat
@@ -1,6 +1,18 @@
 @echo off
 setlocal
 
+if "%~1"=="--help" (
+    echo Usage: install.bat [--show] [recipe]
+    echo   --show    List installed gway services
+    goto :eof
+)
+
+if "%~1"=="--show" (
+    echo Installed GWAY services:
+    for /f "tokens=2 delims=:" %%S in ('sc.exe query state^= all ^| findstr "SERVICE_NAME: gway-"') do echo %%S
+    goto :eof
+)
+
 rem Ensure the script runs from its own directory
 cd /d "%~dp0"
 


### PR DESCRIPTION
## Summary
- enable `--show` option for install.sh to list installed services
- add `--show` option to install.bat
- document how to list installed services

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869605151d48326a13766b1d1f50940