### PR TITLE
Fix OCPP data load in csms

### DIFF
--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -13,11 +13,8 @@ from fastapi import WebSocket, WebSocketDisconnect
 from bottle import request, redirect, HTTPError
 from typing import Dict, Optional
 from gway import gw
-# Avoid relative import issues when loaded as a standalone project
-ocpp_data = gw.load_py_file(
-    os.path.join(os.path.dirname(__file__), "data.py"),
-    "ocpp.data",
-)
+# Use the gateway to load the shared OCPP data helpers once
+ocpp_data = gw.ocpp.data
 
 _csms_loop: Optional[asyncio.AbstractEventLoop] = None
 _transactions: Dict[str, dict] = {}           # charger_id → latest transaction


### PR DESCRIPTION
## Summary
- load `ocpp.data` through the gateway rather than re-importing the file

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: Port 19000 not responding after 12 seconds)*


------
https://chatgpt.com/codex/tasks/task_e_686c480b4d708326b9c5517520dd8918