### PR TITLE
Fix changelog rendering

### DIFF
--- a/projects/release.py
+++ b/projects/release.py
@@ -631,10 +631,15 @@ def update_changelog(version: str, build_hash: str, prev_build: str | None = Non
 
 
 def view_changelog():
-    """Render the changelog including any Unreleased section."""
-    from projects.web import site
+    """Render the changelog, hiding an empty ``Unreleased`` section."""
+    from docutils.core import publish_parts
 
-    return site.view_reader(title="CHANGELOG", ext="rst")
+    text = _ensure_changelog()
+    unreleased_body, trimmed = _pop_unreleased(text)
+    if not unreleased_body.strip():
+        text = trimmed
+
+    return publish_parts(source=text, writer_name="html")["html_body"]
 
 
 if __name__ == "__main__":

--- a/tests/test_view_changelog.py
+++ b/tests/test_view_changelog.py
@@ -1,0 +1,82 @@
+import unittest
+import tempfile
+import os
+import importlib.util
+import types
+import sys
+from pathlib import Path
+
+# Load site module for pseudo package structure
+site_spec = importlib.util.spec_from_file_location(
+    "projects.web.site",
+    Path(__file__).resolve().parents[1] / "projects" / "web" / "site.py",
+)
+site_mod = importlib.util.module_from_spec(site_spec)
+site_spec.loader.exec_module(site_mod)
+
+projects_mod = types.ModuleType("projects")
+web_mod = types.ModuleType("projects.web")
+web_mod.site = site_mod
+projects_mod.web = web_mod
+sys.modules.setdefault("projects", projects_mod)
+sys.modules.setdefault("projects.web", web_mod)
+sys.modules.setdefault("projects.web.site", site_mod)
+
+# Load release module
+release_spec = importlib.util.spec_from_file_location(
+    "projects.release",
+    Path(__file__).resolve().parents[1] / "projects" / "release.py",
+)
+release_mod = importlib.util.module_from_spec(release_spec)
+release_spec.loader.exec_module(release_mod)
+
+class ViewChangelogTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmp.name)
+        self.old_cwd = Path.cwd()
+        os.chdir(self.base)
+
+    def tearDown(self):
+        os.chdir(self.old_cwd)
+        self.tmp.cleanup()
+
+    def _write_changelog(self, text: str):
+        Path("CHANGELOG.rst").write_text(text)
+
+    def test_header_hidden_when_empty(self):
+        content = """Changelog
+=========
+
+Unreleased
+----------
+
+0.1.0 [build 123]
+-----------------
+
+- first change
+"""
+        self._write_changelog(content)
+        html = release_mod.view_changelog()
+        self.assertNotIn("Unreleased", html)
+
+    def test_header_shown_when_has_entries(self):
+        content = """Changelog
+=========
+
+Unreleased
+----------
+- new feature
+
+0.1.0 [build 123]
+-----------------
+
+- first change
+"""
+        self._write_changelog(content)
+        html = release_mod.view_changelog()
+        self.assertIn("Unreleased", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- hide empty `Unreleased` section when viewing the changelog
- test changelog view logic

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686d6c4078fc83269ff9ab037431bb9d