### PR TITLE
Use gway test runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Repository Guidelines
+
+## Testing
+- Install requirements and the package in editable mode before running tests:
+  ```bash
+  pip install -r requirements.txt
+  pip install -e .
+  ```
+- Run the test suite using the built-in runner:
+  ```bash
+  gway test --coverage
+  ```
+  (omit `--coverage` if not needed)
+
+These instructions apply to CODEX and CI environments.

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -7,8 +7,6 @@ Install the runtime dependencies first. The simplest approach is:
 
    pip install -r requirements.txt
    pip install -e .
-   pytest -q
-   # Or use the built-in runner with coverage
    gway test --coverage
 
 This ensures that modules such as ``requests`` and ``websockets`` are


### PR DESCRIPTION
## Summary
- document using `gway test` as the default test command
- add AGENTS instructions so Codex runs `gway test`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6869a967e1e48326ba8029839b12d161