### PR TITLE
Add installer --root flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,7 @@ To run GWAY automatically as a service using a recipe:
 
 .. code-block:: bash
 
-    sudo ./install.sh <recipe> [--debug]   # On Linux/macOS
+    sudo ./install.sh <recipe> [--debug] [--root]   # On Linux/macOS
     install.bat <recipe> [--debug]         # On Windows
     sudo ./install.sh <recipe> --remove    # Remove on Linux/macOS
     install.bat <recipe> --remove [--force]  # Remove on Windows

--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,7 @@ ACTION="install"
 DEBUG_FLAG=""
 RECIPE=""
 FORCE_FLAG=""
+ROOT_FLAG=""
 for arg in "$@"; do
   case "$arg" in
     --repair)
@@ -39,6 +40,9 @@ for arg in "$@"; do
       ;;
     --debug)
       DEBUG_FLAG="-d"
+      ;;
+    --root)
+      ROOT_FLAG="--root"
       ;;
     *)
       if [[ -z "$RECIPE" ]]; then
@@ -124,7 +128,9 @@ SERVICE_NAME="gway-${SERVICE_SAFE_RECIPE}.service"
 SERVICE_PATH="/etc/systemd/system/$SERVICE_NAME"
 
 # Determine service user
-if [[ -n "${SUDO_USER-}" && "$SUDO_USER" != "root" ]]; then
+if [[ "$ROOT_FLAG" == "--root" ]]; then
+  SERVICE_USER="root"
+elif [[ -n "${SUDO_USER-}" && "$SUDO_USER" != "root" ]]; then
   SERVICE_USER="$SUDO_USER"
 else
   SERVICE_USER="$(whoami)"


### PR DESCRIPTION
## Summary
- allow installing a systemd service as root via new `--root` flag
- document flag usage in service installation instructions

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686ac9ec41988326807244fbda6389be