### PR TITLE
Add nested sigil attribute access

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,8 @@ Basic Features
 
 - 🔌 Seamless from CLI or code (e.g., ``gw.awg.find_cable()`` is ``gway awg find-cable``)
 - ⛓️ CLI chaining: ``proj1 func1 - proj2 func2`` (implicit parameter passing by name)
-- 🧠 Sigil-based context resolution (e.g., ``[result-context-environ|fallback]``)
+- 🧠 Sigil-based context resolution (e.g., ``[result-context-environ]``).
+  Nested paths are supported via spaces or dots, e.g., ``[app.name]``
 - ⚙️ Automatic CLI generation, with support for ``*``, ``*args`` and ``**kwargs``
 - 🧪 Built-in test runner and self-packaging: ``gway test`` (use ``--coverage`` for coverage) and ``gway release build``
 - 📦 Environment-aware loading (e.g., ``clients`` and ``servers`` .env files)

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -4,7 +4,7 @@ from gway.sigils import Resolver
 class ResolverDefaultTests(unittest.TestCase):
     def test_resolve_returns_default(self):
         resolver = Resolver([])
-        self.assertEqual(resolver.resolve('[missing]', default='fallback'), 'fallback')
+        self.assertEqual(resolver.resolve('[missing]', default='foo'), 'foo')
 
     def test_resolve_raises_with_sentinel(self):
         resolver = Resolver([])
@@ -39,6 +39,12 @@ class ResolverLookupTests(unittest.TestCase):
             self.assertEqual(env_resolver.resolve('[sigtest]'), 'ok')
         finally:
             del os.environ['SIGTEST']
+
+    def test_nested_lookup_via_path(self):
+        nested = {'app': {'name': 'Demo'}}
+        resolver = Resolver([('env', {}), ('ctx', nested)])
+        self.assertEqual(resolver.resolve('[app.name]'), 'Demo')
+        self.assertEqual(resolver['app.name'], 'Demo')
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sigils.py
+++ b/tests/test_sigils.py
@@ -53,6 +53,16 @@ class SigilTests(unittest.TestCase):
         s = Sigil("Value [FOO-BAR]")
         self.assertEqual(s.resolve(finder), "Value bar")
 
+    def test_dotted_and_spaced_paths(self):
+        class Obj:
+            pass
+        obj = Obj()
+        obj.name = "Widget"
+        data = {"app": {"name": "dict"}, "obj": obj}
+        self.assertEqual(Sigil("[app.name]") % data, "dict")
+        self.assertEqual(Sigil("[app name]") % data, "dict")
+        self.assertEqual(Sigil("[obj.name]") % data, "Widget")
+
     def test_unquote_helper(self):
         from gway.sigils import _unquote
         self.assertEqual(_unquote('"hello"'), "hello")


### PR DESCRIPTION
## Summary
- enable nested sigil resolution via dots or spaces
- document nested sigils in README
- test attribute/item access using dotted paths
- add tests for resolver path lookup
- remove fallback mention in documentation and tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686c6bb85aa08326b2fb4ec386fce163