### PR TITLE
Fix escaping in mail search

### DIFF
--- a/projects/mail.py
+++ b/projects/mail.py
@@ -12,6 +12,11 @@ from email.mime.text import MIMEText
 from email import message_from_bytes
 
 
+def _escape_imap_string(value: str) -> str:
+    """Escape backslashes and quotes for IMAP SEARCH."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
 def send(subject, body=None, to=None, threaded=None, **kwargs):
     """
     Send an email with the specified subject and body, using defaults from env if available.
@@ -125,9 +130,11 @@ def search(subject_fragment, body_fragment=None):
 
         search_criteria = []
         if subject_fragment and subject_fragment != "*":
-            search_criteria.append(f'(SUBJECT "{subject_fragment}")')
+            esc_subject = _escape_imap_string(subject_fragment)
+            search_criteria.append(f'(SUBJECT "{esc_subject}")')
         if body_fragment:
-            search_criteria.append(f'(BODY "{body_fragment}")')
+            esc_body = _escape_imap_string(body_fragment)
+            search_criteria.append(f'(BODY "{esc_body}")')
 
         if not search_criteria:
             gw.warning("No search criteria provided.")

--- a/tests/test_mail_quotes.py
+++ b/tests/test_mail_quotes.py
@@ -1,0 +1,63 @@
+import unittest
+import os
+from unittest.mock import patch
+from email.mime.text import MIMEText
+from gway import gw
+
+
+class FakeIMAP:
+    instances = []
+    def __init__(self, server, port):
+        self.server = server
+        self.port = port
+        self._encoding = 'ascii'
+        self.utf8_enabled = False
+        FakeIMAP.instances.append(self)
+    def login(self, user, password):
+        pass
+    def enable(self, capability):
+        if capability.upper() == 'UTF8=ACCEPT':
+            self._encoding = 'utf-8'
+            self.utf8_enabled = True
+            return 'OK', [b'enabled']
+        raise Exception('unsupported')
+    def select(self, mailbox):
+        pass
+    def search(self, charset, criteria):
+        if isinstance(criteria, str):
+            criteria.encode(self._encoding)
+        else:
+            criteria.decode(self._encoding)
+        self.last_search = (charset, criteria)
+        return 'OK', [b'1']
+    def fetch(self, mail_id, mode):
+        msg = MIMEText('respuesta')
+        return 'OK', [(None, msg.as_bytes())]
+    def close(self):
+        pass
+    def logout(self):
+        pass
+
+class MailQuoteEscapeTests(unittest.TestCase):
+    def setUp(self):
+        os.environ['MAIL_SENDER'] = 'test@example.com'
+        os.environ['MAIL_PASSWORD'] = 'secret'
+        os.environ['IMAP_SERVER'] = 'imap.example.com'
+        os.environ['IMAP_PORT'] = '993'
+        FakeIMAP.instances.clear()
+
+    def tearDown(self):
+        for var in ['MAIL_SENDER','MAIL_PASSWORD','IMAP_SERVER','IMAP_PORT']:
+            os.environ.pop(var, None)
+
+    def test_subject_with_quotes(self):
+        with patch('imaplib.IMAP4_SSL', FakeIMAP):
+            content, attachments = gw.mail.search('He said "Hi"')
+            self.assertEqual(content, 'respuesta')
+            fake = FakeIMAP.instances[0]
+            expected = '(SUBJECT "He said \\"Hi\\"")'
+            self.assertEqual(fake.last_search[1], expected)
+            self.assertTrue(fake.utf8_enabled)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- escape backslashes and quotes when building mail search criteria
- add regression test for subjects containing quotes

## Testing
- `pytest tests/test_mail_utf8.py tests/test_mail_quotes.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686975c53a7483268f1dfbb00e24f206