### PR TITLE
Add render_template CSS order test

### DIFF
--- a/tests/test_render_template_css.py
+++ b/tests/test_render_template_css.py
@@ -1,0 +1,25 @@
+import unittest
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+from bs4 import BeautifulSoup
+
+app_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "app.py"
+spec = importlib.util.spec_from_file_location("webapp", app_path)
+webapp = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(webapp)
+
+class RenderTemplateThemeCssTests(unittest.TestCase):
+    def test_base_and_theme_css_links(self):
+        dummy_theme = "/static/theme.css"
+        with patch.object(webapp.gw.web.nav, 'active_style', return_value=dummy_theme), \
+             patch.object(webapp.gw.web.nav, 'render', return_value=''), \
+             patch.object(webapp, 'is_setup', return_value=True):
+            html = webapp.render_template(css_files=['/static/base.css'])
+
+        soup = BeautifulSoup(html, 'html.parser')
+        links = [l['href'] for l in soup.find_all('link', rel='stylesheet')]
+        self.assertEqual(links, ['/static/base.css', dummy_theme])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add regression test for render_template theme CSS order

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686a80eda08c832690d1589d01b6313e