### PR TITLE
Fix ocpp simulate_cp test

### DIFF
--- a/tests/test_etron_ws.py
+++ b/tests/test_etron_ws.py
@@ -414,6 +414,8 @@ class EtronWebSocketTests(unittest.TestCase):
                     "SIMTEST",
                     1,
                     1,
+                    1,
+                    1,
                 )
             return buf.getvalue()
 


### PR DESCRIPTION
## Summary
- update `simulate_cp` invocation in the Etron websocket tests

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686d191737008326bb6843f38ce298e8