### PR TITLE
Rename commands to cooking metaphors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ Dispatcher helpers expose special functions as web routes:
 - ``view_*`` → ``/project/view`` (HTML output, optionally method specific ``view_get_*``/``view_post_*``).
 - ``api_*`` → ``/api/project/view`` (JSON output).
 - ``render_*`` → ``/render/project/view/hash`` (HTML/JSON fragments).
-Call ``gw.web.app.setup()`` to register views and ``gw.web.server.start_app()`` to launch the server.
+Call ``gw.web.app.make()`` to register views and ``gw.web.server.serve_app()`` to launch the server.
 Existing utilities (``gw.awg``, ``gw.ocpp``, ``gw.vbox`` etc.) are loaded lazily and should be reused via
 ``gw.<project>.<sub>.<function>``.
 

--- a/README.rst
+++ b/README.rst
@@ -247,8 +247,8 @@ Overview
 --------
 
 - **Views** are simply Python functions in a project (e.g. `projects/web/site.py`) named according to a pattern (by default, `view_{name}`).
-- The `web.app.setup` function registers views from one or more projects and sets up all routing and static file handling.
-- The `web.server.start-app` function launches your site on a local server using Bottle (or FastAPI, for ASGI).
+- The `web.app.make` function registers views from one or more projects and sets up all routing and static file handling.
+- The `web.server.serve-app` function launches your site on a local server using Bottle (or FastAPI, for ASGI).
 - All configuration can be scripted using GWAY recipes (`.gwr` files) for full automation.
 
 Minimal Example
@@ -287,9 +287,9 @@ Then in your own recipe:
 .. code-block:: text
 
     # recipes/my-website.gwr
-    web app setup --project mysite --home hello
-    web app setup --project web.navbar
-    web server start-app --host 127.0.0.1 --port 8888
+    web app make --project mysite --home hello
+    web app make --project web.navbar
+    web server serve-app --host 127.0.0.1 --port 8888
     until --forever
 
 Navigate to http://127.0.0.1:8888/mysite/hello or /mysite/about to see your views, including a handy navbar. Press Ctrl+D or close the terminal to end the process.
@@ -305,20 +305,20 @@ You can chain as many projects as you want; each can define its own set of views
 .. code-block:: text
 
     # recipes/my-website.gwr
-    web app setup --home readme
+    web app make --home readme
         --project web.cookie 
         --project web.navbar --home style-changer
         --project vbox --home uploads
         --project conway --home game-of-life --path games/conway
 
-    web server start-app --host 127.0.0.1 --port 8888
+    web server serve-app --host 127.0.0.1 --port 8888
     until --version --build --pypi --notify
 
 
 The above example combines basic features such as cookies and navbar with custom projects, a virtual upload/download box system and Conway's Game of Life, into a single application.
 
 
-The above recipe also shows implicit repeated commands. For example, instead of writing "web app setup" multiple times, each line below that doesn't start with a command repeats the last command with new parameters.
+The above recipe also shows implicit repeated commands. For example, instead of writing "web app make" multiple times, each line below that doesn't start with a command repeats the last command with new parameters.
 
 The **until** function, as used here, will keep the recipe going until the package updates in PyPI (checked hourly) or a manual update ocurrs.  Use ``--notify`` to send a desktop/email notification when the runner would stop, ``--notify-only`` to keep running after notifying, and ``--abort`` to exit the process when a watcher triggers.  By default ``until`` simply returns when its condition is met. This is appropriate for self-restarting services such as those managed by systemd or kubernetes.
 
@@ -327,8 +327,8 @@ The **until** function, as used here, will keep the recipe going until the packa
 How It Works
 ------------
 
-- `web.app.setup` wires up each project, registering all views (functions starting with the given prefix, default `view_`).
-- You call setup multiple times to configure each project. The project/function name can be skipped on repeat lines.
+- `web.app.make` wires up each project, registering all views (functions starting with the given prefix, default `view_`).
+- You call make multiple times to configure each project. The project/function name can be skipped on repeat lines.
 - Each project can declare a "home" view, which becomes the landing page for its route.
 - Static files are served from your `data/static/` directory and are accessible at `/static/filename`.
 - The routing system matches `/project/viewname` to a function named `view_viewname` in the relevant project.

--- a/gway/builtins.py
+++ b/gway/builtins.py
@@ -488,7 +488,7 @@ def try_cast(value, default=None, **types) -> tuple:
             continue
     return default, value
 
-def run_recipe(*scripts: str, **context):
+def do_recipe(*scripts: str, **context):
     """
     Run commands parsed from one or more .gwr files, falling back to the 'recipes/' resource bundle.
     Recipes are just simple GWAY scripts: one command per line, with optional comments.
@@ -497,8 +497,8 @@ def run_recipe(*scripts: str, **context):
     from gway import gw
 
     if not scripts:
-        raise ValueError("At least one script must be provided to run_recipe()")
-    gw.debug(f"run_recipe called with scripts: {scripts!r}")
+        raise ValueError("At least one script must be provided to do_recipe()")
+    gw.debug(f"do_recipe called with scripts: {scripts!r}")
 
     results = []
     for script in scripts:
@@ -528,14 +528,14 @@ def run_recipe(*scripts: str, **context):
                 raise FileNotFoundError(msg) from second_exc
 
         # Load and run the recipe
-        command_sources, comments = load_recipe(script_path)
-        if comments:
-            gw.debug("Recipe comments:\n" + "\n".join(comments))
+        command_sources, notes = load_recipe(script_path)
+        if notes:
+            gw.debug("Recipe notes:\n" + "\n".join(notes))
         result = process(command_sources, **context)
         results.append(result)
     return results[-1] if len(results) == 1 else results
 
-def run(*script: str, **context):
+def do(*script: str, **context):
     """Run recipes. If recipes are not found, treat the input as the literal recipe to be run."""
     from gway import gw
     import uuid
@@ -544,13 +544,13 @@ def run(*script: str, **context):
 
     # Try to run all scripts as recipes first
     try:
-        return gw.run_recipe(*script, **context)
+        return gw.do_recipe(*script, **context)
     except FileNotFoundError:
         # Not found: treat script as raw lines, write to temp recipe and run that
         gw.debug(f"run(): Could not find one or more recipes, treating script as raw lines")
         work_dir = gw.resource("work", check=True)
         unique_id = str(uuid.uuid4())
-        recipe_name = f"run_{unique_id}.gwr"
+        recipe_name = f"do_{unique_id}.gwr"
         recipe_path = os.path.join(work_dir, recipe_name)
 
         now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -572,7 +572,7 @@ def run(*script: str, **context):
         gw.debug(f"Wrote ad-hoc script to {recipe_path}")
 
         # Now run the new recipe
-        return gw.run_recipe(recipe_path, **context)
+        return gw.do_recipe(recipe_path, **context)
 
 
 

--- a/projects/games/mtg.py
+++ b/projects/games/mtg.py
@@ -134,7 +134,7 @@ def view_search_games(
     # --- Cookie-based hand setup ---
     use_hand = (
         hasattr(gw.web, "app") and hasattr(gw.web, "cookies")
-        and getattr(gw.web.app, "is_setup", lambda x: False)("web.cookies")
+        and getattr(gw.web.app, "is_make", lambda x: False)("web.cookies")
         and gw.web.cookies.accepted()
     )
 

--- a/projects/games/qpig.py
+++ b/projects/games/qpig.py
@@ -61,7 +61,7 @@ def _use_cookies():
     use = (
         hasattr(gw.web, "app")
         and hasattr(gw.web, "cookies")
-        and getattr(gw.web.app, "is_setup", lambda x: False)("web.cookies")
+        and getattr(gw.web.app, "is_make", lambda x: False)("web.cookies")
         and gw.web.cookies.accepted()
     )
     gw.debug(f"_use_cookies -> {use}")

--- a/projects/games/snl.py
+++ b/projects/games/snl.py
@@ -35,7 +35,7 @@ def _use_cookies():
     return (
         hasattr(gw.web, "app")
         and hasattr(gw.web, "cookies")
-        and getattr(gw.web.app, "is_setup", lambda x: False)("web.cookies")
+        and getattr(gw.web.app, "is_make", lambda x: False)("web.cookies")
         and gw.web.cookies.accepted()
     )
 

--- a/projects/monitor/README.rst
+++ b/projects/monitor/README.rst
@@ -2,11 +2,11 @@ Network Manager Monitor
 -----------------------
 
 The ``monitor.nmcli`` project collects network information using ``nmcli``.
-It does not alter any connections automatically. Start the watcher from a recipe with:
+It does not alter any connections automatically. Serve the watcher from a recipe with:
 
 .. code-block:: text
 
-    monitor start-watch nmcli
+    monitor serve-watch nmcli
 
 Use the ``run`` page in the web interface to execute arbitrary ``nmcli`` commands when needed.
 

--- a/projects/monitor/monitor.py
+++ b/projects/monitor/monitor.py
@@ -39,7 +39,7 @@ def trigger_watch(project):
         return True
     return False
 
-def start_watch(
+def serve_watch(
     project, *,
     monitor=None,
     interval=120,

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -32,7 +32,7 @@ def authorize_balance(**record):
     except Exception:
         return False
     
-def setup_app(*,
+def make_app(*,
     app=None,
     allowlist=None,
     denylist=None,

--- a/projects/ocpp/sink.py
+++ b/projects/ocpp/sink.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from gway import gw
 
 
-def setup_sink_app(*, app=None):
+def make_sink_app(*, app=None):
     """
     Basic OCPP passive sink for messages, acting as a dummy CSMS server.
     This won't pass compliance or provide authentication. It just accepts and logs all.

--- a/projects/odoo.py
+++ b/projects/odoo.py
@@ -361,7 +361,7 @@ def get_user_info(*, username: str) -> dict:
 
 chatbot_log: list[dict] = []
 
-def setup_chatbot_app(*, 
+def make_chatbot_app(*,
             path="/chatbot", username="[ODOO_USERNAME]", alias="Operator", apps=None
         ):
     """

--- a/projects/recipe.py
+++ b/projects/recipe.py
@@ -7,11 +7,11 @@ from pathlib import Path
 from gway import gw
 
 
-def run(*script: str, **context):
-    return gw.run_recipe(*script, **context)
+def do(*script: str, **context):
+    return gw.do_recipe(*script, **context)
 
 
-def register_gwr():
+def register_recipes():
     """
     Register the .gwr file extension so that double-click launches:
         gway -r "<full path to file>"

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -66,7 +66,7 @@ def current_endpoint():
     """
     return gw.context.get('current_endpoint')
 
-def setup_app(*,
+def make_app(*,
     app=None,
     project="web.site",
     path=None,
@@ -83,8 +83,8 @@ def setup_app(*,
     engine="bottle",
 ):
     """
-    Setup Bottle web application with symmetrical static/shared public folders.
-    Only one project can be setup per call. CSS/JS params are used as the only static includes.
+    Make Bottle web application with symmetrical static/shared public folders.
+    Only one project can be made per call. CSS/JS params are used as the only static includes.
     """
     global _ver, _homes, _enabled
 
@@ -186,7 +186,7 @@ def setup_app(*,
         add_route(app, f"/{static}/<filepath:path>", "GET", send_static)
         
     def _maybe_auth(message: str):
-        if is_setup('web.auth') and not gw.web.auth.is_authorized(strict=auth_required):
+        if is_make('web.auth') and not gw.web.auth.is_authorized(strict=auth_required):
             return gw.web.error.unauthorized(message)
         return None
 
@@ -383,7 +383,7 @@ def render_template(*, title="GWAY", content="", css_files=None, js_files=None):
 
     css_files = gw.cast.to_list(css_files)
     theme_css = None
-    if is_setup('web.nav'):
+    if is_make('web.nav'):
         try:
             theme_css = gw.web.nav.active_style()
         except Exception:
@@ -409,7 +409,7 @@ def render_template(*, title="GWAY", content="", css_files=None, js_files=None):
         Hosting by <a href="https://www.gelectriic.com/">Gelectriic Solutions</a>, 
         <a href="https://pypi.org">PyPI</a> and <a href="https://github.com/arthexis/gway">Github</a>.</p>
     '''
-    nav = gw.web.nav.render(homes=_homes, links=_links) if is_setup('web.nav') else ""
+    nav = gw.web.nav.render(homes=_homes, links=_links) if is_make('web.nav') else ""
 
     html = template("""<!DOCTYPE html>
         <html lang="en">
@@ -466,7 +466,7 @@ def add_route(app, rule: str, method, callback):
         _registered_routes.add(key)
         app.route(rule, method=m)(callback)
 
-def is_setup(project_name):
+def is_make(project_name):
     global _enabled
     return project_name in _enabled
 

--- a/projects/web/auth.py
+++ b/projects/web/auth.py
@@ -86,8 +86,8 @@ def _basic_auth(allow, engine):
                 # Try to detect FastAPI context
                 if ctx.get("websocket", None):
                     engine_actual = "fastapi_ws"
-                elif hasattr(gw.web, "app") and hasattr(gw.web.app, "is_setup"):
-                    if gw.web.app.is_setup("fastapi"):
+                elif hasattr(gw.web, "app") and hasattr(gw.web.app, "is_make"):
+                    if gw.web.app.is_make("fastapi"):
                         engine_actual = "fastapi"
                 else:
                     engine_actual = "bottle"
@@ -178,7 +178,7 @@ def _temp_password(length=16):
     chars = string.ascii_letters + string.digits
     return ''.join(random.choices(chars, k=length))
 
-def config_basic(
+def prep_basic(
     *, 
     allow='work/basic_auth.cdv', 
     engine="auto", 
@@ -230,7 +230,7 @@ def config_basic(
 def clear():
     _challenges.clear()
 
-def is_setup():
+def is_make():
     return bool(_challenges)
 
 def create_user(username, password, *, allow='work/basic_auth.cdv', force=False, **fields):

--- a/projects/web/nav.py
+++ b/projects/web/nav.py
@@ -9,7 +9,7 @@ def render(*, homes=None, links=None):
     """
     Renders the sidebar navigation including search, home links, visited links, and a QR compass.
     """
-    cookies_ok = gw.web.app.is_setup('web.cookies') and gw.web.cookies.accepted()
+    cookies_ok = gw.web.app.is_make('web.cookies') and gw.web.cookies.accepted()
     links_map = links or {}
     gw.verbose(f"Render nav with {homes=} {links_map=} {cookies_ok=}")
 
@@ -163,7 +163,7 @@ def active_style():
     This should be called by render_template for every page load.
     """
     styles = list_styles()
-    style_cookie = gw.web.cookies.get("css") if gw.web.app.is_setup('web.cookies') else None
+    style_cookie = gw.web.cookies.get("css") if gw.web.app.is_make('web.cookies') else None
     style_query = request.query.get("css")
     style_path = None
 
@@ -241,7 +241,7 @@ def view_style_switcher(*, css=None, project=None):
     all_styles = [fname for _, fname in styles]
     style_sources = {fname: src for src, fname in styles}
 
-    cookies_enabled = gw.web.app.is_setup('web.cookies')
+    cookies_enabled = gw.web.app.is_make('web.cookies')
     cookies_accepted = gw.web.cookies.accepted() if cookies_enabled else False
     css_cookie = gw.web.cookies.get("css")
 

--- a/projects/web/proxy.py
+++ b/projects/web/proxy.py
@@ -6,7 +6,7 @@ import requests
 
 
 
-def setup_fallback_app(*, 
+def make_fallback_app(*,
         endpoint: str, app=None, websockets: bool = False, path: str = "/",
         mode: str = "extend", callback=None,
     ):

--- a/projects/web/server.py
+++ b/projects/web/server.py
@@ -7,7 +7,7 @@ from gway import gw, __
 # Registry for active apps and their hosts/ports
 _active_servers = {}  # key: label or index, value: dict with host/port/ws_port
 
-def start_app(*,
+def serve_app(*,
     host            = __('[SITE_HOST]', '[BASE_HOST]', '0.0.0.0'),
     port : int      = __('[SITE_PORT]', '[BASE_PORT]', '8888'),
     ws_port : int   = __('[WS_PORT]', '[WEBSOCKET_PORT]', '9999'),
@@ -76,7 +76,7 @@ def start_app(*,
                 gw.info(f"  App {i+1}: type={app_type}, port={port_i}")
 
                 t = Thread(
-                    target=gw.web.server.start_app,
+                    target=gw.web.server.serve_app,
                     kwargs=dict(
                         host=host,
                         port=port_i,
@@ -110,7 +110,7 @@ def start_app(*,
 
         # Proxy setup (unchanged)
         if proxy:
-            from .proxy import setup_app as setup_proxy
+            from .proxy import make_fallback_app as setup_proxy
             app = setup_proxy(endpoint=proxy, app=app)
 
         # Factory support (unchanged)

--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -5,7 +5,7 @@ import html
 import shlex
 from docutils.core import publish_parts
 from gway import gw, __
-from gway.console import process, chunk
+from gway.console import process, chop
 import markdown as mdlib
 
 def view_reader(
@@ -136,10 +136,10 @@ def view_help(topic="", *args, **kwargs):
             if not cmd_str:
                 return "<i>No command provided.</i>"
             import shlex, html
-            from gway.console import chunk, process
+            from gway.console import chop, process
             try:
                 tokens = shlex.split(cmd_str)
-                commands = chunk(tokens)
+                commands = chop(tokens)
                 results, _ = process(commands)
                 html_parts = [gw.cast.to_html(r) for r in results if r is not None]
                 return "<div class='cli-result'>" + "<hr>".join(html_parts) + "</div>"

--- a/recipes/etron/cloud.gwr
+++ b/recipes/etron/cloud.gwr
@@ -1,7 +1,7 @@
 # file: recipes/etron/cloud.gwr
 # OCPP 1.6 CSMS Recipe for Central Cloud Server
 
-web app setup-app:
+web app make-app:
     --project ocpp.data --home charger-summary
     --project ocpp.csms --home charger-status
     --project ocpp.csms --home cp-simulator
@@ -11,16 +11,16 @@ web app setup-app:
     --project ocpp.data --home charger-summary
    
 # Toggle this version to apply the allow list  
-ocpp csms setup-app:
+ocpp csms make-app:
     --allow data/etron/rfids.cdv --location etron_cloud
 
 # Without --allow, all transactions will be allowed by default
-# ocpp csms setup-app:
+# ocpp csms make-app:
 #     --location porsche_centre --deny data/etron/rfids.cdv
 
 web:
  - static collect
- - auth config-basic
- - server start-app --host 0.0.0.0 --port 8000 --ws-port 9000
+ - auth prep-basic
+ - server serve-app --host 0.0.0.0 --port 8000 --ws-port 9000
 
 until --file VERSION

--- a/recipes/etron/local.gwr
+++ b/recipes/etron/local.gwr
@@ -1,7 +1,7 @@
 # file: recipes/etron/local.gwr
 # OCPP 1.6 CSMS runnable GWAY Recipe with basic RFID auth
 
-web app setup-app:
+web app make-app:
     --project ocpp.data --home charger-summary
     --project web.nav
     --project vbox
@@ -11,15 +11,15 @@ web app setup-app:
     --project ocpp.data --home charger-summary
 
 # Toggle this version to apply the allowlist  
-# ocpp csms setup-app --allow data/etron/rfids.cdv --location porsche_centre
-ocpp csms setup-app:
+# ocpp csms make-app --allow data/etron/rfids.cdv --location porsche_centre
+ocpp csms make-app:
     --location porsche_centre
 
 web:
  - static collect
- - server start-app --host 0.0.0.0 --port 8000 --ws-port 9000
+ - server serve-app --host 0.0.0.0 --port 8000 --ws-port 9000
 
 # This only makes sense for NetworkManager in Linux 
-monitor start-watch nmcli 
+monitor serve-watch nmcli
 
 until --file VERSION

--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -1,7 +1,7 @@
 # file: recipes/gamebox.gwr
 # Games-only demo with cookies, navbar and style switcher
 
-web app setup-app:
+web app make-app:
     --home reader
     --project games.conway --home game-of-life --path conway
     --project games.mtg --home search-games
@@ -12,7 +12,7 @@ web app setup-app:
 
 web:
  - static collect
-- server start-app --port 8888
+ - server serve-app --port 8888
 
 until --forever
 

--- a/recipes/skeleton.gwr
+++ b/recipes/skeleton.gwr
@@ -1,10 +1,10 @@
 # file: recipes/skeleton.gwr
 
-web app setup-app:
+web app make-app:
     --project web.site --home reader
     --project web.nav
     --project cdv --home data-editor
 web:
  - static collect
-- server start-app
+ - server serve-app
 until --forever

--- a/recipes/test/etron/cloud.gwr
+++ b/recipes/test/etron/cloud.gwr
@@ -1,7 +1,7 @@
 # file: recipes/etron/cloud.gwr
 # OCPP 1.6 CSMS Recipe for Central Cloud Server
 
-web app setup-app:
+web app make-app:
     --project ocpp.data --home charger-summary
     --project ocpp.csms --home charger-status
     --project ocpp.csms --home cp-simulator
@@ -11,16 +11,16 @@ web app setup-app:
     --project ocpp.data --home charger-summary
    
 # Toggle this version to apply the allow list  
-ocpp csms setup-app:
+ocpp csms make-app:
     --allow data/etron/rfids.cdv --location etron_cloud
 
 # Without --allow, all transactions will be allowed by default
-# ocpp csms setup-app:
+# ocpp csms make-app:
 #     --location porsche_centre --deny data/etron/rfids.cdv
 
 web:
  - static collect
- - auth config-basic --temp-link
- - server start-app --host 0.0.0.0 --port 18000 --ws-port 19000
+ - auth prep-basic --temp-link
+ - server serve-app --host 0.0.0.0 --port 18000 --ws-port 19000
 
 until --file VERSION

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -3,7 +3,7 @@
 
 # Lines without a starting command repeat the previous with new params
 
-web app setup-app:
+web app make-app:
     --home reader
     --project awg --home cable-finder
     --project web.nav --home style-switcher
@@ -18,13 +18,13 @@ web app setup-app:
 
 web:
  - static collect
- - auth config-basic --optional --temp-link
+ - auth prep-basic --optional --temp-link
 
-ocpp csms setup-app:
+ocpp csms make-app:
     --location simulator
 
 web:
- - server start-app --port 18888 --ws-port 19999
+ - server serve-app --port 18888 --ws-port 19999
 
 # Loop until VERSION or BUILD or PyPI changes
 until --version --build --pypi

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -3,7 +3,7 @@
 
 # Lines without a starting command repeat the previous with new params
 
-web app setup-app:
+web app make-app:
     --home reader
     --project awg --home cable-finder
     --project release --home changelog
@@ -20,13 +20,13 @@ web app setup-app:
 
 web:
  - static collect
- - auth config-basic --optional --temp-link
+ - auth prep-basic --optional --temp-link
 
-ocpp csms setup-app:
+ocpp csms make-app:
     --location simulator
 
 web:
- - server start-app --port 8888 --ws-port 9999
+ - server serve-app --port 8888 --ws-port 9999
 
 # Loop until VERSION or BUILD or PyPI changes
 until --version --build --pypi

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -33,7 +33,7 @@ class GatewayBuiltinsTests(unittest.TestCase):
         self.assertIn('help', builtin_ls)
         self.assertIn('test', builtin_ls)
         self.assertIn('abort', builtin_ls)
-        self.assertIn('run_recipe', builtin_ls)
+        self.assertIn('do_recipe', builtin_ls)
 
     def test_list_projects(self):
         project_ls = gw.projects()

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -8,24 +8,24 @@ from pathlib import Path
 import gway.console as console
 
 
-class TestChunkFunction(unittest.TestCase):
-    def test_chunk_splits_on_dash_and_semicolon(self):
+class TestChopFunction(unittest.TestCase):
+    def test_chop_splits_on_dash_and_semicolon(self):
         self.assertEqual(
-            console.chunk(['a', 'b', '-', 'c', 'd']),
+            console.chop(['a', 'b', '-', 'c', 'd']),
             [['a', 'b'], ['c', 'd']]
         )
         self.assertEqual(
-            console.chunk(['x', 'y', ';', 'z']),
+            console.chop(['x', 'y', ';', 'z']),
             [['x', 'y'], ['z']]
         )
 
-    def test_chunk_handles_empty(self):
-        self.assertEqual(console.chunk([]), [])
+    def test_chop_handles_empty(self):
+        self.assertEqual(console.chop([]), [])
 
-    def test_chunk_preserves_tokens(self):
+    def test_chop_preserves_tokens(self):
         tokens = ['cmd', 'arg;with;semicolons', ';', 'next']
         self.assertEqual(
-            console.chunk(tokens),
+            console.chop(tokens),
             [['cmd', 'arg;with;semicolons'], ['next']]
         )
 
@@ -44,7 +44,7 @@ class TestNormalizeToken(unittest.TestCase):
 
 class TestLoadRecipeAbsolutePath(unittest.TestCase):
     def setUp(self):
-        # Create a temporary recipe file with comments and indented options
+        # Create a temporary recipe file with notes and indented options
         self.temp_file = tempfile.NamedTemporaryFile('w', delete=False)
         self.temp_file.write(
             """# comment1
@@ -60,15 +60,15 @@ cmd2 --flag
     def tearDown(self):
         os.remove(self.temp_file.name)
 
-    def test_load_recipe_parses_commands_and_comments(self):
-        commands, comments = console.load_recipe(self.temp_file.name)
-        expected_comments = ['# comment1', '# comment2']
+    def test_load_recipe_parses_commands_and_notes(self):
+        commands, notes = console.load_recipe(self.temp_file.name)
+        expected_notes = ['# comment1', '# comment2']
         expected_commands = [
             ['cmd1', 'arg1', '--opt1', 'val1'],
             ['cmd1', 'arg1', '--opt2', 'val2'],
             ['cmd2', '--flag']
         ]
-        self.assertEqual(comments, expected_comments)
+        self.assertEqual(notes, expected_notes)
         self.assertEqual(commands, expected_commands)
 
     def test_load_recipe_nonexistent_raises_file_not_found(self):
@@ -103,25 +103,25 @@ app start --port 8000
 
     def test_load_recipe_finds_gwr_extension(self):
         # Provide base name without extension
-        commands, comments = console.load_recipe('sample')
+        commands, notes = console.load_recipe('sample')
         expected_commands = [
             ['app', 'start', '--port', '8000'],
             ['app', 'start', '--debug']
         ]
-        expected_comments = ['# sample recipe']
+        expected_notes = ['# sample recipe']
         self.assertEqual(commands, expected_commands)
-        self.assertEqual(comments, expected_comments)
+        self.assertEqual(notes, expected_notes)
 
 
 class TestLoadRecipeColonSyntax(unittest.TestCase):
     def test_load_recipe_with_colon_repetition(self):
         content = (
-            """web app setup-app:
+            """web app make-app:
     --project one --home first
     --project two
 web:
  - static collect
- - server start-app --host 1 --port 2
+ - server serve-app --host 1 --port 2
 """
         )
         with tempfile.NamedTemporaryFile('w', delete=False) as f:
@@ -133,21 +133,21 @@ web:
             os.remove(temp_name)
 
         expected = [
-            ['web', 'app', 'setup-app', '--project', 'one', '--home', 'first'],
-            ['web', 'app', 'setup-app', '--project', 'two'],
+            ['web', 'app', 'make-app', '--project', 'one', '--home', 'first'],
+            ['web', 'app', 'make-app', '--project', 'two'],
             ['web', 'static', 'collect'],
-            ['web', 'server', 'start-app', '--host', '1', '--port', '2'],
+            ['web', 'server', 'serve-app', '--host', '1', '--port', '2'],
         ]
         self.assertEqual(commands, expected)
 
     def test_load_recipe_colon_without_indentation(self):
         content = (
-            """web app setup-app:
+            """web app make-app:
 --project one
 --project two
 web:
 - static collect
-- server start-app --host 1 --port 2
+- server serve-app --host 1 --port 2
 """
         )
         with tempfile.NamedTemporaryFile('w', delete=False) as f:
@@ -159,10 +159,10 @@ web:
             os.remove(temp_name)
 
         expected = [
-            ['web', 'app', 'setup-app', '--project', 'one'],
-            ['web', 'app', 'setup-app', '--project', 'two'],
+            ['web', 'app', 'make-app', '--project', 'one'],
+            ['web', 'app', 'make-app', '--project', 'two'],
             ['web', 'static', 'collect'],
-            ['web', 'server', 'start-app', '--host', '1', '--port', '2'],
+            ['web', 'server', 'serve-app', '--host', '1', '--port', '2'],
         ]
         self.assertEqual(commands, expected)
 

--- a/tests/test_nav_active_style.py
+++ b/tests/test_nav_active_style.py
@@ -29,7 +29,7 @@ class FakeCookies:
 class FakeApp:
     def __init__(self, enabled=True):
         self.enabled = enabled
-    def is_setup(self, name):
+    def is_make(self, name):
         return self.enabled
 
 

--- a/tests/test_nav_compass.py
+++ b/tests/test_nav_compass.py
@@ -22,7 +22,7 @@ class NavCompassTests(unittest.TestCase):
     def setUp(self):
         self.orig_request = nav.request
         self.orig_app = nav.gw.web.app
-        nav.gw.web.app = type('A', (), {'is_setup': lambda self2, n: False})()
+        nav.gw.web.app = type('A', (), {'is_make': lambda self2, n: False})()
         self.orig_cookies = nav.gw.web.cookies
         nav.gw.web.cookies = type('C', (), {'accepted': lambda self2: False})()
         self.orig_qr = nav.gw.qr.generate_url

--- a/tests/test_nav_links.py
+++ b/tests/test_nav_links.py
@@ -20,7 +20,7 @@ class NavLinksTests(unittest.TestCase):
         self.orig_request = nav.request
         nav.request = FakeRequest('/games/conway/game-of-life')
         self.orig_app = nav.gw.web.app
-        nav.gw.web.app = type('A', (), {'is_setup': lambda self2, n: False})()
+        nav.gw.web.app = type('A', (), {'is_make': lambda self2, n: False})()
         self.orig_cookies = nav.gw.web.cookies
         nav.gw.web.cookies = type('C', (), {'accepted': lambda self2: False})()
 

--- a/tests/test_qpig_farm.py
+++ b/tests/test_qpig_farm.py
@@ -20,7 +20,7 @@ class FakeCookies:
         return True
 
 class FakeApp:
-    def is_setup(self, name):
+    def is_make(self, name):
         return True
 
 class QPigFarmButtonTests(unittest.TestCase):

--- a/tests/test_render_template_css.py
+++ b/tests/test_render_template_css.py
@@ -14,7 +14,7 @@ class RenderTemplateThemeCssTests(unittest.TestCase):
         dummy_theme = "/static/theme.css"
         with patch.object(webapp.gw.web.nav, 'active_style', return_value=dummy_theme), \
              patch.object(webapp.gw.web.nav, 'render', return_value=''), \
-             patch.object(webapp, 'is_setup', return_value=True):
+             patch.object(webapp, 'is_make', return_value=True):
             html = webapp.render_template(css_files=['/static/base.css'])
 
         soup = BeautifulSoup(html, 'html.parser')


### PR DESCRIPTION
## Summary
- rename run functions to cooking names like `do_recipe`
- rename setup/start/config verbs to make/serve/prep
- rename `chunk` parser helper to `chop`
- log recipe notes in helpers
- update docs and tests to reflect new wording
- refine variable naming in `process`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686d71ff76288326bf2e83a85eaeea4c