### PR TITLE
Fix Windows service execution

### DIFF
--- a/tools/windows_service.py
+++ b/tools/windows_service.py
@@ -66,7 +66,7 @@ class GatewayService(win32serviceutil.ServiceFramework if win32serviceutil else 
 
     def SvcDoRun(self):  # pragma: no cover - requires Windows
         bat = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "gway.bat"))
-        cmd = [bat]
+        cmd = ["cmd", "/c", bat]
         if self.debug:
             cmd.append("-d")
         if self.recipe:


### PR DESCRIPTION
## Summary
- fix Windows service process spawning by running `gway.bat` through `cmd.exe`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686b2d5b3a488326b22e068cba652383