### PR TITLE
Add service user options for Windows installer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Unreleased
 ---------------------
 
 - 0b416ec fix ocpp.data to load directly
+- Allow specifying service user and password for Windows installer
+- Windows service runs `python -m gway` instead of `gway.bat`
 
 0.4.39 [build ccb94e]
 ---------------------

--- a/README.rst
+++ b/README.rst
@@ -176,7 +176,7 @@ To run GWAY automatically as a service using a recipe:
 .. code-block:: bash
 
     sudo ./install.sh <recipe> [--debug] [--root]   # On Linux/macOS
-    install.bat <recipe> [--debug]         # On Windows
+    install.bat <recipe> [--debug] [--user <account> --password <pass>]         # On Windows
     sudo ./install.sh <recipe> --remove    # Remove on Linux/macOS
     install.bat <recipe> --remove [--force]  # Remove on Windows
     install.bat <recipe> --repair            # Repair one service on Windows

--- a/install.bat
+++ b/install.bat
@@ -9,6 +9,8 @@ set "ACTION=install"
 set "RECIPE="
 set "FORCE_FLAG="
 set "DEBUG_FLAG="
+set "USER_FLAG="
+set "PASSWORD_FLAG="
 :parse_args
 if "%~1"=="" goto end_parse_args
 if "%~1"=="--remove" (
@@ -19,6 +21,20 @@ if "%~1"=="--remove" (
     set "FORCE_FLAG=--force"
  ) else if "%~1"=="--debug" (
     set "DEBUG_FLAG=--debug"
+ ) else if "%~1"=="--user" (
+    if "%~2"=="" (
+        echo ERROR: --user requires a value
+        exit /b 1
+    )
+    set "USER_FLAG=--user %~2"
+    shift
+ ) else if "%~1"=="--password" (
+    if "%~2"=="" (
+        echo ERROR: --password requires a value
+        exit /b 1
+    )
+    set "PASSWORD_FLAG=--password %~2"
+    shift
 ) else (
     if not defined RECIPE (
         set "RECIPE=%~1"
@@ -56,7 +72,7 @@ rem No-arg case
 if not defined RECIPE (
     echo GWAY has been set up in .venv.
     echo To install a Windows service for a recipe, run:
-    echo   install.bat ^<recipe^> [--debug]
+    echo   install.bat ^<recipe^> [--debug] [--user ^<account^> --password ^<pass^>]
     echo To remove a Windows service, run:
     echo   install.bat ^<recipe^> --remove [--force]
     echo To repair a Windows service, run:
@@ -78,7 +94,7 @@ set "SERVICE_PY=%~dp0tools\windows_service.py"
 
 if "%ACTION%"=="install" (
     echo Installing Windows service %SERVICE_NAME% for recipe %RECIPE%...
-    python "%SERVICE_PY%" install --name %SERVICE_NAME% --recipe %RECIPE% %DEBUG_FLAG%
+    python "%SERVICE_PY%" install --name %SERVICE_NAME% --recipe %RECIPE% %DEBUG_FLAG% %USER_FLAG% %PASSWORD_FLAG%
     python "%SERVICE_PY%" start --name %SERVICE_NAME%
 ) else if "%ACTION%"=="remove" (
     echo Removing Windows service %SERVICE_NAME% for recipe %RECIPE%...
@@ -88,7 +104,7 @@ if "%ACTION%"=="install" (
     echo Repairing Windows service %SERVICE_NAME% for recipe %RECIPE%...
     python "%SERVICE_PY%" stop --name %SERVICE_NAME%
     python "%SERVICE_PY%" remove --name %SERVICE_NAME% --recipe %RECIPE% %FORCE_FLAG%
-    python "%SERVICE_PY%" install --name %SERVICE_NAME% --recipe %RECIPE% %DEBUG_FLAG%
+    python "%SERVICE_PY%" install --name %SERVICE_NAME% --recipe %RECIPE% %DEBUG_FLAG% %USER_FLAG% %PASSWORD_FLAG%
     python "%SERVICE_PY%" start --name %SERVICE_NAME%
 )
 

--- a/tests/test_windows_service.py
+++ b/tests/test_windows_service.py
@@ -15,5 +15,18 @@ class FormatDisplayNameTests(unittest.TestCase):
         self.assertEqual(ws._format_display_name('foo_bar-baz'), 'Foo Bar Baz')
 
 
+class ParseArgsTests(unittest.TestCase):
+    def test_parse_args_user_password(self):
+        args = ws.parse_args([
+            'install',
+            '--name', 'svc',
+            '--recipe', 'demo',
+            '--user', 'testuser',
+            '--password', 'secret',
+        ])
+        self.assertEqual(args.user, 'testuser')
+        self.assertEqual(args.password, 'secret')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- allow setting service account user and password via `--user`/`--password` options
- parse the new flags in `install.bat`
- document usage and changelog
- test parsing logic for new arguments
- run Windows service using `python -m gway` instead of `gway.bat`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686c64e729148326b0397217b80fcd20