### PR TITLE
Fix README bullet list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ Core Concepts
   results, ``gw.context`` and environment variables.
 - **Recipes** ``.gwr``: text files listing commands.  Indented lines reuse the
   previous command allowing very compact scripts.  Run them via
-``gway -r file`` or ``gw.run_recipe('file.gwr')``.
+  ``gway -r file`` or ``gw.run_recipe('file.gwr')``.
 - **Unquoted Kwargs**: values after ``--key`` may include spaces up to the next
   ``-`` or ``--`` token; quoting is optional.
 - **Environment Loading**: ``envs/clients/<user>.env`` and

--- a/tests/test_readme_format.py
+++ b/tests/test_readme_format.py
@@ -1,0 +1,20 @@
+import unittest
+from pathlib import Path
+from docutils.core import publish_parts
+
+
+class ReadmeFormatTests(unittest.TestCase):
+    def test_readme_parses_without_errors(self):
+        content = Path("README.rst").read_text(encoding="utf-8")
+        try:
+            publish_parts(
+                source=content,
+                writer_name="html",
+                settings_overrides={"halt_level": 2},
+            )
+        except Exception as exc:
+            self.fail(f"README.rst contains formatting errors: {exc}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix indentation in README bullet list so docutils can parse it
- add regression test verifying README renders via docutils

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686dcb35af9c832696f94bbb832654cb