### PR TITLE
Add test flag support for optional screenshot tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Basic Features
 - 🧠 Sigil-based context resolution (e.g., ``[result-context-environ]``).
   Nested paths are supported via spaces or dots, e.g., ``[app.name]``
 - ⚙️ Automatic CLI generation, with support for ``*``, ``*args`` and ``**kwargs``
-- 🧪 Built-in test runner and self-packaging: ``gway test`` (use ``--coverage`` for coverage) and ``gway release build``
+- 🧪 Built-in test runner and self-packaging: ``gway test`` (use ``--coverage`` for coverage and ``--flags`` to enable optional tests) and ``gway release build``
 - 📦 Environment-aware loading (e.g., ``clients`` and ``servers`` .env files)
 
 

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -11,3 +11,16 @@ Install the runtime dependencies first. The simplest approach is:
 
 This ensures that modules such as ``requests`` and ``websockets`` are
 available to the test suite.
+
+Enabling Optional Tests
+-----------------------
+
+Some tests are skipped by default, such as those that capture screenshots. You
+can enable them by passing feature flags to ``gway test``:
+
+.. code-block:: bash
+
+   gway test --flags screenshot
+
+The flags are stored in the ``GW_TEST_FLAGS`` environment variable, which test
+cases can check via ``is_test_flag('flag')``.

--- a/tests/test_auth_charger.py
+++ b/tests/test_auth_charger.py
@@ -10,6 +10,7 @@ import requests
 import random
 import string
 from gway import gw
+from gway.builtins import is_test_flag
 import importlib.util
 from pathlib import Path
 
@@ -121,7 +122,7 @@ class AuthChargerStatusTests(unittest.TestCase):
         )
         self.assertIn("cookie", resp2.text.lower())
 
-    @unittest.skip("Screenshot tests disabled")
+    @unittest.skipUnless(is_test_flag("screenshot"), "Screenshot tests disabled")
     def test_charger_status_screenshot(self):
         """Capture charger status page screenshot using basic auth."""
         screenshot_dir = Path("work/screenshots")

--- a/tests/test_conway_web.py
+++ b/tests/test_conway_web.py
@@ -10,6 +10,7 @@ import socket
 import requests
 from bs4 import BeautifulSoup
 from gway import gw
+from gway.builtins import is_test_flag
 import importlib.util
 from pathlib import Path
 
@@ -152,7 +153,7 @@ class ConwayWebTests(unittest.TestCase):
         js_links = [script['src'] for script in body.find_all('script', src=True)]
         self.assertIn("/shared/global.js", js_links, f"/shared/global.js not linked before </body>: {js_links}")
 
-    @unittest.skip("Screenshot tests disabled")
+    @unittest.skipUnless(is_test_flag("screenshot"), "Screenshot tests disabled")
     def test_conway_game_page_screenshot(self):
         """Capture a screenshot of the Game of Life page for manual review."""
         screenshot_dir = Path("work/screenshots")

--- a/tests/test_nav_styles.py
+++ b/tests/test_nav_styles.py
@@ -8,6 +8,7 @@ import requests
 from bs4 import BeautifulSoup
 import importlib.util
 from pathlib import Path
+from gway.builtins import is_test_flag
 
 # Dynamically load the web.auto helpers for screenshot capture
 auto_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "auto.py"
@@ -157,7 +158,7 @@ class NavStyleTests(unittest.TestCase):
             f"Readme page did not include expected theme <link> for classic-95.css in <head>. Got links: {[str(l) for l in soup2.find_all('link', rel='stylesheet')]}"
         )
 
-    @unittest.skip("Screenshot tests disabled")
+    @unittest.skipUnless(is_test_flag("screenshot"), "Screenshot tests disabled")
     def test_style_switcher_screenshot(self):
         """Capture a screenshot of the style switcher page."""
         screenshot_dir = Path("work/screenshots")

--- a/tests/test_screenshot_attachment.py
+++ b/tests/test_screenshot_attachment.py
@@ -3,6 +3,7 @@ import subprocess
 import time
 import socket
 from pathlib import Path
+from gway.builtins import is_test_flag
 import importlib.util
 
 # Dynamically import the capture helpers without relying on projects as a package
@@ -44,7 +45,7 @@ class ScreenshotAttachmentTest(unittest.TestCase):
                 time.sleep(0.2)
         raise TimeoutError(f"Port {port} not responding after {timeout} seconds")
 
-    @unittest.skip("Screenshot tests disabled")
+    @unittest.skipUnless(is_test_flag("screenshot"), "Screenshot tests disabled")
     def test_capture_help_page_screenshot(self):
         screenshot_dir = Path("work/screenshots")
         screenshot_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- make `gway test` accept `--flags` and store them in `GW_TEST_FLAGS`
- provide `is_test_flag()` helper
- use `is_test_flag('screenshot')` to conditionally run screenshot tests
- document optional test flags

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`
- `gway test --flags screenshot`


------
https://chatgpt.com/codex/tasks/task_e_686c6dc5e84083268a572931771ee44e