### PR TITLE
Fix hello_world result for web

### DIFF
--- a/gway/builtins.py
+++ b/gway/builtins.py
@@ -21,12 +21,21 @@ def hello_world(name: str = "World", *, greeting: str = "Hello", **kwargs):
     from gway import gw
     version = gw.version()
     message = f"{greeting.title()}, {name.title()}!"
-    if hasattr(gw, "hello_world"): 
-        if not gw.silent: print(message)
-        else: print(f"{gw.silent=}")
-    else: 
+    if hasattr(gw, "hello_world"):
+        if not gw.silent:
+            print(message)
+        else:
+            print(f"{gw.silent=}")
+    else:
         print("Greeting protocol not found ((serious smoke)).")
-    return locals()
+
+    # Only return simple fields to avoid huge recursive HTML when rendered
+    return {
+        "greeting": greeting,
+        "name": name,
+        "message": message,
+        "version": version,
+    }
 
 def abort(message: str, *, exit_code: int = 13) -> int:
     """Abort with error message."""

--- a/tests/test_cast_to_dict.py
+++ b/tests/test_cast_to_dict.py
@@ -1,0 +1,30 @@
+import unittest
+import importlib.util
+from pathlib import Path
+
+spec = importlib.util.spec_from_file_location(
+    "cast_mod", Path(__file__).resolve().parents[1] / "projects" / "cast.py"
+)
+cast_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cast_mod)
+
+
+class ToDictSanitizeTests(unittest.TestCase):
+    def test_default_max_depth(self):
+        data = {"a": {"b": {"c": {"d": {"e": 1}}}}}
+        result = cast_mod.to_dict(data)
+        self.assertEqual(result, {"a": {"b": {"c": {"d": "..."}}}})
+
+    def test_override_max_depth(self):
+        data = {"a": {"b": {"c": {"d": {"e": 1}}}}}
+        result = cast_mod.to_dict(data, max_depth=2)
+        self.assertEqual(result, {"a": {"b": "..."}})
+
+    def test_json_string_input(self):
+        text = '{"x": {"y": {"z": 2}}}'
+        result = cast_mod.to_dict(text, max_depth=2)
+        self.assertEqual(result, {"x": {"y": "..."}})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- avoid returning the gw object from `hello_world`
- keep output small for search-box CLI results
- sanitize dictionaries recursively with depth limit
- test to_dict sanitization behavior

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686dda3784a08326a367c00da9d223ac