### PR TITLE
Fix mobile nav state across pages

### DIFF
--- a/data/static/web/nav/mobile.js
+++ b/data/static/web/nav/mobile.js
@@ -9,6 +9,7 @@
     const SPLITTER_ID = 'nav-splitter';
     const ARROW_WIDTH = 54; // px
     let isOpen = true;
+    let initialized = false;
 
     function isMobile() {
         return window.innerWidth <= 650;
@@ -187,8 +188,19 @@
         const layout = document.querySelector(LAYOUT_SELECTOR);
         if (!layout) return;
 
+        const sameOrigin = document.referrer &&
+            new URL(document.referrer, location.href).origin === location.origin;
+
         if (isMobile()) {
-            rollNav(true); // mobile: start closed
+            if (!initialized) {
+                if (sameOrigin) {
+                    rollNav(true);
+                } else {
+                    rollNav(false);
+                    setTimeout(() => rollNav(true), 400);
+                }
+                initialized = true;
+            }
             showHandle();
             fixFooterOverlap();
             fixMainMargin();


### PR DESCRIPTION
## Summary
- keep nav collapsed between internal page loads on mobile
- auto-collapse only on first visit from external referrer

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686edaa5a5108326a866eb25f5a0f73b