### PR TITLE
Fix website recipe to include changelog

### DIFF
--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -14,6 +14,7 @@ web app setup-app:
     --project ocpp.data --auth-required --home charger-summary
     --project games.conway --home game-of-life --path conway
     --project games.mtg --home search-games
+    --project release --home changelog
     --project web.auth
 
 web:


### PR DESCRIPTION
## Summary
- make changelog view available by enabling the `release` project in the demo website recipe

## Testing
- `gway test --coverage` *(fails: KeyboardInterrupt)*
- `curl -I http://127.0.0.1:8888/release/changelog`

------
https://chatgpt.com/codex/tasks/task_e_686d2dcc0d108326bb924f07f95e8183