### PR TITLE
Implement timed execution across Gateway

### DIFF
--- a/gway/console.py
+++ b/gway/console.py
@@ -57,7 +57,8 @@ def cli_main():
         name=args.username or "gw",
         project_path=args.projects,
         debug=args.debug,
-        wizard=args.wizard
+        wizard=args.wizard,
+        timed=args.timed
     )
 
     gw_local.verbose(
@@ -81,6 +82,8 @@ def cli_main():
         run_kwargs['client'] = args.client
     if args.server:
         run_kwargs['server'] = args.server
+    if args.timed:
+        run_kwargs['timed'] = True
     all_results, last_result = process(command_sources, **run_kwargs)
 
     # Resolve expression if requested

--- a/gway/runner.py
+++ b/gway/runner.py
@@ -20,6 +20,7 @@ class Runner:
 
     def run_coroutine(self, func_name, coro_or_func, args=None, kwargs=None):
         try:
+            start_time = time.perf_counter() if getattr(self, 'timed_enabled', False) else None
             loop = asyncio.new_event_loop()
             asyncio.set_event_loop(loop)
 
@@ -40,6 +41,9 @@ class Runner:
                     self.exception(e)
         finally:
             loop.close()
+            if start_time is not None:
+                if hasattr(self, 'log'):
+                    self.log(f"[timed] {func_name} (async) took {time.perf_counter() - start_time:.3f}s")
 
     def until(self, *, file=None, url=None, pypi=False, version=False, build=False,
               forever=False, notify=False, notify_only=False, abort=False):


### PR DESCRIPTION
## Summary
- add a `timed` option to `Gateway` and propagate via CLI
- time wrapped function calls and async coroutines
- log per‑test duration via custom unittest result
- measure web request processing time in Bottle app

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686d517c70d48326b63a836cc8d55a85