### PR TITLE
Improve AWG cable finder layout

### DIFF
--- a/data/static/awg/cable_finder.css
+++ b/data/static/awg/cable_finder.css
@@ -7,12 +7,13 @@
 }
 .cable-form label {
     display: flex;
-    flex-direction: column;
-    font-weight: 500;
+    align-items: center;
+    font-weight: 600;
+    font-size: 1.1em;
 }
 .cable-form input,
 .cable-form select {
-    margin-top: 3px;
+    margin-left: 6px;
     padding: 4px 6px;
     font-size: 1em;
 }


### PR DESCRIPTION
## Summary
- align labels and fields in the cable finder form
- enlarge label font

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686dbfca21948326b1667aea2348b612