### PR TITLE
Improve conduit selection when near fill limit

### DIFF
--- a/tests/test_awg.py
+++ b/tests/test_awg.py
@@ -44,5 +44,11 @@ class TestMaxAwg(unittest.TestCase):
         self.assertIn("warning", res)
         self.assertGreater(res["vdperc"], 3)
 
+
+class TestConduitSizing(unittest.TestCase):
+    def test_edge_capacity_selects_next_size(self):
+        res = gw.awg.find_conduit(awg=8, cables=3, conduit="emt")
+        self.assertEqual(res["size_inch"], "3/4")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- adjust SQL in `find_conduit` to include capacity
- choose next trade size when cable count hits the limit
- test conduit sizing edge case

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686dedd2b7fc83269ea17ee5a2c218e6