### PR TITLE
Add changelog tracking and view

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,8 @@
+Changelog
+=========
+
+0.4.31 [build 937abe0]
+---------------------
+
+- Initial CHANGELOG created.
+

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,8 @@ Fetch the source, changelogs and issues (or submit your own) here:
 
 https://github.com/arthexis/gway
 
+Browse the latest changes in the `CHANGELOG <https://arthexis.com/release/changelog>`_.
+
 See a demo and the full list of available projects and other help topics online here:
 
 https://arthexis.com/site/help


### PR DESCRIPTION
## Summary
- track released builds and commits in `CHANGELOG.rst`
- show unreleased commits in new `release.view_changelog`
- update release build to write entries to the changelog
- link the changelog from the README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6869e18637688326b6d8db1f5677fb66