### PR TITLE
Fix INBOX selection and regression test

### DIFF
--- a/projects/mail.py
+++ b/projects/mail.py
@@ -121,7 +121,8 @@ def search(subject_fragment, body_fragment=None):
             mail.enable('UTF8=ACCEPT')
         except Exception:
             pass
-        mail.select('inbox')
+        # Ensure mailbox is selected case-sensitively for broader compatibility
+        mail.select('INBOX')
 
         search_criteria = []
         if subject_fragment and subject_fragment != "*":


### PR DESCRIPTION
## Summary
- select the INBOX mailbox in mail.search
- expand FakeIMAP helper to track selected mailbox
- add regression test ensuring gw.mail.search works with INBOX

## Testing
- `pip install -q -r requirements.txt`
- `pip install -e . -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686975e5fe1083269de376a2c0a56368