### PR TITLE
Adjust nav link fonts across styles

### DIFF
--- a/data/static/base.css
+++ b/data/static/base.css
@@ -150,6 +150,18 @@ aside ul li a:hover, aside ul li a.active {
     text-decoration: underline;
 }
 
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
+}
+
 /* 8. Buttons & form controls */
 button, input[type="submit"], input[type="button"] {
     background: var(--accent-alt, #007bff);

--- a/data/static/styles/classic-95.css
+++ b/data/static/styles/classic-95.css
@@ -85,6 +85,19 @@ aside {
     background: #d4d0c8 !important;
     border-right: 2px solid #808080 !important;
 }
+aside ul li a {
+    font-size: 0.93em;
+}
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
+}
 
 main {
     background: #fff;

--- a/data/static/styles/dark-material.css
+++ b/data/static/styles/dark-material.css
@@ -55,17 +55,30 @@ aside ul li {
 }
 
 aside ul li a {
-  color: var(--fg);
-  text-decoration: none;
-  display: block;
-  padding: 0.25rem 0.5rem;
-  border-radius: var(--border-radius);
+    color: var(--fg);
+    text-decoration: none;
+    display: block;
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--border-radius);
+    font-size: 0.93em;
 }
 
 aside ul li a:hover,
 aside ul li a.active {
-  background-color: var(--accent);
-  color: var(--bg);
+    background-color: var(--accent);
+    color: var(--bg);
+}
+
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
 }
 
 /* QR image cap */

--- a/data/static/styles/fast-food.css
+++ b/data/static/styles/fast-food.css
@@ -41,7 +41,7 @@ aside ul li a {
     color: var(--fast-red);
     font-family: 'Bebas Neue', 'Montserrat', 'Arial Black', Arial, sans-serif;
     border-radius: 7px;
-    font-size: 1.12em;
+    font-size: 1.05em;
     padding-left: 1.05em;
     font-weight: bold;
     border-left: 5px solid var(--fast-yellow);
@@ -54,6 +54,18 @@ aside ul li a:hover {
     color: #fff;
     border-left: 5.5px solid var(--fast-red);
     text-shadow: 0 1px 0 #ffd100, 0 0 14px #ec1c2444;
+}
+
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
 }
 
 main {

--- a/data/static/styles/glitch-punk.css
+++ b/data/static/styles/glitch-punk.css
@@ -49,20 +49,33 @@ aside ul {
   padding: 0;
 }
 aside ul li a {
-  color: var(--accent-alt);
-  font-weight: bold;
-  padding: 0.6em 0;
-  border-radius: 8px;
-  text-shadow: 0 0 5px #ff0080, 0 0 2px #00fff3;
-  background: transparent;
+    color: var(--accent-alt);
+    font-weight: bold;
+    padding: 0.6em 0;
+    font-size: 0.93em;
+    border-radius: 8px;
+    text-shadow: 0 0 5px #ff0080, 0 0 2px #00fff3;
+    background: transparent;
   transition: background 0.15s, color 0.15s;
   animation: link-glitch 3.5s infinite alternate-reverse;
 }
 aside ul li a.active,
 aside ul li a:hover {
-  color: var(--accent);
-  background: #21214a55;
-  animation-duration: 1.1s;
+    color: var(--accent);
+    background: #21214a55;
+    animation-duration: 1.1s;
+}
+
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
 }
 aside .compass,
 aside img.compass {

--- a/data/static/styles/hello-ween.css
+++ b/data/static/styles/hello-ween.css
@@ -35,6 +35,7 @@ aside ul li a {
     color: #ff6f36;
     font-family: 'EB Garamond', 'Georgia', serif;
     border-radius: 7px;
+    font-size: 0.93em;
     padding-left: 1.1em;
     transition: background 0.15s, color 0.14s, text-shadow 0.16s;
     text-shadow: 0 0 4px #efbfff88;
@@ -45,6 +46,18 @@ aside ul li a:hover {
     color: #7cfe81;
     font-weight: bold;
     text-shadow: 0 0 6px #7cfe8188, 0 0 6px #180c1e;
+}
+
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
 }
 
 main {

--- a/data/static/styles/mystic-eye.css
+++ b/data/static/styles/mystic-eye.css
@@ -48,7 +48,7 @@ aside ul li a {
     font-family: inherit;
     border-radius: 10px;
     padding-left: 1.2em;
-    font-size: 1.04em;
+    font-size: 0.97em;
     font-weight: 500;
     letter-spacing: 0.09em;
     transition: background 0.16s, color 0.13s;
@@ -62,6 +62,18 @@ aside ul li a:hover {
     border-left: 3.4px solid var(--sigil-blue);
     font-weight: bold;
     text-shadow: 0 0 12px #9466dbcc, 0 0 6px #39e6c2bb;
+}
+
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
 }
 
 main {

--- a/data/static/styles/palimpsesto.css
+++ b/data/static/styles/palimpsesto.css
@@ -55,6 +55,7 @@ aside ul li a {
     font-family: 'Special Elite', 'IM Fell DW Pica', serif;
     font-weight: 600;
     border-radius: 7px;
+    font-size: 0.93em;
     padding-left: 1.3em;
     transition: background 0.17s, color 0.12s;
     border-left: 3.3px double #ffe45e;
@@ -69,6 +70,18 @@ aside ul li a:hover {
     font-weight: bold;
     text-decoration: underline wavy #db2861;
     box-shadow: 0 0 8px #db286144;
+}
+
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
 }
 
 main {

--- a/data/static/styles/party-code.css
+++ b/data/static/styles/party-code.css
@@ -53,6 +53,7 @@ aside ul li a {
     margin-bottom: 0.3em;
     box-shadow: 0 1px 4px 0 #ffd4fd26;
     font-weight: 600;
+    font-size: 0.93em;
     letter-spacing: 0.04em;
     border-left: 4px solid #fff0;
     transition: background 0.18s, color 0.17s, border-left 0.18s;
@@ -62,6 +63,18 @@ aside ul li a.active {
     background: linear-gradient(90deg, #fdffd5 0%, #ffb8e8 100%);
     color: #a8115e;
     border-left: 4px solid var(--accent-alt);
+}
+
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
 }
 
 /* Main area - clean with a gentle shadow */

--- a/data/static/styles/radio-darker.css
+++ b/data/static/styles/radio-darker.css
@@ -47,7 +47,7 @@ aside ul li a {
     background: none;
     color: var(--fg);
     font-family: inherit;
-    font-size: 1em;
+    font-size: 0.93em;
     letter-spacing: 0.07em;
     font-weight: 500;
     border-left: 2.2px solid #0f2;
@@ -59,6 +59,18 @@ aside ul li a:hover {
     color: #fff;
     border-left: 2.5px solid var(--accent);
     text-shadow: 0 0 8px #3aff2b77;
+}
+
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
 }
 
 main {

--- a/data/static/styles/tea-time.css
+++ b/data/static/styles/tea-time.css
@@ -105,9 +105,21 @@ footer {
 aside ul li a {
     text-transform: uppercase;
     font-weight: bold;
-    font-size: 0.8em;
+    font-size: 0.73em;
     display: block;
     margin: 0.4em 0;
+}
+
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
 }
 input.main {
     width: 70%;

--- a/data/static/styles/xp-summer.css
+++ b/data/static/styles/xp-summer.css
@@ -34,6 +34,7 @@ aside ul li a {
     color: #1452b5;
     font-family: 'Trebuchet MS', 'Segoe UI', Arial, sans-serif;
     border-radius: 8px;
+    font-size: 0.93em;
     padding-left: 1em;
     transition: background 0.18s, color 0.18s;
 }
@@ -42,6 +43,18 @@ aside ul li a:hover {
     background: linear-gradient(90deg, #f2fcff 20%, #a7f6d3 80%);
     color: #15700b;
     font-weight: bold;
+}
+
+aside ul.sub-links {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0.2em 0 0.4em;
+    font-size: 0.85em;
+}
+
+aside ul.sub-links li a {
+    text-transform: none;
+    padding: 0.2em 0;
 }
 
 main {

--- a/tests/_test_failure.py
+++ b/tests/_test_failure.py
@@ -2,7 +2,9 @@
 
 import unittest
 import pytest
+from gway.builtins import is_test_flag
 
+@unittest.skipUnless(is_test_flag("failure"), "Failure tests disabled")
 class SimpleFailTest(unittest.TestCase):
     @pytest.mark.xfail(reason="This test always fails", strict=False)
     def test_always_fails(self):


### PR DESCRIPTION
## Summary
- show sub-links in the navbar at a smaller font size
- shrink home link fonts in all style themes
- skip the intentional failing test unless `GW_TEST_FLAGS` includes `failure`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686da73f28e883268883b4238725f322