### PR TITLE
Improve charger summary table style

### DIFF
--- a/data/static/ocpp/csms/charger_status.css
+++ b/data/static/ocpp/csms/charger_status.css
@@ -164,3 +164,17 @@
     padding: 4px;
 }
 .ocpp-status form.inline { display: inline; }
+
+/* Summary table for stored charger data */
+.ocpp-summary {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.94em;
+}
+.ocpp-summary th, .ocpp-summary td {
+    border: 1px solid #bbb;
+    padding: 4px 6px;
+}
+.ocpp-summary td {
+    vertical-align: top;
+}

--- a/projects/ocpp/data.py
+++ b/projects/ocpp/data.py
@@ -244,12 +244,17 @@ def list_chargers() -> list[str]:
 def view_charger_summary(**_):
     """Simple HTML summary of charger data."""
     rows = get_summary()
-    html = ["<h1>OCPP Charger Summary</h1>"]
+    html = [
+        '<link rel="stylesheet" href="/static/ocpp/csms/charger_status.css">',
+        "<h1>OCPP Charger Summary</h1>",
+    ]
     if not rows:
         html.append("<p>No data.</p>")
         return "\n".join(html)
     html.append("<table class='ocpp-summary'>")
-    html.append("<tr><th>Charger</th><th>Sessions</th><th>Energy(kWh)</th><th>Last Stop</th><th>Last Error</th></tr>")
+    html.append(
+        "<tr><th>Charger</th><th>Sessions</th><th>Energy(kWh)</th><th>Last Stop</th><th>Last Error</th></tr>"
+    )
     for r in rows:
         html.append(
             f"<tr><td>{r['charger_id']}</td><td>{r['sessions']}</td><td>{r['energy']}</td>"


### PR DESCRIPTION
## Summary
- load OCPP CSS for charger summary page
- style the charger summary table with a small border and reduced font size
- show charger details in multiple columns again

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686ddae340ec832689a207abe89e08f1