### PR TITLE
Handle IMAP search charset errors

### DIFF
--- a/tests/test_mail_utf8.py
+++ b/tests/test_mail_utf8.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import imaplib
 from unittest.mock import patch
 from email.mime.text import MIMEText
 from gway import gw
@@ -55,6 +56,27 @@ class MailUTF8Tests(unittest.TestCase):
             self.assertEqual(content, 'respuesta')
             fake = FakeIMAP.instances[0]
             self.assertTrue(fake.utf8_enabled)
+            self.assertEqual(fake.last_search[0], None)
+
+    def test_charset_fallback(self):
+        class RejectIMAP(FakeIMAP):
+            def __init__(self, *a, **kw):
+                super().__init__(*a, **kw)
+                self.failed = False
+                self._encoding = 'utf-8'
+            def enable(self, capability):
+                raise Exception('unsupported')
+            def search(self, charset, criteria):
+                if not self.failed:
+                    self.failed = True
+                    raise imaplib.IMAP4.error('BAD parse error')
+                return super().search(charset, criteria)
+
+        with patch('imaplib.IMAP4_SSL', RejectIMAP):
+            content, attachments = gw.mail.search('instalación')
+            self.assertEqual(content, 'respuesta')
+            fake = FakeIMAP.instances[0]
+            self.assertTrue(getattr(fake, 'failed', False))
             self.assertEqual(fake.last_search[0], None)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- retry IMAP searches without charset when server rejects UTF-8
- cover fallback logic with new unit test

## Testing
- `pytest tests/test_mail_utf8.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686975e57db48326ae665f2a9d6ec635