### PR TITLE
Add PowerShell service discovery script

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.bat text eol=crlf
+*.ps1 text eol=crlf

--- a/install.bat
+++ b/install.bat
@@ -8,7 +8,7 @@ rem Repair previously installed services
 if "%~1"=="--repair" (
     echo Repairing installed gway services...
     for /f "usebackq delims=" %%R in (
-        `powershell -NoProfile -Command "Get-Service | Where-Object { $_.Name -like 'gway-*' } | ForEach-Object { sc.exe qc $_.Name | Select-String '-r ' | ForEach-Object { if (\$_ -match '-r\\s+([^\"\\s]+)') { $matches[1] } } }"`
+        `powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0tools\list_services.ps1"`
     ) do (
         call "%~f0" %%R
     )

--- a/tools/list_services.ps1
+++ b/tools/list_services.ps1
@@ -1,0 +1,9 @@
+Get-Service |
+  Where-Object { $_.Name -like 'gway-*' } |
+  ForEach-Object {
+    sc.exe qc $_.Name |
+    Select-String '-r ' |
+    ForEach-Object {
+      if ($_ -match '-r\s+([^\\"\s]+)') { $matches[1] }
+    }
+  }


### PR DESCRIPTION
## Summary
- add `tools/list_services.ps1` to enumerate installed gway services
- use the new script from `install.bat` when repairing services
- ensure `.ps1` files use CRLF line endings via `.gitattributes`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686991df3c888326aac67a15307e8a1b