### PR TITLE
Fix cable finder form alignment

### DIFF
--- a/projects/awg.py
+++ b/projects/awg.py
@@ -311,7 +311,7 @@ def view_cable_finder(
                     </tr>
                     <tr>
                         <td><label for="max_lines">Max Lines:</label></td>
-                        <td colspan="3">
+                        <td>
                             <select id="max_lines" name="max_lines">
                                 <option value="1">1</option>
                                 <option value="2">2</option>


### PR DESCRIPTION
## Summary
- fix alignment of Max Lines and Ground fields in AWG cable finder form

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686dec232b188326948adef4c5a8920e