### PR TITLE
Refine colon syntax parsing for hyphen prefix lines

### DIFF
--- a/gway/console.py
+++ b/gway/console.py
@@ -450,14 +450,30 @@ def load_recipe(recipe_filename):
     
     deindented_lines = []
     last_prefix = ""
+    colon_prefix = None
     with open(recipe_path) as f:
         for raw_line in f:
             line = raw_line.rstrip("\n")
             stripped_line = line.lstrip()
             if not stripped_line:
+                colon_prefix = None
                 continue  # skip blank lines
             if stripped_line.startswith("#"):
                 comments.append(stripped_line)
+                colon_prefix = None
+                continue
+            if colon_prefix:
+                if stripped_line.startswith("- "):
+                    addition = stripped_line[1:].lstrip()
+                    deindented_lines.append(colon_prefix + " " + addition)
+                    continue
+                if stripped_line.startswith("--"):
+                    deindented_lines.append(colon_prefix + " " + stripped_line)
+                    continue
+                colon_prefix = None
+            if stripped_line.endswith(":"):
+                colon_prefix = stripped_line[:-1].rstrip()
+                last_prefix = colon_prefix
                 continue
             # Detect if line is indented and starts with '--'
             if line[:1].isspace() and stripped_line.startswith("--"):

--- a/recipes/etron/cloud.gwr
+++ b/recipes/etron/cloud.gwr
@@ -1,7 +1,8 @@
 # file: recipes/etron/cloud.gwr
 # OCPP 1.6 CSMS Recipe for Central Cloud Server
 
-web app setup-app --project ocpp.data --home charger-summary
+web app setup-app:
+    --project ocpp.data --home charger-summary
     --project ocpp.csms --home charger-status
     --project ocpp.csms --home cp-simulator
     --project web.cookies
@@ -10,13 +11,16 @@ web app setup-app --project ocpp.data --home charger-summary
     --project ocpp.data --home charger-summary
    
 # Toggle this version to apply the allow list  
-ocpp csms setup-app --allow data/etron/rfids.cdv --location etron_cloud
+ocpp csms setup-app:
+    --allow data/etron/rfids.cdv --location etron_cloud
 
 # Without --allow, all transactions will be allowed by default
-# ocpp csms setup-app --location porsche_centre --deny data/etron/rfids.cdv
+# ocpp csms setup-app:
+#     --location porsche_centre --deny data/etron/rfids.cdv
 
-web static collect
-web auth config-basic 
-web server start-app --host 0.0.0.0 --port 8000 --ws-port 9000 
+web:
+ - static collect
+ - auth config-basic
+ - server start-app --host 0.0.0.0 --port 8000 --ws-port 9000
 
 until --file VERSION

--- a/recipes/etron/local.gwr
+++ b/recipes/etron/local.gwr
@@ -1,7 +1,8 @@
 # file: recipes/etron/local.gwr
 # OCPP 1.6 CSMS runnable GWAY Recipe with basic RFID auth
 
-web app setup-app --project ocpp.data --home charger-summary
+web app setup-app:
+    --project ocpp.data --home charger-summary
     --project web.nav
     --project vbox
     --project ocpp.csms --home charger-status
@@ -11,10 +12,12 @@ web app setup-app --project ocpp.data --home charger-summary
 
 # Toggle this version to apply the allowlist  
 # ocpp csms setup-app --allow data/etron/rfids.cdv --location porsche_centre
-ocpp csms setup-app --location porsche_centre
+ocpp csms setup-app:
+    --location porsche_centre
 
-web static collect
-web server start-app --host 0.0.0.0 --port 8000 --ws-port 9000 
+web:
+ - static collect
+ - server start-app --host 0.0.0.0 --port 8000 --ws-port 9000
 
 # This only makes sense for NetworkManager in Linux 
 monitor start-watch nmcli 

--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -1,16 +1,18 @@
 # file: recipes/gamebox.gwr
 # Games-only demo with cookies, navbar and style switcher
 
-web app setup-app --home reader 
-    --project games.conway --home game-of-life --path conway 
-    --project games.mtg --home search-games 
-    --project games.qpig --home qpig-farm --path qpig 
-    --project games.snl --home snl-board --path snl 
-    --project web.nav --home style-switcher 
+web app setup-app:
+    --home reader
+    --project games.conway --home game-of-life --path conway
+    --project games.mtg --home search-games
+    --project games.qpig --home qpig-farm --path qpig
+    --project games.snl --home snl-board --path snl
+    --project web.nav --home style-switcher
     --project web.cookies --home cookie-jar
 
-web static collect
-web server start-app --port 8888
+web:
+ - static collect
+ - server start-app --port 8888
 
 forever
 

--- a/recipes/skeleton.gwr
+++ b/recipes/skeleton.gwr
@@ -1,7 +1,9 @@
 # file: recipes/skeleton.gwr
 
-web app setup-app --project web.site --home reader
-web app setup-app --project web.nav 
-web static collect
-web server start-app 
+web app setup-app:
+    --project web.site --home reader
+    --project web.nav
+web:
+ - static collect
+ - server start-app
 forever

--- a/recipes/test/etron/cloud.gwr
+++ b/recipes/test/etron/cloud.gwr
@@ -1,7 +1,8 @@
 # file: recipes/etron/cloud.gwr
 # OCPP 1.6 CSMS Recipe for Central Cloud Server
 
-web app setup-app --project ocpp.data --home charger-summary
+web app setup-app:
+    --project ocpp.data --home charger-summary
     --project ocpp.csms --home charger-status
     --project ocpp.csms --home cp-simulator
     --project web.cookies
@@ -10,13 +11,16 @@ web app setup-app --project ocpp.data --home charger-summary
     --project ocpp.data --home charger-summary
    
 # Toggle this version to apply the allow list  
-ocpp csms setup-app --allow data/etron/rfids.cdv --location etron_cloud
+ocpp csms setup-app:
+    --allow data/etron/rfids.cdv --location etron_cloud
 
 # Without --allow, all transactions will be allowed by default
-# ocpp csms setup-app --location porsche_centre --deny data/etron/rfids.cdv
+# ocpp csms setup-app:
+#     --location porsche_centre --deny data/etron/rfids.cdv
 
-web static collect
-web auth config-basic --temp-link
-web server start-app --host 0.0.0.0 --port 18000 --ws-port 19000 
+web:
+ - static collect
+ - auth config-basic --temp-link
+ - server start-app --host 0.0.0.0 --port 18000 --ws-port 19000
 
 until --file VERSION

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -3,23 +3,27 @@
 
 # Lines without a starting command repeat the previous with new params
 
-web app setup-app --home reader
+web app setup-app:
+    --home reader
     --project awg --home cable-finder
     --project web.nav --home style-switcher
     --project web.cookies --home cookie-jar
-    --project vbox --home uploads 
+    --project vbox --home uploads
     --project ocpp.csms --auth-required --home charger-status
     --project ocpp.evcs --auth-required --home cp-simulator
     --project games.conway --home game-of-life --path conway
-    --project games.mtg --home search-games 
-    --project web.auth 
+    --project games.mtg --home search-games
+    --project web.auth
 
-web static collect
-web auth config-basic --optional --temp-link
+web:
+ - static collect
+ - auth config-basic --optional --temp-link
 
-ocpp csms setup-app --location simulator
+ocpp csms setup-app:
+    --location simulator
 
-web server start-app --port 18888 --ws-port 19999
+web:
+ - server start-app --port 18888 --ws-port 19999
 
 # Loop until VERSION or BUILD or PyPI changes
 until --version --build --pypi

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -3,23 +3,27 @@
 
 # Lines without a starting command repeat the previous with new params
 
-web app setup-app --home reader
+web app setup-app:
+    --home reader
     --project awg --home cable-finder
     --project web.nav --home style-switcher
     --project web.cookies --home cookie-jar
-    --project vbox --home uploads 
+    --project vbox --home uploads
     --project ocpp.csms --auth-required --home charger-status
     --project ocpp.evcs --auth-required --home cp-simulator
     --project games.conway --home game-of-life --path conway
     --project games.mtg --home search-games
     --project web.auth
 
-web static collect
-web auth config-basic --optional --temp-link
+web:
+ - static collect
+ - auth config-basic --optional --temp-link
 
-ocpp csms setup-app --location simulator
+ocpp csms setup-app:
+    --location simulator
 
-web server start-app --port 8888 --ws-port 9999
+web:
+ - server start-app --port 8888 --ws-port 9999
 
 # Loop until VERSION or BUILD or PyPI changes
 until --version --build --pypi

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -113,5 +113,59 @@ app start --port 8000
         self.assertEqual(comments, expected_comments)
 
 
+class TestLoadRecipeColonSyntax(unittest.TestCase):
+    def test_load_recipe_with_colon_repetition(self):
+        content = (
+            """web app setup-app:
+    --project one --home first
+    --project two
+web:
+ - static collect
+ - server start-app --host 1 --port 2
+"""
+        )
+        with tempfile.NamedTemporaryFile('w', delete=False) as f:
+            f.write(content)
+            temp_name = f.name
+        try:
+            commands, _ = console.load_recipe(temp_name)
+        finally:
+            os.remove(temp_name)
+
+        expected = [
+            ['web', 'app', 'setup-app', '--project', 'one', '--home', 'first'],
+            ['web', 'app', 'setup-app', '--project', 'two'],
+            ['web', 'static', 'collect'],
+            ['web', 'server', 'start-app', '--host', '1', '--port', '2'],
+        ]
+        self.assertEqual(commands, expected)
+
+    def test_load_recipe_colon_without_indentation(self):
+        content = (
+            """web app setup-app:
+--project one
+--project two
+web:
+- static collect
+- server start-app --host 1 --port 2
+"""
+        )
+        with tempfile.NamedTemporaryFile('w', delete=False) as f:
+            f.write(content)
+            temp_name = f.name
+        try:
+            commands, _ = console.load_recipe(temp_name)
+        finally:
+            os.remove(temp_name)
+
+        expected = [
+            ['web', 'app', 'setup-app', '--project', 'one'],
+            ['web', 'app', 'setup-app', '--project', 'two'],
+            ['web', 'static', 'collect'],
+            ['web', 'server', 'start-app', '--host', '1', '--port', '2'],
+        ]
+        self.assertEqual(commands, expected)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- update recipe parser to repeat when colon lines are followed by `-` or `--`, regardless of indentation
- test colon prefix handling without indentation
- migrate all recipes to explicit colon form

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686be37d9a84832691045a1e798a9996