### PR TITLE
Improve sigil resolver

### DIFF
--- a/projects/release.py
+++ b/projects/release.py
@@ -355,6 +355,34 @@ def loc(*paths):
     return file_counts
 
 
+def benchmark_sigils(iterations: int = 10000) -> float:
+    """Benchmark Sigil resolution performance."""
+    from time import perf_counter
+    from gway.sigils import Sigil
+
+    ctx = {
+        "name": "Bench",
+        "num": 42,
+        "info": {"x": 1, "y": 2},
+    }
+    samples = [
+        Sigil("[name]"),
+        Sigil("Value [num]"),
+        Sigil("[info.x]"),
+        Sigil("[info]")
+    ]
+
+    start = perf_counter()
+    for _ in range(iterations):
+        for s in samples:
+            _ = s % ctx
+    elapsed = perf_counter() - start
+    gw.info(
+        f"Resolved {iterations * len(samples)} sigils in {elapsed:.4f}s"
+    )
+    return elapsed
+
+
 def create_shortcut(
     name="Launch GWAY",
     target=r"gway.bat",


### PR DESCRIPTION
## Summary
- handle non-string sigil values
- serialize embedded objects
- block underscore path segments
- add benchmark utility to release project
- test new sigil behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686c71466b0483269b4e0e33eb718de9