### PR TITLE
Add CDV data editor view

### DIFF
--- a/recipes/skeleton.gwr
+++ b/recipes/skeleton.gwr
@@ -3,6 +3,7 @@
 web app setup-app:
     --project web.site --home reader
     --project web.nav
+    --project cdv --home data-editor
 web:
  - static collect
  - server start-app

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -14,6 +14,7 @@ web app setup-app:
     --project ocpp.data --auth-required --home charger-summary
     --project games.conway --home game-of-life --path conway
     --project games.mtg --home search-games
+    --project cdv --home data-editor
     --project release --home changelog
     --project web.auth
 

--- a/tests/test_cdv_utils.py
+++ b/tests/test_cdv_utils.py
@@ -1,0 +1,52 @@
+import unittest
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+# Load web.site so cdv can import its helpers
+site_spec = importlib.util.spec_from_file_location(
+    "projects.web.site", Path(__file__).resolve().parents[1] / "projects" / "web" / "site.py"
+)
+site_mod = importlib.util.module_from_spec(site_spec)
+site_spec.loader.exec_module(site_mod)
+
+projects_mod = types.ModuleType("projects")
+web_mod = types.ModuleType("projects.web")
+web_mod.site = site_mod
+projects_mod.web = web_mod
+sys.modules.setdefault("projects", projects_mod)
+sys.modules.setdefault("projects.web", web_mod)
+sys.modules.setdefault("projects.web.site", site_mod)
+
+cdv_path = Path(__file__).resolve().parents[1] / "projects" / "cdv.py"
+spec = importlib.util.spec_from_file_location("cdv_mod", cdv_path)
+cdv_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cdv_mod)
+
+
+class CDVUtilsTests(unittest.TestCase):
+    def test_sanitize_cdv_path(self):
+        cases = {
+            "foo/bar": "foo/bar",
+            "../secret/file.cdv": "secret/file.cdv",
+            "foo\\bar": "foo/bar",
+            "../../evil": "evil",
+        }
+        for raw, expected in cases.items():
+            with self.subTest(raw=raw):
+                self.assertEqual(cdv_mod._sanitize_cdv_path(raw), expected)
+
+    def test_parse_and_serialize_roundtrip(self):
+        text = "id1:name=John%20Doe:age=30\nid2:msg=Hello"
+        records = cdv_mod._parse_cdv_text(text)
+        self.assertEqual(records, {
+            "id1": {"name": "John Doe", "age": "30"},
+            "id2": {"msg": "Hello"},
+        })
+        serialized = cdv_mod._records_to_text(records)
+        self.assertEqual(serialized, "id1:name=John%20Doe:age=30\nid2:msg=Hello")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add sanitized CDV helpers and interactive data editor view
- expose cdv project in default recipes
- test CDV utilities

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686d3c34822083269029fa7b9f894800