### PR TITLE
Fix simulator recv overlap

### DIFF
--- a/projects/ocpp/evcs.py
+++ b/projects/ocpp/evcs.py
@@ -264,6 +264,8 @@ async def simulate_cp(
                     await listener
                 except asyncio.CancelledError:
                     pass
+                # give the event loop a moment to finalize the cancelled recv
+                await asyncio.sleep(0)
 
                 # StopTransaction
                 await ws.send(json.dumps([2, "stop", "StopTransaction", {

--- a/tests/test_etron_ws.py
+++ b/tests/test_etron_ws.py
@@ -400,6 +400,27 @@ class EtronWebSocketTests(unittest.TestCase):
 
         asyncio.run(run_stop_check())
 
+    def test_evcs_simulator_session_runs_without_recv_error(self):
+        """EVCS simulator should complete a short session without recv overlap errors."""
+        async def run_sim():
+            import io, contextlib
+            buf = io.StringIO()
+            with contextlib.redirect_stdout(buf):
+                await gw.ocpp.evcs.simulate_cp.__wrapped__(
+                    0,
+                    "localhost",
+                    19000,
+                    KNOWN_GOOD_TAG,
+                    "SIMTEST",
+                    1,
+                    1,
+                )
+            return buf.getvalue()
+
+        output = asyncio.run(run_sim())
+        self.assertNotIn("cannot call recv", output)
+        self.assertIn("Simulation ended", output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- address intermittent recv overlap in simulator
- cover simulator session with a regression test

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686c873d6ac08326a34b32f16ebcb9ac