### PR TITLE
Add notification flag to runner

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -290,11 +290,11 @@ Then in your own recipe:
     web app setup --project mysite --home hello
     web app setup --project web.navbar
     web server start-app --host 127.0.0.1 --port 8888
-    forever
+    until --forever
 
 Navigate to http://127.0.0.1:8888/mysite/hello or /mysite/about to see your views, including a handy navbar. Press Ctrl+D or close the terminal to end the process.
 
-The **forever** function keeps the above apps and servers running forever.
+The ``--forever`` option for ``until`` keeps the above apps and servers running indefinitely.
 
 
 Composing Sites from Multiple Projects
@@ -312,7 +312,7 @@ You can chain as many projects as you want; each can define its own set of views
         --project conway --home game-of-life --path games/conway
 
     web server start-app --host 127.0.0.1 --port 8888
-    until --version --build --pypi
+    until --version --build --pypi --notify
 
 
 The above example combines basic features such as cookies and navbar with custom projects, a virtual upload/download box system and Conway's Game of Life, into a single application.
@@ -320,7 +320,7 @@ The above example combines basic features such as cookies and navbar with custom
 
 The above recipe also shows implicit repeated commands. For example, instead of writing "web app setup" multiple times, each line below that doesn't start with a command repeats the last command with new parameters.
 
-The **until** function, as used here, will keep the recipe going until the package updates in PyPI (checked hourly) or a manual update ocurrs. This is appropriate for self-restarting services such as those managed by systemd or kubernetes.
+The **until** function, as used here, will keep the recipe going until the package updates in PyPI (checked hourly) or a manual update ocurrs.  Use ``--notify`` to send a desktop/email notification when the runner would stop, ``--notify-only`` to keep running after notifying, and ``--abort`` to exit the process when a watcher triggers.  By default ``until`` simply returns when its condition is met. This is appropriate for self-restarting services such as those managed by systemd or kubernetes.
 
 
 

--- a/gway/builtins.py
+++ b/gway/builtins.py
@@ -570,6 +570,24 @@ def random_id(length: int = 8, alphabet: str = _EZ_ALPHABET) -> str:
     """Generate a readable random ID, avoiding confusing characters."""
     return ''.join(random.choices(alphabet, k=length))
 
+def notify(message: str, *, title: str = "GWAY Notice", timeout: int = 10):
+    """Send a notification via GUI, email or console fallback."""
+    from gway import gw
+    try:
+        gw.screen.notify(message, title=title, timeout=timeout)
+        return "gui"
+    except Exception as e:
+        gw.debug(f"GUI notify failed: {e}")
+    try:
+        if hasattr(gw, "mail") and os.environ.get("ADMIN_EMAIL"):
+            gw.mail.send(title, body=message, to=os.environ.get("ADMIN_EMAIL"))
+            return "email"
+    except Exception as e:  # pragma: no cover - mail may not be configured
+        gw.debug(f"Email notify failed: {e}")
+    print(message)
+    gw.info(f"Console notify: {message}")
+    return "console"
+
 def shell():
     """Launch an interactive Python shell with 'from gway import gw' preloaded."""
     from gway import gw, __

--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -12,7 +12,7 @@ web app setup-app:
 
 web:
  - static collect
- - server start-app --port 8888
+- server start-app --port 8888
 
-forever
+until --forever
 

--- a/recipes/skeleton.gwr
+++ b/recipes/skeleton.gwr
@@ -5,5 +5,5 @@ web app setup-app:
     --project web.nav
 web:
  - static collect
- - server start-app
-forever
+- server start-app
+until --forever

--- a/tests/test_notify_builtin.py
+++ b/tests/test_notify_builtin.py
@@ -1,0 +1,33 @@
+import unittest
+import os
+import sys
+from io import StringIO
+from unittest.mock import patch
+from gway import gw
+
+class NotifyBuiltinTests(unittest.TestCase):
+    def setUp(self):
+        self.out = StringIO()
+        self.orig = sys.stdout
+        sys.stdout = self.out
+
+    def tearDown(self):
+        sys.stdout = self.orig
+        os.environ.pop('ADMIN_EMAIL', None)
+
+    def test_console_fallback(self):
+        with patch.object(gw.screen, 'notify', side_effect=Exception('fail')):
+            with patch.object(gw.mail, 'send') as mock_send:
+                gw.notify('hello world', title='T')
+                mock_send.assert_not_called()
+        self.assertIn('hello world', self.out.getvalue())
+
+    def test_email_fallback(self):
+        os.environ['ADMIN_EMAIL'] = 'test@example.com'
+        with patch.object(gw.screen, 'notify', side_effect=Exception('fail')):
+            with patch.object(gw.mail, 'send') as mock_send:
+                gw.notify('msg', title='Notice')
+                mock_send.assert_called_once()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_until.py
+++ b/tests/test_until.py
@@ -1,0 +1,76 @@
+import unittest
+import os
+import tempfile
+import threading
+import time
+from unittest.mock import patch
+from gway import gw
+import gway.runner as runner
+
+class UntilAbortTests(unittest.TestCase):
+    def setUp(self):
+        self.orig_threads = list(gw._async_threads)
+
+    def tearDown(self):
+        gw._async_threads.clear()
+        gw._async_threads.extend(self.orig_threads)
+
+    def _start_dummy_async(self, stop_event):
+        def dummy():
+            while not stop_event.is_set():
+                time.sleep(0.01)
+        t = threading.Thread(target=dummy, daemon=True)
+        gw._async_threads.append(t)
+        t.start()
+        return t
+
+    def _trigger_change(self, path, stop_event):
+        time.sleep(0.2)
+        with open(path, 'w') as f:
+            f.write('changed')
+        stop_event.set()
+
+    def test_until_returns_on_change(self):
+        stop = threading.Event()
+        dummy = self._start_dummy_async(stop)
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            path = tmp.name
+        trig = threading.Thread(target=self._trigger_change, args=(path, stop), daemon=True)
+        trig.start()
+        orig_watch = runner.watch_file
+        def fast_watch(*a, **k):
+            k['interval'] = 0.05
+            return orig_watch(*a, **k)
+
+        with patch('gway.runner.watch_file', side_effect=fast_watch):
+            with patch.object(gw, 'abort') as abort_fn:
+                gw.until(file=path)
+                abort_fn.assert_not_called()
+        dummy.join(1)
+        trig.join(1)
+        os.unlink(path)
+        # If we reach here, until returned without aborting
+
+    def test_until_abort_raises(self):
+        stop = threading.Event()
+        dummy = self._start_dummy_async(stop)
+        with tempfile.NamedTemporaryFile(delete=False) as tmp:
+            path = tmp.name
+        trig = threading.Thread(target=self._trigger_change, args=(path, stop), daemon=True)
+        trig.start()
+        orig_watch = runner.watch_file
+        def fast_watch(*a, **k):
+            k['interval'] = 0.05
+            return orig_watch(*a, **k)
+
+        with patch('gway.runner.watch_file', side_effect=fast_watch):
+            with patch.object(gw, 'abort', side_effect=SystemExit(1)) as abort_fn:
+                with self.assertRaises(SystemExit):
+                    gw.until(file=path, abort=True)
+                abort_fn.assert_called_once()
+        dummy.join(1)
+        trig.join(1)
+        os.unlink(path)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new notify builtin for GUI/mail/console fallbacks
- implement `--notify` and `--notify-only` flags in `until`
- add optional `--abort` flag and avoid forced exit by default
- document runner notifications
- replace `forever` command with `until --forever`
- add tests for notification and until abort logic
- use `gw.abort` when aborting from `until`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686c90d862e88326ab695bbb67a89631