### PR TITLE
Add test for missing vbid in view_downloads

### DIFF
--- a/tests/test_vbox.py
+++ b/tests/test_vbox.py
@@ -1,0 +1,33 @@
+import unittest
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+# Load the vbox module dynamically from projects directory
+vbox_path = Path(__file__).resolve().parents[1] / "projects" / "vbox.py"
+spec = importlib.util.spec_from_file_location("vbox", vbox_path)
+vbox = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(vbox)
+
+
+class ViewDownloadsTests(unittest.TestCase):
+    def setUp(self):
+        # Patch render_error to capture calls
+        self.render_patch = patch.object(
+            vbox,
+            "render_error",
+            side_effect=lambda title, msg, **kw: {"title": title, "message": msg, "extra": kw},
+        )
+        self.mock_render = self.render_patch.start()
+
+    def tearDown(self):
+        self.render_patch.stop()
+
+    def test_missing_vbid_returns_render_error(self):
+        result = vbox.view_downloads(vbid=None)
+        self.assertEqual(result["title"], "Missing vbid")
+        self.assertIn("vbid", result["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add regression test covering vbox.view_downloads when vbid is missing

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686a9e0d58cc832691b942df76f88e35