### PR TITLE
Fix windows stop service error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 ---------------------
 
 - a4056e5 Improve nmcli monitor table styling
+- Ignore "service has not been started" error when removing Windows services
 
 0.4.37 [build 6aa9b9]
 ---------------------

--- a/tools/windows_service.py
+++ b/tools/windows_service.py
@@ -131,7 +131,12 @@ def main(argv: list[str] | None = None) -> None:
     elif args.command == "start":
         win32serviceutil.StartService(args.name)
     elif args.command == "stop":
-        win32serviceutil.StopService(args.name)
+        try:
+            win32serviceutil.StopService(args.name)
+        except Exception as exc:  # pragma: no cover - requires Windows
+            # Ignore "service not started" errors when stopping
+            if getattr(exc, "winerror", None) != 1062:
+                raise
     elif args.command == "run":
         win32serviceutil.HandleCommandLine(Service, argv=[sys.argv[0]])
     else:  # pragma: no cover - unreachable


### PR DESCRIPTION
## Summary
- ignore 'service not started' error when stopping services
- document fix in changelog

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686b2cda9f748326a5511dc01d464b05