### PR TITLE
Add games home and view aliases

### DIFF
--- a/projects/games/games.py
+++ b/projects/games/games.py
@@ -1,0 +1,83 @@
+# file: projects/games/games.py
+"""Central home view and aliases for all games."""
+
+import importlib.util
+from pathlib import Path
+
+
+def _load(mod_file: str, name: str):
+    spec = importlib.util.spec_from_file_location(
+        name, Path(__file__).with_name(mod_file)
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[arg-type]
+    return module
+
+
+conway = _load("conway.py", "games.conway")
+mtg = _load("mtg.py", "games.mtg")
+qpig = _load("qpig.py", "games.qpig")
+snl = _load("snl.py", "games.snl")
+
+WIKI_ICON = (
+    '<svg viewBox="0 0 20 20" width="12" height="12" style="vertical-align:baseline">'
+    '<path d="M10 3h7v7h-2V6.414l-9.293 9.293-1.414-1.414L13.586 5H10V3z" fill="currentColor"/>'
+    '<path d="M5 5h3V3H3v5h2V5z" fill="currentColor"/></svg>'
+)
+
+
+_DEF = [
+    (
+        "Conway's Game of Life",
+        "game-of-life",
+        "A classic cellular automaton that shows how complex patterns arise from simple rules.",
+        "https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life",
+    ),
+    (
+        "Magic Card Search",
+        "search-games",
+        "Look up Magic: The Gathering cards using the Scryfall API.",
+        "https://en.wikipedia.org/wiki/Magic:_The_Gathering",
+    ),
+    (
+        "Quantum Piggy Farm",
+        "qpig-farm",
+        "Prototype incremental game about raising quantum guinea pigs.",
+        "https://en.wikipedia.org/wiki/Incremental_game",
+    ),
+    (
+        "Snakes and Ladders",
+        "snl-board",
+        "Race to 100 while snakes send you back down the board.",
+        "https://en.wikipedia.org/wiki/Snakes_and_Ladders",
+    ),
+]
+
+
+def view_games():
+    """Home view listing all available games."""
+    html = ["<h1>Games</h1>", "<ul class='games-list'>"]
+    for title, route, desc, link in _DEF:
+        wiki = f'<a href="{link}" target="_blank" class="wiki">{WIKI_ICON}</a>'
+        html.append(
+            f"<li><a href='/games/{route}'><b>{title}</b></a><br><span>{desc} {wiki}</span></li>"
+        )
+    html.append("</ul>")
+    return "\n".join(html)
+
+
+def view_game_of_life(*args, **kwargs):
+    return conway.view_game_of_life(*args, **kwargs)
+
+
+def view_search_games(*args, **kwargs):
+    return mtg.view_search_games(*args, **kwargs)
+
+
+def view_qpig_farm(*args, **kwargs):
+    return qpig.view_qpig_farm(*args, **kwargs)
+
+
+def view_snl_board(*args, **kwargs):
+    return snl.view_snl_board(*args, **kwargs)
+

--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -3,10 +3,7 @@
 
 web app setup-app:
     --home reader
-    --project games.conway --home game-of-life --path conway
-    --project games.mtg --home search-games
-    --project games.qpig --home qpig-farm --path qpig
-    --project games.snl --home snl-board --path snl
+    --project games --home games --links game-of-life,search-games,qpig-farm,snl-board
     --project web.nav --home style-switcher
     --project web.cookies --home cookie-jar
 

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -12,8 +12,7 @@ web app setup-app:
     --project ocpp.data --home charger-summary
     --project ocpp.csms --auth required --home charger-status
     --project ocpp.evcs --auth required --home cp-simulator
-    --project games.conway --home game-of-life --path conway
-    --project games.mtg --home search-games
+    --project games --home games --links game-of-life,search-games,qpig-farm,snl-board
     --project web.auth
 
 web:

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -13,8 +13,7 @@ web app setup-app:
     --project ocpp.csms --auth required --home charger-status
     --project ocpp.evcs --auth required --home cp-simulator
     --project ocpp.data --auth required --home charger-summary
-    --project games.conway --home game-of-life --path conway
-    --project games.mtg --home search-games
+    --project games --home games --links game-of-life,search-games,qpig-farm,snl-board
     --project cdv --home data-editor --auth required
     --project web.auth
 

--- a/tests/test_conway_web.py
+++ b/tests/test_conway_web.py
@@ -65,7 +65,7 @@ class ConwayWebTests(unittest.TestCase):
 
     def test_game_of_life_page_includes_css_and_js(self):
         """Game of Life page includes its css/js and download link."""
-        soup, resp = self._get_soup(self.base_url + "/conway/game-of-life")
+        soup, resp = self._get_soup(self.base_url + "/games/game-of-life")
         # CSS
         css_links = [link['href'] for link in soup.find_all('link', rel="stylesheet")]
         gw.info(f"CSS links found: {css_links}")
@@ -143,7 +143,7 @@ class ConwayWebTests(unittest.TestCase):
         """
         CSS should appear in <head>, JS should appear before </body>.
         """
-        soup, resp = self._get_soup(self.base_url + "/conway/game-of-life")
+        soup, resp = self._get_soup(self.base_url + "/games/game-of-life")
         head = soup.head
         body = soup.body
         # CSS in head
@@ -161,7 +161,7 @@ class ConwayWebTests(unittest.TestCase):
         screenshot_file = screenshot_dir / "conway_game.png"
         try:
             webauto.capture_page_source(
-                self.base_url + "/conway/game-of-life",
+                self.base_url + "/games/game-of-life",
                 screenshot=str(screenshot_file),
             )
         except Exception as e:

--- a/tests/test_nav_links.py
+++ b/tests/test_nav_links.py
@@ -18,7 +18,7 @@ class FakeRequest:
 class NavLinksTests(unittest.TestCase):
     def setUp(self):
         self.orig_request = nav.request
-        nav.request = FakeRequest('/games/conway/game-of-life')
+        nav.request = FakeRequest('/games/game-of-life')
         self.orig_app = nav.gw.web.app
         nav.gw.web.app = type('A', (), {'is_setup': lambda self2, n: False})()
         self.orig_cookies = nav.gw.web.cookies
@@ -30,14 +30,14 @@ class NavLinksTests(unittest.TestCase):
         nav.gw.web.cookies = self.orig_cookies
 
     def test_render_includes_project_links(self):
-        homes = [('Games', 'games/conway/game-of-life')]
-        html = nav.render(homes=homes, links={'games/conway/game-of-life': ['score', 'about']})
+        homes = [('Games', 'games/game-of-life')]
+        html = nav.render(homes=homes, links={'games/game-of-life': ['score', 'about']})
         soup = BeautifulSoup(html, 'html.parser')
         sub = soup.find('ul', class_='sub-links')
         self.assertIsNotNone(sub)
         hrefs = [a['href'] for a in sub.find_all('a')]
-        self.assertIn('/games/conway/score', hrefs)
-        self.assertIn('/games/conway/about', hrefs)
+        self.assertIn('/games/score', hrefs)
+        self.assertIn('/games/about', hrefs)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add games/games.py with a central home view listing available games
- route all game links through the unified games project
- update website and gamebox recipes to use new links
- adjust tests for updated paths

## Testing
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686dc5398ef0832687142ee093df16a2