### PR TITLE
Display Basic Auth user with logout

### DIFF
--- a/data/static/base.css
+++ b/data/static/base.css
@@ -260,6 +260,8 @@ img.compass {
 form.navbar { margin-bottom: 1em; }
 div.compass { margin-top: 1em; text-align: center; }
 p.compass { margin-bottom: 0.5em; }
+p.user-info { text-align: center; margin-bottom: 0.5em; font-size: 0.95em; }
+a.logout { margin-left: 0.4em; }
 
 /* 13. Utility classes */
 .hidden { display: none !important; }

--- a/projects/web/auth.py
+++ b/projects/web/auth.py
@@ -245,3 +245,10 @@ def create_user(username, password, *, allow='work/basic_auth.cdv', force=False,
     user_fields.update(fields)
     gw.cdv.update(allow, username, **user_fields)
     gw.info(f"[auth] Created/updated user '{username}' in '{allow}'")
+
+def view_logout():
+    """Force browser to prompt for credentials again."""
+    from bottle import response
+    response.status = 401
+    response.headers['WWW-Authenticate'] = 'Basic realm="GWAY"'
+    return "<b>Logged out</b>"

--- a/projects/web/nav.py
+++ b/projects/web/nav.py
@@ -1,6 +1,7 @@
 # file: projects/web/nav.py
 
 import os
+import html
 from gway import gw
 from bottle import request
 
@@ -83,6 +84,20 @@ def render(*, homes=None, links=None):
         </form>
     '''.format(request.query.get("topic", ""))
 
+    # --- Current user info (Basic Auth) ---
+    user_html = ""
+    try:
+        auth_header = request.get_header("Authorization")
+        username, _ = gw.web.auth.parse_basic_auth_header(auth_header)
+        if username:
+            logout_url = gw.web.app.build_url("auth", "logout")
+            user_html = (
+                f'<p class="user-info">User: {html.escape(username)} '
+                f'<a href="{logout_url}" class="logout">Logout</a></p>'
+            )
+    except Exception as e:
+        gw.debug(f"Could not resolve auth user: {e}")
+
     # --- QR code for this page ---
     compass = ""
     try:
@@ -96,7 +111,7 @@ def render(*, homes=None, links=None):
     except Exception as e:
         gw.debug(f"Could not generate QR compass: {e}")
         
-    return f"<aside>{search_box}<ul>{links_html}</ul><br>{compass}</aside>"
+    return f"<aside>{search_box}<ul>{links_html}</ul>{user_html}<br>{compass}</aside>"
 
 def active_style():
     """


### PR DESCRIPTION
## Summary
- show Basic Auth user above the QR compass in sidebar
- add logout link handled by new `view_logout`
- style the user line and logout link in CSS

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686d6d4acf688326a55ff10e01a4dd24