### PR TITLE
Fix filename sanitization in vbox

### DIFF
--- a/tests/test_vbox.py
+++ b/tests/test_vbox.py
@@ -30,5 +30,17 @@ class StreamFileResponseTests(unittest.TestCase):
             os.remove(tmp_path)
 
 
+class SanitizeFilenameTests(unittest.TestCase):
+    def test_sanitize_filename(self):
+        cases = {
+            "foo/bar": "foobar",
+            "../secret": "secret",
+            "normal-name.txt": "normal-name.txt",
+        }
+        for raw, expected in cases.items():
+            with self.subTest(raw=raw):
+                self.assertEqual(vbox._sanitize_filename(raw), expected)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- sanitize filenames in upload handler and remote sync
- test the new `_sanitize_filename` helper

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686af5ca46188326842b7308aa956977