### PR TITLE
Nest Websites section under Advanced Recipe

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -107,6 +107,18 @@ next non-indented command.
    # Watch for file changes
    until --file work/reload.txt
 
+Websites
+~~~~~~~~
+
+The ``web`` project assembles view functions into a small site. Register each
+project with ``gw.web.app.setup`` and then launch the server using
+``gw.web.server.start_app``. Routes of the form ``/project/view`` map to
+``view_*`` functions and static files under ``data/static`` are served from
+``/static``. ``web.site.view_reader`` renders ``.rst`` or ``.md`` files when
+you visit ``/site/reader/PATH``; it first checks the workspace root and
+then ``data/static`` automatically. See the `Web README
+</site/reader?tome=web>`_ for a more complete guide.
+
 Folder Structure
 ----------------
 
@@ -136,18 +148,6 @@ Here's a quick reference of the main directories in a typical GWAY workspace:
 | tools/         | Platform-specific scripts and files.                         |
 +----------------+--------------------------------------------------------------+
 
-Websites
---------
-
-The ``web`` project assembles view functions into a small site. Register each
-project with ``gw.web.app.setup`` and then launch the server using
-``gw.web.server.start_app``. Routes of the form ``/project/view`` map to
-``view_*`` functions and static files under ``data/static`` are served from
-``/static``. ``web.site.view_reader`` renders ``.rst`` or ``.md`` files when
-you visit ``/site/reader/PATH``; it first checks the workspace root and
-then ``data/static`` automatically. See the `Web README
-</site/reader?tome=web>`_ for a more complete guide.
-
 Project READMEs
 ---------------
 
@@ -156,15 +156,41 @@ The following projects bundle additional documentation.  Each link uses
 ``data/static`` folder.
 
 
+- `awg </site/reader?tome=awg>`_
+- `cdv </site/reader?tome=cdv>`_
+- `games </site/reader?tome=games>`_
+  - `conway </site/reader?tome=games/conway>`_
+  - `mtg </site/reader?tome=games/mtg>`_
+  - `qpig </site/reader?tome=games/qpig>`_
 - `monitor </site/reader?tome=monitor>`_
 - `ocpp </site/reader?tome=ocpp>`_
+  - `csms </site/reader?tome=ocpp/csms>`_
+  - `evcs </site/reader?tome=ocpp/evcs>`_
+  - `data </site/reader?tome=ocpp/data>`_
+- `release </site/reader?tome=release>`_
+- `vbox </site/reader?tome=vbox>`_
 - `web </site/reader?tome=web>`_
-- `games/qpig </site/reader?tome=games/qpig>`_
+  - `nav </site/reader?tome=web/nav>`_
+  - `cookies </site/reader?tome=web/cookies>`_
+  - `auth </site/reader?tome=web/auth>`_
 
+.. _/site/reader?tome=awg: /site/reader?tome=awg
+.. _/site/reader?tome=cdv: /site/reader?tome=cdv
+.. _/site/reader?tome=games: /site/reader?tome=games
+.. _/site/reader?tome=games/conway: /site/reader?tome=games/conway
+.. _/site/reader?tome=games/mtg: /site/reader?tome=games/mtg
+.. _/site/reader?tome=games/qpig: /site/reader?tome=games/qpig
 .. _/site/reader?tome=monitor: /site/reader?tome=monitor
 .. _/site/reader?tome=ocpp: /site/reader?tome=ocpp
+.. _/site/reader?tome=ocpp/csms: /site/reader?tome=ocpp/csms
+.. _/site/reader?tome=ocpp/evcs: /site/reader?tome=ocpp/evcs
+.. _/site/reader?tome=ocpp/data: /site/reader?tome=ocpp/data
+.. _/site/reader?tome=release: /site/reader?tome=release
+.. _/site/reader?tome=vbox: /site/reader?tome=vbox
 .. _/site/reader?tome=web: /site/reader?tome=web
-.. _/site/reader?tome=games/qpig: /site/reader?tome=games/qpig
+.. _/site/reader?tome=web/nav: /site/reader?tome=web/nav
+.. _/site/reader?tome=web/cookies: /site/reader?tome=web/cookies
+.. _/site/reader?tome=web/auth: /site/reader?tome=web/auth
 
 You can generate these links yourself with
 ``gw.web.build_url('site/reader', tome='proj')``.

--- a/data/static/awg/README.rst
+++ b/data/static/awg/README.rst
@@ -1,0 +1,4 @@
+AWG Project
+-----------
+
+Simple utility to calculate cable sizes using American Wire Gauge tables.

--- a/data/static/cdv/README.rst
+++ b/data/static/cdv/README.rst
@@ -1,0 +1,4 @@
+CDV Storage
+-----------
+
+Helpers for working with colon-delimited value files.

--- a/data/static/games/README.rst
+++ b/data/static/games/README.rst
@@ -1,0 +1,4 @@
+Games Collection
+----------------
+
+Shared helpers for simple demo games.

--- a/data/static/games/conway/README.rst
+++ b/data/static/games/conway/README.rst
@@ -1,0 +1,4 @@
+Conway's Game of Life
+---------------------
+
+Single-page JavaScript implementation.

--- a/data/static/games/mtg/README.rst
+++ b/data/static/games/mtg/README.rst
@@ -1,0 +1,4 @@
+MTG Card Search
+---------------
+
+Frontend to query the Scryfall API for Magic cards.

--- a/data/static/ocpp/csms/README.rst
+++ b/data/static/ocpp/csms/README.rst
@@ -1,0 +1,4 @@
+CSMS Dashboard
+--------------
+
+Central system server with a web status page.

--- a/data/static/ocpp/data/README.rst
+++ b/data/static/ocpp/data/README.rst
@@ -1,0 +1,4 @@
+OCPP Data Helpers
+-----------------
+
+Database functions used to persist charging session information.

--- a/data/static/ocpp/evcs/README.rst
+++ b/data/static/ocpp/evcs/README.rst
@@ -1,0 +1,4 @@
+EVCS Simulator
+--------------
+
+Mock charge point that connects to the CSMS dashboard.

--- a/data/static/release/README.rst
+++ b/data/static/release/README.rst
@@ -1,0 +1,4 @@
+Release Utilities
+-----------------
+
+Scripts for building distributions and uploading them to package indexes.

--- a/data/static/vbox/README.rst
+++ b/data/static/vbox/README.rst
@@ -1,0 +1,4 @@
+Virtual Box
+-----------
+
+Upload and download files through a secure web interface.

--- a/data/static/web/auth/README.rst
+++ b/data/static/web/auth/README.rst
@@ -1,0 +1,4 @@
+Web Authentication
+------------------
+
+Basic account login example used by the website recipe.

--- a/data/static/web/cookies/README.rst
+++ b/data/static/web/cookies/README.rst
@@ -1,0 +1,4 @@
+Cookie Jar
+----------
+
+Demonstrates cookie-based preferences for the demo site.

--- a/data/static/web/nav/README.rst
+++ b/data/static/web/nav/README.rst
@@ -1,0 +1,4 @@
+Web Navigation
+--------------
+
+JavaScript helpers for responsive navigation menus.


### PR DESCRIPTION
## Summary
- make 'Websites' a subsection of the advanced recipe
- link project and sub‑project READMEs
- add minimal README stubs for website example projects

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686daa1799648326b01c7ee146b62289