### PR TITLE
Fix Windows service batch invocation

### DIFF
--- a/tools/windows_service.py
+++ b/tools/windows_service.py
@@ -58,7 +58,9 @@ class GatewayService(win32serviceutil.ServiceFramework if win32serviceutil else 
 
     def SvcDoRun(self):  # pragma: no cover - requires Windows
         bat = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "gway.bat"))
-        cmd = [bat, "-r", self.recipe] if self.recipe else [bat]
+        cmd = ["cmd.exe", "/c", bat]
+        if self.recipe:
+            cmd += ["-r", self.recipe]
         self.process = subprocess.Popen(cmd, cwd=os.path.dirname(bat))
         win32event.WaitForSingleObject(self.stop_event, win32event.INFINITE)
         if self.process and self.process.poll() is None:


### PR DESCRIPTION
## Summary
- ensure `gway.bat` is invoked via `cmd.exe /c` when running as a service
- install dependencies and run tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6869fa63ead483268f66a2d9e4313abe