### PR TITLE
Add ocpp data view to website demo

### DIFF
--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -9,6 +9,7 @@ web app setup-app:
     --project web.nav --home style-switcher
     --project web.cookies --home cookie-jar
     --project vbox --home uploads
+    --project ocpp.data --home charger-summary
     --project ocpp.csms --auth-required --home charger-status
     --project ocpp.evcs --auth-required --home cp-simulator
     --project games.conway --home game-of-life --path conway


### PR DESCRIPTION
## Summary
- include OCPP data project in the website recipe so the charger summary page is reachable

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_686c7b1afcdc83268d075f8efaa359c6