### PR TITLE
Fix release README failure handling

### DIFF
--- a/projects/release.py
+++ b/projects/release.py
@@ -213,7 +213,16 @@ def build(
                 text=True
             )
             if check_result.returncode != 0:
-                gw.error(f"PyPI README rendering check failed, aborting upload:\n{check_result.stdout}")
+                gw.error(
+                    "PyPI README rendering check failed, aborting upload:\n"
+                    f"{check_result.stdout}"
+                )
+                gw.info("Stashing release changes due to build failure...")
+                subprocess.run(
+                    ["git", "stash", "--include-untracked", "-m", "gway-release-abort"],
+                    check=False,
+                )
+                gw.error("Build aborted. README syntax errors detected.")
                 return
 
             gw.info("Twine check passed. Uploading to PyPI...")


### PR DESCRIPTION
## Summary
- stash repository changes if README fails validation during release build
- clarify the build abort message

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686d9647e0948326b349654a4f6b0b36