### PR TITLE
Add click-triggered render refresh

### DIFF
--- a/data/static/render.js
+++ b/data/static/render.js
@@ -7,6 +7,7 @@
  * - data-gw-refresh: interval in seconds (optional)
  * - data-gw-params: comma-separated data attributes to POST (optional; defaults to all except data-gw-*)
  * - data-gw-target: 'content' (default, replace innerHTML), or 'replace' (replace the whole element)
+ * - data-gw-click: any value starting with "re" to manually re-render the block on click (optional, case-insensitive)
  *
  * No external dependencies.
  */
@@ -82,6 +83,14 @@
         timers[id] = setInterval(() => renderBlock(el), refresh * 1000);
         // Render once immediately
         renderBlock(el);
+      }
+      let click = el.getAttribute('data-gw-click');
+      if (click && /^re/i.test(click) && !el.dataset.gwClickSetup) {
+        el.addEventListener('click', evt => {
+          evt.preventDefault();
+          renderBlock(el);
+        });
+        el.dataset.gwClickSetup = '1';
       }
     });
   }

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -512,7 +512,7 @@ def view_charger_status(*, action=None, charger_id=None, **_):
 
     # --- The key block for autorefresh ---
     html.append(
-        '<div id="charger-list" data-gw-render="charger_list" data-gw-refresh="5">'
+        '<div id="charger-list" data-gw-render="charger_list" data-gw-refresh="5" data-gw-click="refresh">'
     )
     if not all_chargers:
         html.append('<p><em>No chargers connected or transactions seen yet.</em></p>')
@@ -603,7 +603,7 @@ def view_charger_detail(*, charger_id=None, **_):
         html.append(f'<p class="error">{msg}</p>')
 
     html.append(
-        f'<div id="charger-info" data-gw-render="charger_info" data-gw-refresh="5" data-charger-id="{charger_id}">' +
+        f'<div id="charger-info" data-gw-render="charger_info" data-gw-refresh="5" data-gw-click="refresh" data-charger-id="{charger_id}">' +
         _render_charger_card(charger_id, tx, state, raw_hb) +
         '</div>'
     )
@@ -625,7 +625,7 @@ def view_charger_detail(*, charger_id=None, **_):
     )
 
     html.append(
-        f'<div id="charger-log" data-gw-render="charger_log" data-gw-refresh="2" data-charger-id="{charger_id}">' +
+        f'<div id="charger-log" data-gw-render="charger_log" data-gw-refresh="2" data-gw-click="refresh" data-charger-id="{charger_id}">' +
         render_charger_log(charger_id=charger_id) +
         '</div>'
     )


### PR DESCRIPTION
## Summary
- support `data-gw-click` values that start with `re` in `render.js`
- enable click-to-refresh on CSMS dashboard blocks
- remove docs about adding `data-gw-click`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686dc0774b308326a9bd23f75feeb06a