### PR TITLE
Sanitize nmcli AP params and test

### DIFF
--- a/projects/monitor/nmcli.py
+++ b/projects/monitor/nmcli.py
@@ -19,6 +19,7 @@ Renders:
 
 import subprocess
 from gway import gw
+from gway.sigils import _unquote
 
 def now_iso():
     import datetime
@@ -29,6 +30,9 @@ def now_iso():
 def nmcli(*args):
     result = subprocess.run(["nmcli", *args], capture_output=True, text=True)
     return result.stdout.strip()
+
+def _sanitize(val):
+    return _unquote(val.strip()) if isinstance(val, str) else val
 
 def get_wlan_ifaces():
     output = nmcli("device", "status")
@@ -181,6 +185,9 @@ def ap_profile_exists(ap_con, ap_ssid, ap_password):
     return False
 
 def ensure_ap_profile(ap_con, ap_ssid, ap_password):
+    ap_con = _sanitize(ap_con)
+    ap_ssid = _sanitize(ap_ssid)
+    ap_password = _sanitize(ap_password)
     if not ap_con:
         raise ValueError("AP_CON must be specified.")
     if not ap_ssid or not ap_password:
@@ -204,6 +211,9 @@ def ensure_ap_profile(ap_con, ap_ssid, ap_password):
           "wifi-sec.psk", ap_password)
 
 def set_wlan0_ap(ap_con, ap_ssid, ap_password):
+    ap_con = _sanitize(ap_con)
+    ap_ssid = _sanitize(ap_ssid)
+    ap_password = _sanitize(ap_password)
     ensure_ap_profile(ap_con, ap_ssid, ap_password)
     gw.info(f"[nmcli] Activating wlan0 AP: conn={ap_con}, ssid={ap_ssid}")
     nmcli("device", "disconnect", "wlan0")

--- a/tests/test_nmcli_sanitize.py
+++ b/tests/test_nmcli_sanitize.py
@@ -1,0 +1,33 @@
+import unittest
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+nmcli_path = Path(__file__).resolve().parents[1] / 'projects' / 'monitor' / 'nmcli.py'
+spec = importlib.util.spec_from_file_location('nmcli_mod', nmcli_path)
+nmcli_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(nmcli_mod)
+
+class SanitizeHelperTests(unittest.TestCase):
+    def test_sanitize_quotes(self):
+        self.assertEqual(nmcli_mod._sanitize('"foo"'), 'foo')
+
+class EnsureApProfileTests(unittest.TestCase):
+    def test_ensure_ap_profile_uses_unquoted_values(self):
+        calls = []
+        def fake_nmcli(*args):
+            calls.append(args)
+            if args == ('connection', 'show'):
+                return 'NAME UUID TYPE DEVICE\nmyap 123 wifi --'
+            if args == ('connection', 'show', 'myap'):
+                return '802-11-wireless.ssid: myssid\n802-11-wireless-security.psk: pass'
+            return ''
+        with patch.object(nmcli_mod, 'nmcli', side_effect=fake_nmcli):
+            nmcli_mod.ensure_ap_profile('"myap"', '"myssid"', '"pass"')
+        self.assertEqual(calls, [
+            ('connection', 'show'),
+            ('connection', 'show', 'myap'),
+        ])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- import `_unquote` and add `_sanitize` helper in nmcli project
- sanitize AP profile parameters
- unit tests for sanitize helper and ensure_ap_profile quoting

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test`


------
https://chatgpt.com/codex/tasks/task_e_686b130a307c8326855ec78d98efde82