### PR TITLE
Add .gitattributes for batch files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.bat text eol=crlf


### PR DESCRIPTION
## Summary
- normalize batch file line endings
- enforce CRLF for `*.bat`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686976ba06d88326b412fd2c7d1f2743