### PR TITLE
Improve sigils tests

### DIFF
--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -11,5 +11,34 @@ class ResolverDefaultTests(unittest.TestCase):
         with self.assertRaises(KeyError):
             resolver.resolve('[missing]')
 
+class ResolverLookupTests(unittest.TestCase):
+    def setUp(self):
+        self.resolver = Resolver([
+            ('env', {}),
+            ('ctx', {'foo_bar': 'spam'})
+        ])
+
+    def test_contains_and_get(self):
+        self.assertTrue('[foo_bar]' in self.resolver)
+        self.assertFalse('[missing]' in self.resolver)
+        self.assertEqual(self.resolver['foo_bar'], 'spam')
+        self.assertEqual(self.resolver.get('foo_bar'), 'spam')
+
+    def test_keys_returns_union(self):
+        self.assertIn('foo_bar', self.resolver.keys())
+
+    def test_dash_underscore_item_access(self):
+        self.resolver._search_order.append(('extra', {'hello-world': 'hi'}))
+        self.assertEqual(self.resolver['hello-world'], 'hi')
+
+    def test_env_variable_resolution(self):
+        import os
+        os.environ['SIGTEST'] = 'ok'
+        env_resolver = Resolver([('env', {}), ('ctx', {})])
+        try:
+            self.assertEqual(env_resolver.resolve('[sigtest]'), 'ok')
+        finally:
+            del os.environ['SIGTEST']
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sigils.py
+++ b/tests/test_sigils.py
@@ -46,6 +46,19 @@ class SigilTests(unittest.TestCase):
         self.assertIn("[val]", str(s))
         self.assertIn("[val]", repr(s))
 
+    def test_make_lookup_with_callable_variants(self):
+        def finder(key, _):
+            if key == "FOO_BAR":
+                return "bar"
+        s = Sigil("Value [FOO-BAR]")
+        self.assertEqual(s.resolve(finder), "Value bar")
+
+    def test_unquote_helper(self):
+        from gway.sigils import _unquote
+        self.assertEqual(_unquote('"hello"'), "hello")
+        self.assertEqual(_unquote("'world'"), "world")
+        self.assertEqual(_unquote("plain"), "plain")
+
 class SpoolTests(unittest.TestCase):
     def setUp(self):
         self.mapping = {"A": "apple", "B": "banana", "C": "cucumber"}
@@ -81,6 +94,11 @@ class SpoolTests(unittest.TestCase):
         spool = Spool("[X]", "[A]")
         # Provide a gw-style object with .resolve()
         self.assertEqual(spool.resolve(self.mapping), "apple")
+
+    def test_spool_flatten_and_str(self):
+        spool = Spool(["[A]", ["[B]", "[C]"]])
+        self.assertEqual(len(spool), 3)
+        self.assertEqual(str(spool), "[A] | [B] | [C]")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- cover `Sigil._make_lookup` using a callable
- verify quote handling via `_unquote`
- test `Spool` flattening and string conversion
- add Resolver lookup tests covering `__contains__`, `.get`, `.keys`, dash/underscore matching and env var handling

## Testing
- `pytest -q tests/test_sigils.py tests/test_resolver.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68696badeb7083269d8948f44d919d7f