### PR TITLE
Clarify feedback privacy notice

### DIFF
--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -454,7 +454,7 @@ def view_feedback(*, name=None, email=None, topic=None, message=None):
             back = gw.web.app.build_url("feedback")
             return f"<h1>Missing required fields: {html.escape(miss)}</h1><p><a href='{back}'>Back</a></p>"
 
-        body = f"**From:** {name} <{email}>\n\n{message}"
+        body = f"**From:** {name}\n\n{message}"
         try:
             issue_url = _create_github_issue(topic, body)
         except Exception as e:
@@ -466,6 +466,7 @@ def view_feedback(*, name=None, email=None, topic=None, message=None):
 
     return """
         <h1>Send Feedback</h1>
+        <p>Your name and message may be publicly displayed and processed. Your email will be kept private.</p>
         <form method="post">
             <input type="text" name="name" placeholder="Your Name" required class="main" />
             <input type="email" name="email" placeholder="Email" required class="main" />

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -14,6 +14,7 @@ class FeedbackViewTests(unittest.TestCase):
         self.assertIn("name=\"email\"", html)
         self.assertIn("name=\"topic\"", html)
         self.assertIn("name=\"message\"", html)
+        self.assertIn("publicly displayed", html)
 
     def test_feedback_post_calls_issue(self):
         class FakeRequest:
@@ -27,6 +28,8 @@ class FeedbackViewTests(unittest.TestCase):
                     html = site.view_feedback(name='A', email='a@example.com', topic='Test', message='Hello')
                     self.assertIn('Thank you', html)
                     p.assert_called_once()
+                    body = p.call_args.kwargs['json']['body']
+                    self.assertNotIn('a@example.com', body)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- note that feedback name and message may be public while email stays private
- keep email out of created GitHub issues
- test that the new disclaimer appears and email is not posted

## Testing
- `gway test --coverage` *(fails: ConnectionError to localhost, FileNotFoundError for logs)*

------
https://chatgpt.com/codex/tasks/task_e_686db3f901fc8326b44238cade39921e