### PR TITLE
Update auth flag for setup

### DIFF
--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -39,10 +39,14 @@ def setup_app(*,
     location=None,
     authorize=authorize_balance,
     email=None,
-    auth_required=False,
+    auth="disabled",
 ):
     # no globals needed here; dictionaries are modified in-place
     email = email if isinstance(email, str) else (gw.resolve('[ADMIN_EMAIL]') if email else email)
+
+    auth_required = str(auth).strip().lower() not in {
+        "none", "false", "disabled", "optional"
+    }
 
     oapp = app
     from fastapi import FastAPI as _FastAPI

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -79,7 +79,7 @@ def setup_app(*,
     shared="shared",
     css="global",           # Default CSS (without .css extension)
     js="global",            # Default JS  (without .js extension)
-    auth_required=False,    # Default: Don't enforce --optional security
+    auth="disabled",       # Accept "optional"/"disabled" words to disable
     engine="bottle",
 ):
     """
@@ -87,6 +87,10 @@ def setup_app(*,
     Only one project can be setup per call. CSS/JS params are used as the only static includes.
     """
     global _ver, _homes, _enabled
+
+    auth_required = str(auth).strip().lower() not in {
+        "none", "false", "disabled", "optional"
+    }
 
     if engine != "bottle":
         raise NotImplementedError("Only Bottle is supported at the moment.")

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -10,8 +10,8 @@ web app setup-app:
     --project web.cookies --home cookie-jar
     --project vbox --home uploads
     --project ocpp.data --home charger-summary
-    --project ocpp.csms --auth-required --home charger-status
-    --project ocpp.evcs --auth-required --home cp-simulator
+    --project ocpp.csms --auth required --home charger-status
+    --project ocpp.evcs --auth required --home cp-simulator
     --project games.conway --home game-of-life --path conway
     --project games.mtg --home search-games
     --project web.auth

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -10,12 +10,12 @@ web app setup-app:
     --project web.nav --home style-switcher
     --project web.cookies --home cookie-jar
     --project vbox --home uploads
-    --project ocpp.csms --auth-required --home charger-status
-    --project ocpp.evcs --auth-required --home cp-simulator
-    --project ocpp.data --auth-required --home charger-summary
+    --project ocpp.csms --auth required --home charger-status
+    --project ocpp.evcs --auth required --home cp-simulator
+    --project ocpp.data --auth required --home charger-summary
     --project games.conway --home game-of-life --path conway
     --project games.mtg --home search-games
-    --project cdv --home data-editor --auth-required
+    --project cdv --home data-editor --auth required
     --project web.auth
 
 web:


### PR DESCRIPTION
## Summary
- tweak `web.app.setup_app` and `ocpp.csms.setup_app` to use an `--auth` flag that accepts words like `optional` or `disabled`
- update website recipes to use `--auth required`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: test_until_abort_raises)*

------
https://chatgpt.com/codex/tasks/task_e_686d8a8644e48326aa41b90b8bcb75c6