### PR TITLE
Fix nav sub-link padding

### DIFF
--- a/data/static/styles/base.css
+++ b/data/static/styles/base.css
@@ -157,7 +157,7 @@ aside ul.sub-links {
 }
 aside ul.sub-links li a {
     text-transform: none;
-    padding: 0.2em 0;
+    padding: 0.2em 0.5em;
 }
 
 /* 8. Buttons & form controls */

--- a/data/static/styles/dark-material.css
+++ b/data/static/styles/dark-material.css
@@ -78,7 +78,7 @@ aside ul.sub-links {
 
 aside ul.sub-links li a {
     text-transform: none;
-    padding: 0.2em 0;
+    padding: 0.2em 0.5rem;
 }
 
 /* QR image cap */

--- a/data/static/styles/fast-food.css
+++ b/data/static/styles/fast-food.css
@@ -65,7 +65,7 @@ aside ul.sub-links {
 
 aside ul.sub-links li a {
     text-transform: none;
-    padding: 0.2em 0;
+    padding: 0.2em 0 0.2em 1.05em;
 }
 
 main {

--- a/data/static/styles/hello-ween.css
+++ b/data/static/styles/hello-ween.css
@@ -57,7 +57,7 @@ aside ul.sub-links {
 
 aside ul.sub-links li a {
     text-transform: none;
-    padding: 0.2em 0;
+    padding: 0.2em 0 0.2em 1.1em;
 }
 
 main {

--- a/data/static/styles/mystic-eye.css
+++ b/data/static/styles/mystic-eye.css
@@ -73,7 +73,7 @@ aside ul.sub-links {
 
 aside ul.sub-links li a {
     text-transform: none;
-    padding: 0.2em 0;
+    padding: 0.2em 0 0.2em 1.2em;
 }
 
 main {

--- a/data/static/styles/palimpsesto.css
+++ b/data/static/styles/palimpsesto.css
@@ -81,7 +81,7 @@ aside ul.sub-links {
 
 aside ul.sub-links li a {
     text-transform: none;
-    padding: 0.2em 0;
+    padding: 0.2em 0 0.2em 1.3em;
 }
 
 main {

--- a/data/static/styles/party-code.css
+++ b/data/static/styles/party-code.css
@@ -74,7 +74,7 @@ aside ul.sub-links {
 
 aside ul.sub-links li a {
     text-transform: none;
-    padding: 0.2em 0;
+    padding: 0.2em 0 0.2em 1em;
 }
 
 /* Main area - clean with a gentle shadow */

--- a/data/static/styles/radio-darker.css
+++ b/data/static/styles/radio-darker.css
@@ -70,7 +70,7 @@ aside ul.sub-links {
 
 aside ul.sub-links li a {
     text-transform: none;
-    padding: 0.2em 0;
+    padding: 0.2em 0 0.2em 1em;
 }
 
 main {

--- a/data/static/styles/xp-summer.css
+++ b/data/static/styles/xp-summer.css
@@ -54,7 +54,7 @@ aside ul.sub-links {
 
 aside ul.sub-links li a {
     text-transform: none;
-    padding: 0.2em 0;
+    padding: 0.2em 0 0.2em 1em;
 }
 
 main {


### PR DESCRIPTION
## Summary
- ensure sub navigation links have left padding in base.css
- align sub-link padding across dark-material, fast-food, hello-ween, mystic-eye, palimpsesto, party-code, radio-darker and xp-summer styles

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686ef5000ee883268b9ca951ca952cc9