### PR TITLE
Fix README changelog link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ Fetch the source, changelogs and issues (or submit your own) here:
 
 https://github.com/arthexis/gway
 
-Browse the latest changes in the `CHANGELOG <https://arthexis.com/release/changelog>`_.
+Browse the latest changes in the `CHANGELOG <https://arthexis.com/site/reader?title=CHANGELOG&ext=rst>`_.
 
 See a demo and the full list of available projects and other help topics online here:
 


### PR DESCRIPTION
## Summary
- fix the CHANGELOG link in the README to use the existing reader view

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686d544981788326b912cd63f98113da