### PR TITLE
Show AWG form in two columns

### DIFF
--- a/data/static/awg/cable_finder.css
+++ b/data/static/awg/cable_finder.css
@@ -7,8 +7,16 @@
 }
 .form-table td {
     padding: 4px 8px;
+    vertical-align: middle;
 }
 .form-table td:first-child {
+    text-align: right;
+    white-space: nowrap;
+    font-weight: 600;
+    font-size: 1.1em;
+}
+.form-table.two-col td:nth-child(1),
+.form-table.two-col td:nth-child(3) {
     text-align: right;
     white-space: nowrap;
     font-weight: 600;
@@ -20,6 +28,10 @@
     padding: 4px 6px;
     font-size: 1em;
     box-sizing: border-box;
+}
+.cable-form button.submit {
+    padding: 0.6em 2em;
+    min-width: 8em;
 }
 .warning {
     background: #fee;

--- a/tests/test_awg.py
+++ b/tests/test_awg.py
@@ -32,6 +32,12 @@ class TestMaxAwg(unittest.TestCase):
         res = gw.awg.find_awg(meters=30, amps=40, max_lines="")
         self.assertEqual(res["lines"], 1)
 
+    def test_ground_parameter_controls_cable_count(self):
+        res0 = gw.awg.find_awg(meters=30, amps=40, ground=0)
+        self.assertTrue(res0["cables"].endswith("+0"))
+        res1 = gw.awg.find_awg(meters=30, amps=40, ground=1)
+        self.assertTrue(res1["cables"].endswith("+1"))
+
     def test_forced_awg_returns_warning(self):
         res = gw.awg.find_awg(meters=30, amps=150, max_awg="14")
         self.assertEqual(res["awg"], "14")


### PR DESCRIPTION
## Summary
- tweak AWG view HTML to show form in two columns
- add CSS rules to style two-column table
- fix conduit size lookup and display
- add ground selector to AWG form
- widen Find Cable button and vertically align form labels

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686de25eb83c8326bdb2fe11a1b9c28f