### PR TITLE
Use public parse_basic_auth_header

### DIFF
--- a/projects/web/auth.py
+++ b/projects/web/auth.py
@@ -57,7 +57,8 @@ def is_authorized(*, strict=False, context=None):
             return False
     return True
 
-def _parse_basic_auth_header(header):
+def parse_basic_auth_header(header):
+    """Parse an HTTP Basic Auth header."""
     if not header or not header.startswith("Basic "):
         return None, None
     try:
@@ -98,14 +99,14 @@ def _basic_auth(allow, engine):
                 from bottle import request, response
                 ctx["response"] = response
                 auth_header = request.get_header("Authorization")
-                username, password = _parse_basic_auth_header(auth_header)
+                username, password = parse_basic_auth_header(auth_header)
             elif engine_actual == "fastapi":
                 # Context should include 'request' and 'response'
                 req = ctx.get("request")
                 resp = ctx.get("response")
                 ctx["response"] = resp
                 auth_header = req.headers.get("authorization") if req else None
-                username, password = _parse_basic_auth_header(auth_header)
+                username, password = parse_basic_auth_header(auth_header)
             elif engine_actual == "fastapi_ws":
                 # Context should include 'websocket'
                 ws = ctx.get("websocket")
@@ -119,7 +120,7 @@ def _basic_auth(allow, engine):
                         # Accept fallback with capitalization
                         if not auth_header:
                             auth_header = headers.get("Authorization")
-                username, password = _parse_basic_auth_header(auth_header)
+                username, password = parse_basic_auth_header(auth_header)
             else:
                 gw.error(f"[auth] Unknown engine: {engine_actual}")
                 return False, ctx

--- a/tests/test_parse_basic_auth_header.py
+++ b/tests/test_parse_basic_auth_header.py
@@ -1,0 +1,36 @@
+import unittest
+import base64
+from gway import gw
+
+web = gw.load_project('web')
+
+
+class ParseBasicAuthHeaderTests(unittest.TestCase):
+    def test_valid_header(self):
+        username = 'foo'
+        password = 'bar'
+        creds = f"{username}:{password}".encode('utf-8')
+        header = 'Basic ' + base64.b64encode(creds).decode()
+        self.assertEqual(
+            web.auth.parse_basic_auth_header(header),
+            (username, password),
+        )
+
+    def test_invalid_headers(self):
+        invalid_headers = [
+            None,
+            '',
+            'Bearer abc',
+            'Basic not-base64',
+            'Basic ' + base64.b64encode(b'nocolon').decode(),
+        ]
+        for hdr in invalid_headers:
+            with self.subTest(hdr=hdr):
+                self.assertEqual(
+                    web.auth.parse_basic_auth_header(hdr),
+                    (None, None),
+                )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- inline basic auth header parser into `parse_basic_auth_header`
- update auth logic to call the public parser

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686a80e8799083268fa17de47e4f7254