### PR TITLE
Remove temp requirements check

### DIFF
--- a/gway.bat
+++ b/gway.bat
@@ -13,12 +13,6 @@ if not exist ".venv" (
     python -m pip install --upgrade pip
     python -m pip install -e .
 
-    :: Install additional requirements if the file exists
-    if exist "temp\requirements.txt" (
-        echo Installing additional requirements from temp\requirements.txt...
-        python -m pip install -r temp\requirements.txt
-    )
-
     deactivate
 )
 

--- a/gway.sh
+++ b/gway.sh
@@ -15,12 +15,6 @@ if [ ! -d ".venv" ]; then
   pip install --upgrade pip
   pip install -e .
 
-  # Install additional requirements if the file exists
-  if [ -f "temp/requirements.txt" ]; then
-    echo "Installing additional requirements from temp/requirements.txt..."
-    pip install -r temp/requirements.txt
-  fi
-
   deactivate
 fi
 

--- a/install.bat
+++ b/install.bat
@@ -49,10 +49,6 @@ if not exist ".venv" (
     echo Installing gway in editable mode...
     python -m pip install --upgrade pip
     python -m pip install -e .
-    if exist "temp\requirements.txt" (
-        echo Installing additional requirements from temp\requirements.txt...
-        python -m pip install -r temp\requirements.txt
-    )
     deactivate
 )
 


### PR DESCRIPTION
## Summary
- trim gway.bat and install.bat to stop looking for `temp\requirements.txt`
- remove the same step from gway.sh

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686c668054e083268cf7bc6fe428fbe3