### PR TITLE
Show AWG form in two columns

### DIFF
--- a/data/static/awg/cable_finder.css
+++ b/data/static/awg/cable_finder.css
@@ -14,6 +14,13 @@
     font-weight: 600;
     font-size: 1.1em;
 }
+.form-table.two-col td:nth-child(1),
+.form-table.two-col td:nth-child(3) {
+    text-align: right;
+    white-space: nowrap;
+    font-weight: 600;
+    font-size: 1.1em;
+}
 .cable-form input,
 .cable-form select {
     width: 100%;

--- a/projects/awg.py
+++ b/projects/awg.py
@@ -247,20 +247,16 @@ def view_cable_finder(
         return '''<link rel="stylesheet" href="/static/awg/cable_finder.css">
             <h1>AWG Cable & Conduit Finder</h1>
             <form method="post" class="cable-form">
-                <table class="form-table">
+                <table class="form-table two-col">
                     <tr>
                         <td><label for="meters">Meters:</label></td>
                         <td><input id="meters" type="number" name="meters" required min="1" /></td>
-                    </tr>
-                    <tr>
                         <td><label for="amps">Amps:</label></td>
                         <td><input id="amps" type="number" name="amps" value="40" /></td>
                     </tr>
                     <tr>
                         <td><label for="volts">Volts:</label></td>
                         <td><input id="volts" type="number" name="volts" value="220" /></td>
-                    </tr>
-                    <tr>
                         <td><label for="material">Material:</label></td>
                         <td>
                             <select id="material" name="material">
@@ -278,8 +274,6 @@ def view_cable_finder(
                                 <option value="3">AC Three Phases (3)</option>
                             </select>
                         </td>
-                    </tr>
-                    <tr>
                         <td><label for="temperature">Temperature:</label></td>
                         <td>
                             <select id="temperature" name="temperature">
@@ -301,14 +295,12 @@ def view_cable_finder(
                                 <option value="none">None</option>
                             </select>
                         </td>
-                    </tr>
-                    <tr>
                         <td><label for="max_awg">Max AWG:</label></td>
                         <td><input id="max_awg" type="text" name="max_awg" /></td>
                     </tr>
                     <tr>
                         <td><label for="max_lines">Max Lines:</label></td>
-                        <td>
+                        <td colspan="3">
                             <select id="max_lines" name="max_lines">
                                 <option value="1">1</option>
                                 <option value="2">2</option>


### PR DESCRIPTION
## Summary
- tweak AWG view HTML to show form in two columns
- add CSS rules to style two-column table

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686de25eb83c8326bdb2fe11a1b9c28f