### PR TITLE
Refactor apps to drop unwrap helpers

### DIFF
--- a/projects/web/auto.py
+++ b/projects/web/auto.py
@@ -53,8 +53,19 @@ def browse(
 
     # Try to unwrap an existing driver from the given object (tuple/list etc)
     try:
-        from gway import gw
-        driver = gw.unwrap_one(driver, webdriver.Remote) if driver else None
+        match driver:
+            case webdriver.Remote() as d:
+                driver = d
+            case list() | tuple() as seq:
+                driver = next((x for x in seq if isinstance(x, webdriver.Remote)), None)
+            case None:
+                driver = None
+            case _ if isinstance(driver, webdriver.Remote):
+                pass
+            case _ if hasattr(driver, "__iter__") and not isinstance(driver, (str, bytes, bytearray)):
+                driver = next((x for x in driver if isinstance(x, webdriver.Remote)), None)
+            case _:
+                driver = None
     except Exception:
         pass
 

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -33,8 +33,6 @@ class GatewayBuiltinsTests(unittest.TestCase):
         self.assertIn('help', builtin_ls)
         self.assertIn('test', builtin_ls)
         self.assertIn('abort', builtin_ls)
-        self.assertIn('unwrap_one', builtin_ls)
-        self.assertIn('unwrap_all', builtin_ls)
         self.assertIn('run_recipe', builtin_ls)
 
     def test_list_projects(self):


### PR DESCRIPTION
## Summary
- drop `unwrap_one`/`unwrap_all` helpers from builtins
- pattern-match apps in OCPP and web modules
- update webdriver detection to use match
- simplify proxy setup comment
- adjust builtin tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6869e2c892048326be67bef7c4433bea