### PR TITLE
Avoid duplicate routes when reusing setup_app

### DIFF
--- a/work/static/web/README.rst
+++ b/work/static/web/README.rst
@@ -1,0 +1,8 @@
+Web Project Notes
+-----------------
+
+* `setup_app` can be invoked multiple times. Each call adds routes and homes for a single project.
+* Routes are registered with `add_route`, which skips duplicates so repeated setups won't register the same handler twice.
+* When reusing `setup_app`, provide unique paths or homes to avoid collisions.
+* CLI flags resolve to a single value. Lists like ``--home a,b,c`` are not supported. Call the command once per value instead.
+* `web.site.view_reader` serves ``.md`` or ``.rst`` files from the resource root and can be used for a lightweight blog. Subfolders and hidden files are not allowed.


### PR DESCRIPTION
## Summary
- prevent duplicate route handlers when the same project is setup multiple times
- register routes via helper that skips duplicates
- document setup options in work/static/web/README.rst

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6869e6d6cb488326811ceb59ce60c1a1