### PR TITLE
Add nmcli connection parser helper

### DIFF
--- a/tests/test_nmcli_sanitize.py
+++ b/tests/test_nmcli_sanitize.py
@@ -17,15 +17,15 @@ class EnsureApProfileTests(unittest.TestCase):
         calls = []
         def fake_nmcli(*args):
             calls.append(args)
-            if args == ('connection', 'show'):
-                return 'NAME UUID TYPE DEVICE\nmyap 123 wifi --'
+            if args == ('-t', '-f', 'NAME,UUID,TYPE,DEVICE', 'connection', 'show'):
+                return 'myap:123:wifi:\n'
             if args == ('connection', 'show', 'myap'):
                 return '802-11-wireless.ssid: myssid\n802-11-wireless-security.psk: pass'
             return ''
         with patch.object(nmcli_mod, 'nmcli', side_effect=fake_nmcli):
             nmcli_mod.ensure_ap_profile('"myap"', '"myssid"', '"pass"')
         self.assertEqual(calls, [
-            ('connection', 'show'),
+            ('-t', '-f', 'NAME,UUID,TYPE,DEVICE', 'connection', 'show'),
             ('connection', 'show', 'myap'),
         ])
 


### PR DESCRIPTION
## Summary
- parse `nmcli connection show` output with new helper `nmcli_list_connections`
- use helper in nmcli monitoring utilities
- adjust nmcli sanitize tests for new nmcli invocation

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686b3bdf291483269dd6b9c53cb0dc87