### PR TITLE
Fix theme background extending beyond viewport

### DIFF
--- a/data/static/styles/classic-95.css
+++ b/data/static/styles/classic-95.css
@@ -1,6 +1,7 @@
 /* win95.css — Layered atop base.css */
 
-body {
+body,
+.page-wrap {
     background-color: #c0c0c0;
     color: #000000;
     font-family: 'MS Sans Serif', Tahoma, Geneva, Verdana, Arial, sans-serif;


### PR DESCRIPTION
## Summary
- ensure classic-95 grey background fills the whole page

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686c764c62308326aa24ff6908f347fa