### PR TITLE
Remove TODO comments and README section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,7 +146,6 @@ Install via PyPI:
     pip install gway
 
 
-# TODO: Explain configuration of the local GWAY_ROOT directory
 
 
 Install from Source:
@@ -363,18 +362,6 @@ Design Philosophies
 ===================
 
 This section contains notes from the author that **may** provide insight to future developers.
-
-
-Keep a Goal in Mind by Making it a TODO
----------------------------------------
-
-Before you start writing any code, even if you have already planned the feature in an external system, write a # TODO comment explaining the required changes in as much detail as you need to define it unambiguously.
-
-TODOs should live with the code they intend to affect. They warn that things are going to soon be different. It allows a good feature to be noted instead of lost to priorities. Keeping the tasks in the code itself as TODOs is superior to using an external tool. Those systems should look at the code as the source of truth to determine what TODOs need to be accomplished and make them more visible instead.
-
-However, if a TODO affects the entire project, put it at the top of the file instead.
-
-You may write the TODO and then dispatch it in the same coding session, or it may live on for many commits until its time comes. Or maybe you change your mind and delete the TODO. You get a space, close to the code, where you can see the effects of what you intend to integrate next.
 
 
 On Comments and the Code that Binds Them

--- a/gway/builtins.py
+++ b/gway/builtins.py
@@ -394,7 +394,6 @@ def help(*args, full=False):
 def sample_cli(func):
     """Generate a sample CLI string for a function."""
 
-    # TODO: Is this working properly? Are we not using it in view_help?
 
     from gway import gw
     if not callable(func):

--- a/gway/envs.py
+++ b/gway/envs.py
@@ -46,7 +46,6 @@ def load_env(env_type: str, name: str, env_root: str):
     but base env vars will not override the primary env's values.
     """
 
-    # TODO: When creating an empty file, include a header starting with #
     # followed by the short path of the file, like this: 
     # envs/<env_type>/<name>.env
 

--- a/gway/structs.py
+++ b/gway/structs.py
@@ -164,6 +164,5 @@ null = Null()
 Null = null
 
 
-# TODO: Create a new Apeiron class that will hold "conversion" functions
 # Apeiron should be designed as a Mixin for Gateway. Its methods will be
 # to_html, to_list, to_yaml, etc. This will free space from gway/builtins.py

--- a/projects/cdv.py
+++ b/projects/cdv.py
@@ -171,7 +171,6 @@ def debit(table_path: str, entry: str, *, field: str = 'balance', **kwargs) -> b
 
 def view_colon_validator(*, text=None):
     
-    # TODO: If text is None, return an html fragment with a form in which the user
     # can paste a CDV file into a large textarea and submit for validation as 'text'.
     # If text is received, test and validate it and let the user know if there are any issues
     # found that would impede the file to be processed as a valid CDV. 

--- a/projects/clip.py
+++ b/projects/clip.py
@@ -95,8 +95,6 @@ def track_history(interval: int = 5, *, stop_after=None, notify=True):
 def view_history(*, selection: list = None, copy: bool = True, purge: bool = True):
     gw.verbose(f"Received {selection=}")
     selection = gw.cast.to_list(selection) if selection else selection
-    # TODO: If copy, concatenate selection, copy to clipboard
-    # TODO: If purge, remove listed all items by sequence from history.txt
     raise NotImplementedError
 
 

--- a/projects/clock.py
+++ b/projects/clock.py
@@ -5,7 +5,6 @@ import time
 import requests
 import datetime
 
-# TODO: Check that other modules use these functions uniformly
 #       If there is missing functionality we need for other projects, add it.
 
 def now(*, utc=False) -> "datetime":

--- a/projects/mail.py
+++ b/projects/mail.py
@@ -1,4 +1,3 @@
-# TODO: Use the mail project to create a simple approval request workflow
 
 # projects/mail.py
 

--- a/projects/ocpp/evcs.py
+++ b/projects/ocpp/evcs.py
@@ -8,7 +8,6 @@ import base64
 from bottle import request
 import asyncio, json, random, time, websockets
 
-# TODO: Fix this issue found in the logs.
 # [Simulator:CPX] Exception: cannot call recv while another coroutine is already running recv or recv_streaming
 # It seems to ocurr intermitently. 
 
@@ -36,7 +35,6 @@ def _unique_cp_path(cp_path, idx, total_threads):
     rand_tag = secrets.token_hex(2).upper()  # 4 hex digits, e.g., '1A2B'
     return f"{cp_path}-{rand_tag}"
 
-# TODO: Update sigils to new model
 
 def simulate(
     *,

--- a/projects/odoo.py
+++ b/projects/odoo.py
@@ -144,7 +144,6 @@ def fetch_customers(
     Returns:
         dict: The fetched customers.
     """
-    # TODO: If latest_quotes is a number, also fetch the many latest quotes for this customer.
 
     model = 'res.partner'
     method = 'search_read'

--- a/projects/screen.py
+++ b/projects/screen.py
@@ -115,7 +115,6 @@ def _sanitize_filename(name: str) -> str:
     return cleaned.replace(" ", "_").strip("_") or "window"
 
 
-# TODO: Allow the screenshot to be named (overrides the date pattern)
 
 def shot(*, name: str = None, mode: str = "full") -> str:
     """

--- a/projects/vbox.py
+++ b/projects/vbox.py
@@ -464,7 +464,6 @@ def view_downloads(*hashes: tuple[str], vbid: str = None, modified_since=None, *
     - If modified_since is passed (as iso or epoch seconds), only send file if newer, else 304.
     """
 
-    # TODO: Support multiple hashes by checking them one by one. If the first doesn't exist, 
     # try the next and so forth. Give up when every hash fails to match. First matches is chosen first.
 
     gw.warning(f"Download view: {hashes=} {vbid=} {kwargs=}")

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -8,7 +8,6 @@ import datetime
 from bottle import Bottle, static_file, request, response, template, HTTPResponse
 from gway import gw
 
-# TODO: 
 
 _ver = None
 _homes = []   # (title, route)

--- a/projects/web/proxy.py
+++ b/projects/web/proxy.py
@@ -4,7 +4,6 @@ from fastapi import FastAPI
 from gway import gw
 import requests
 
-# TODO: Test that setup_fallback_app will work with our OCPP apps.
 
 
 def setup_fallback_app(*, 
@@ -19,14 +18,12 @@ def setup_fallback_app(*,
     # selectors for app types
     from bottle import Bottle
 
-    # TODO: Implement a mode kwarg that defaults to "extend" and functions like this:
     # replace: Replace all paths in the received apps with the proxied endpoint.
     # extend: Redirect all paths not already configured to the proxy.
     # errors: Catch errors thrown by the app and redirect the failed calls to the proxy.
     # trigger: Use a callback function to check. Redirects when result is True.
     # Move this explanation to the docstring.
 
-    # TODO: Apply the proxy mode to each received app and return the collection
 
     # collect apps by type
     match app:
@@ -60,7 +57,6 @@ def setup_fallback_app(*,
     elif fastapi_app:
         prepared.append(_wire_proxy(fastapi_app, endpoint, websockets, path))
 
-    # TODO: Test that this return is properly compatible with web.server.start_app after the fixes
 
     return prepared[0] if len(prepared) == 1 else tuple(prepared)
 

--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -122,7 +122,6 @@ def view_help(topic="", *args, **kwargs):
     If there is an exact match in the search, show it at the top (highlighted).
     """
 
-    # TODO: Change how the help system works: Instead of just using the results of
     # gw.gelp at all times, compliment this result with other information. 
 
     topic_in = topic or ""

--- a/tests/test_conway_web.py
+++ b/tests/test_conway_web.py
@@ -1,7 +1,6 @@
 # file: tests/test_conway_web.py
 
 
-# TODO: Fix test_download_board_link_works
 
 
 import unittest

--- a/tests/test_nav_styles.py
+++ b/tests/test_nav_styles.py
@@ -82,7 +82,6 @@ class NavStyleTests(unittest.TestCase):
         self.assertIsNotNone(preview_div, "style-preview div not found")
         self.assertIn("Palimpsesto", preview_div.text, "Preview does not mention 'Palimpsesto'")
 
-    # TODO: The following test keeps failing. We should do a standalone test for cookies to isolate the source
 
     def test_theme_switch_sets_css_cookie_and_main_link(self):
         """Test POST to change theme sets cookie and updates <head> <link>."""


### PR DESCRIPTION
## Summary
- strip all TODO comments across source files
- remove the TODO configuration line from the README
- drop the "Keep a Goal in Mind by Making it a TODO" section

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686b3c335c648326b0a1c73bd489292e