### PR TITLE
Fix install service script path and add --remove flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,6 +178,7 @@ To run GWAY automatically as a service using a recipe:
 
     sudo ./install.sh <recipe> [--debug]   # On Linux/macOS
     install.bat <recipe> [--debug]         # On Windows
+    sudo ./install.sh <recipe> --remove    # Remove on Linux/macOS
     install.bat <recipe> --remove [--force]  # Remove on Windows
     install.bat <recipe> --repair            # Repair one service on Windows
 


### PR DESCRIPTION
## Summary
- allow `install.sh --remove` to remove a recipe service
- correct service ExecStartPre path to use current repo location
- document Linux removal command

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686ab8f61ad48326b9292041e3899906