### PR TITLE
Add manual AWG option with warnings

### DIFF
--- a/tests/test_awg.py
+++ b/tests/test_awg.py
@@ -35,5 +35,11 @@ class TestMaxAwg(unittest.TestCase):
         res = gw.awg.find_awg(meters=30, amps=40, max_lines="")
         self.assertEqual(res["lines"], 1)
 
+    def test_forced_awg_returns_warning(self):
+        res = gw.awg.find_awg(meters=30, amps=150, force_awg="14")
+        self.assertEqual(res["awg"], "14")
+        self.assertIn("warning", res)
+        self.assertGreater(res["vdperc"], 3)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow forcing an AWG size in `find_awg`
- surface AWG input field on the cable finder page
- adjust heading to "Cable Result"
- test forced AWG mode

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686d57fd3cf48326ba73f2b16446e507