### PR TITLE
Fix nmcli email fallback

### DIFF
--- a/projects/monitor/nmcli.py
+++ b/projects/monitor/nmcli.py
@@ -230,8 +230,10 @@ def maybe_notify_ap_switch(ap_ssid, email=None):
     prev_mode = state.get("wlan0_mode")
     prev_ssid = state.get("wlan0_ssid")
     prev_inet = state.get("wlan0_inet")
-    recipient = email or gw.resolve('[ADMIN_EMAIL]')
-    if recipient and prev_mode == "station" and prev_inet:
+    recipient = email if email else gw.resolve('[ADMIN_EMAIL]', default=None)
+    if not recipient:
+        return
+    if prev_mode == "station" and prev_inet:
         subject = "[nmcli] wlan0 switching to AP mode"
         body = (
             f"Previous mode: station\n"

--- a/tests/test_nmcli.py
+++ b/tests/test_nmcli.py
@@ -1,0 +1,15 @@
+import os
+import unittest
+from gway import gw
+
+class NmcliNotificationTests(unittest.TestCase):
+    def test_no_admin_email_no_exception(self):
+        os.environ.pop('ADMIN_EMAIL', None)
+        gw.monitor.set_states('nmcli', {'wlan0_mode': 'station', 'wlan0_inet': True})
+        try:
+            gw.monitor.nmcli.maybe_notify_ap_switch('test')
+        except Exception as e:
+            self.fail(f"maybe_notify_ap_switch raised {e}")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- update nmcli notification logic
- test nmcli notification with missing ADMIN_EMAIL

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686b1300cc508326924325ddeadd20c9