### PR TITLE
Allow colon after flag in recipe lines

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -166,6 +166,27 @@ web:
         ]
         self.assertEqual(commands, expected)
 
+    def test_load_recipe_colon_after_flag_mid_line(self):
+        content = (
+            """web server start-app --port: --ws-port 9999
+    - 8888
+    - 7777
+"""
+        )
+        with tempfile.NamedTemporaryFile('w', delete=False) as f:
+            f.write(content)
+            temp_name = f.name
+        try:
+            commands, _ = console.load_recipe(temp_name)
+        finally:
+            os.remove(temp_name)
+
+        expected = [
+            ['web', 'server', 'start-app', '--port', '8888', '--ws-port', '9999'],
+            ['web', 'server', 'start-app', '--port', '7777', '--ws-port', '9999'],
+        ]
+        self.assertEqual(commands, expected)
+
 
 class TestPrepareKwargParsing(unittest.TestCase):
     def test_multi_word_kwargs(self):


### PR DESCRIPTION
## Summary
- support colon syntax after flag tokens in `load_recipe`
- test colon after flag mid-line

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686dc957a90c8326a3c9ac16455afce3