### PR TITLE
Fix IMAP search unicode handling

### DIFF
--- a/projects/mail.py
+++ b/projects/mail.py
@@ -151,12 +151,18 @@ def search(subject_fragment, body_fragment=None):
             if getattr(mail, 'utf8_enabled', False):
                 status, data = mail.search(None, *criteria)
             else:
+                encoded_criteria = [
+                    c.encode('utf-8') if isinstance(c, str) else c
+                    for c in criteria
+                ]
                 try:
-                    status, data = mail.search('UTF-8', *criteria)
+                    status, data = mail.search('UTF-8', *encoded_criteria)
                 except imaplib.IMAP4.error as e:
                     if 'bad' in str(e).lower() or 'parse' in str(e).lower():
-                        gw.warning(f"Search charset failed ({e}); retrying without charset")
-                        status, data = mail.search(None, *criteria)
+                        gw.warning(
+                            f"Search charset failed ({e}); retrying without charset"
+                        )
+                        status, data = mail.search(None, *encoded_criteria)
                     else:
                         raise
         except imaplib.IMAP4.error as e:

--- a/tests/test_mail_utf8.py
+++ b/tests/test_mail_utf8.py
@@ -81,7 +81,10 @@ class MailUTF8Tests(unittest.TestCase):
             fake = FakeIMAP.instances[0]
             self.assertTrue(getattr(fake, 'failed', False))
             self.assertEqual(fake.last_search[0], None)
-            self.assertEqual(fake.last_search[1], ['SUBJECT', '"instalación"'])
+            self.assertEqual(
+                fake.last_search[1],
+                [b'SUBJECT', '"instalación"'.encode('utf-8')],
+            )
 
     def test_search_uses_inbox_uppercase(self):
         """Ensure search operates with FakeIMAP when selecting 'INBOX'."""


### PR DESCRIPTION
## Summary
- avoid UnicodeEncodeError by sending UTF-8 encoded search criteria
- update charset fallback test for byte criteria

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686b0cf1a748832697251d4ba4ee5b9d