### PR TITLE
Refactor test imports and add guidelines

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -24,3 +24,36 @@ can enable them by passing feature flags to ``gway test``:
 
 The flags are stored in the ``GW_TEST_FLAGS`` environment variable, which test
 cases can check via ``is_test_flag('flag')``.
+
+Importing Project Modules
+-------------------------
+
+Tests should access project code via the ``gw`` dispatcher whenever possible:
+
+.. code-block:: python
+
+   from gway import gw
+   html = gw.web.nav.render()
+
+This mirrors real-world usage and avoids fragile import paths.  When a test
+needs to call private helpers that are not exposed through ``gw``, load the
+module lazily during ``setUpClass`` using a small helper:
+
+.. code-block:: python
+
+   class MyTests(unittest.TestCase):
+       @staticmethod
+       def _load_mod():
+           import importlib.util
+           from pathlib import Path
+
+           spec = importlib.util.spec_from_file_location(
+               "mod", Path(__file__).resolve().parents[1] / "projects" / "mod.py"
+           )
+           module = importlib.util.module_from_spec(spec)
+           spec.loader.exec_module(module)
+           return module
+
+       @classmethod
+       def setUpClass(cls):
+           cls.mod = cls._load_mod()

--- a/tests/test_app_utils.py
+++ b/tests/test_app_utils.py
@@ -1,22 +1,31 @@
 import unittest
 import datetime
-import importlib.util
-from pathlib import Path
 from unittest.mock import patch
-
-app_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "app.py"
-spec = importlib.util.spec_from_file_location("webapp", app_path)
-webapp = importlib.util.module_from_spec(spec)
 import sys
-sys.modules[spec.name] = webapp
-spec.loader.exec_module(webapp)
 
 
 class FormatFreshTests(unittest.TestCase):
+    @staticmethod
+    def _load_webapp():
+        import importlib.util
+        from pathlib import Path
+
+        app_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "app.py"
+        spec = importlib.util.spec_from_file_location("webapp", app_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+
+
+    @classmethod
+    def setUpClass(cls):
+        cls.webapp = cls._load_webapp()
+
     def setUp(self):
         # reset cache used by _refresh_fresh_date in case other tests ran
-        webapp._fresh_mtime = None
-        webapp._fresh_dt = None
+        self.webapp._fresh_mtime = None
+        self.webapp._fresh_dt = None
 
     def test_format_fresh_various_ranges(self):
         base = datetime.datetime(2024, 8, 20, 12, 0, 0)
@@ -29,41 +38,56 @@ class FormatFreshTests(unittest.TestCase):
         with patch('webapp.datetime.datetime', FixedDateTime):
             # Seconds
             dt = base - datetime.timedelta(seconds=20)
-            self.assertEqual(webapp._format_fresh(dt), 'seconds ago')
+            self.assertEqual(self.webapp._format_fresh(dt), 'seconds ago')
             # Minutes
             dt = base - datetime.timedelta(minutes=1)
-            self.assertEqual(webapp._format_fresh(dt), 'a minute ago')
+            self.assertEqual(self.webapp._format_fresh(dt), 'a minute ago')
             dt = base - datetime.timedelta(minutes=5)
-            self.assertEqual(webapp._format_fresh(dt), '5 minutes ago')
+            self.assertEqual(self.webapp._format_fresh(dt), '5 minutes ago')
             # Hours
             dt = base - datetime.timedelta(hours=1)
-            self.assertEqual(webapp._format_fresh(dt), 'an hour ago')
+            self.assertEqual(self.webapp._format_fresh(dt), 'an hour ago')
             dt = base - datetime.timedelta(hours=3)
-            self.assertEqual(webapp._format_fresh(dt), '3 hours ago')
+            self.assertEqual(self.webapp._format_fresh(dt), '3 hours ago')
             # Days
             dt = base - datetime.timedelta(days=1)
-            self.assertEqual(webapp._format_fresh(dt), 'a day ago')
+            self.assertEqual(self.webapp._format_fresh(dt), 'a day ago')
             dt = base - datetime.timedelta(days=3)
-            self.assertEqual(webapp._format_fresh(dt), '3 days ago')
+            self.assertEqual(self.webapp._format_fresh(dt), '3 days ago')
             # Same year
             dt = base - datetime.timedelta(days=30)
-            self.assertEqual(webapp._format_fresh(dt), 'July 21')
+            self.assertEqual(self.webapp._format_fresh(dt), 'July 21')
             # Previous year
             dt = base - datetime.timedelta(days=400)
-            self.assertEqual(webapp._format_fresh(dt), 'July 17, 2023')
+            self.assertEqual(self.webapp._format_fresh(dt), 'July 17, 2023')
 
 
 class RefreshFreshDateTests(unittest.TestCase):
+    @staticmethod
+    def _load_webapp():
+        import importlib.util
+        from pathlib import Path
+
+        app_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "app.py"
+        spec = importlib.util.spec_from_file_location("webapp", app_path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+    @classmethod
+    def setUpClass(cls):
+        cls.webapp = cls._load_webapp()
+
     def setUp(self):
-        webapp._fresh_mtime = None
-        webapp._fresh_dt = None
+        self.webapp._fresh_mtime = None
+        self.webapp._fresh_dt = None
 
     def test_refresh_fresh_date_caching_and_updates(self):
         with patch('webapp.gw.resource', return_value='/fake/VERSION') as res, \
              patch('webapp.os.path.getmtime', side_effect=[100, 100, 200]):
-            dt1 = webapp._refresh_fresh_date()
-            dt2 = webapp._refresh_fresh_date()
-            dt3 = webapp._refresh_fresh_date()
+            dt1 = self.webapp._refresh_fresh_date()
+            dt2 = self.webapp._refresh_fresh_date()
+            dt3 = self.webapp._refresh_fresh_date()
 
             self.assertEqual(dt1, datetime.datetime.fromtimestamp(100))
             self.assertIs(dt1, dt2)
@@ -73,7 +97,7 @@ class RefreshFreshDateTests(unittest.TestCase):
 
     def test_refresh_fresh_date_errors_return_none(self):
         with patch('webapp.gw.resource', side_effect=Exception('boom')):
-            self.assertIsNone(webapp._refresh_fresh_date())
+            self.assertIsNone(self.webapp._refresh_fresh_date())
 
 
 if __name__ == '__main__':

--- a/tests/test_auth_charger.py
+++ b/tests/test_auth_charger.py
@@ -11,14 +11,6 @@ import random
 import string
 from gway import gw
 from gway.builtins import is_test_flag
-import importlib.util
-from pathlib import Path
-
-# Dynamically load the web.auto helpers for screenshots
-auto_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "auto.py"
-spec = importlib.util.spec_from_file_location("webauto", auto_path)
-webauto = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(webauto)
 
 CDV_PATH = os.path.abspath("work/basic_auth.cdv")  # Use production path
 # Generate a random user/pass for each test run
@@ -130,7 +122,7 @@ class AuthChargerStatusTests(unittest.TestCase):
         screenshot_file = screenshot_dir / "charger_status.png"
         url = f"http://{TEST_USER}:{TEST_PASS}@127.0.0.1:18888/ocpp/csms/charger-status"
         try:
-            webauto.capture_page_source(url, screenshot=str(screenshot_file))
+            gw.web.auto.capture_page_source(url, screenshot=str(screenshot_file))
         except Exception as e:
             self.skipTest(f"Webdriver unavailable: {e}")
         self.assertTrue(screenshot_file.exists())

--- a/tests/test_cast_to_dict.py
+++ b/tests/test_cast_to_dict.py
@@ -1,28 +1,22 @@
 import unittest
-import importlib.util
 from pathlib import Path
-
-spec = importlib.util.spec_from_file_location(
-    "cast_mod", Path(__file__).resolve().parents[1] / "projects" / "cast.py"
-)
-cast_mod = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(cast_mod)
+from gway import gw
 
 
 class ToDictSanitizeTests(unittest.TestCase):
     def test_default_max_depth(self):
         data = {"a": {"b": {"c": {"d": {"e": 1}}}}}
-        result = cast_mod.to_dict(data)
+        result = gw.cast.to_dict(data)
         self.assertEqual(result, {"a": {"b": {"c": {"d": "..."}}}})
 
     def test_override_max_depth(self):
         data = {"a": {"b": {"c": {"d": {"e": 1}}}}}
-        result = cast_mod.to_dict(data, max_depth=2)
+        result = gw.cast.to_dict(data, max_depth=2)
         self.assertEqual(result, {"a": {"b": "..."}})
 
     def test_json_string_input(self):
         text = '{"x": {"y": {"z": 2}}}'
-        result = cast_mod.to_dict(text, max_depth=2)
+        result = gw.cast.to_dict(text, max_depth=2)
         self.assertEqual(result, {"x": {"y": "..."}})
 
 

--- a/tests/test_cdv_utils.py
+++ b/tests/test_cdv_utils.py
@@ -4,28 +4,33 @@ from pathlib import Path
 import sys
 import types
 
-# Load web.site so cdv can import its helpers
-site_spec = importlib.util.spec_from_file_location(
-    "projects.web.site", Path(__file__).resolve().parents[1] / "projects" / "web" / "site.py"
-)
-site_mod = importlib.util.module_from_spec(site_spec)
-site_spec.loader.exec_module(site_mod)
-
-projects_mod = types.ModuleType("projects")
-web_mod = types.ModuleType("projects.web")
-web_mod.site = site_mod
-projects_mod.web = web_mod
-sys.modules.setdefault("projects", projects_mod)
-sys.modules.setdefault("projects.web", web_mod)
-sys.modules.setdefault("projects.web.site", site_mod)
-
-cdv_path = Path(__file__).resolve().parents[1] / "projects" / "cdv.py"
-spec = importlib.util.spec_from_file_location("cdv_mod", cdv_path)
-cdv_mod = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(cdv_mod)
-
 
 class CDVUtilsTests(unittest.TestCase):
+    @staticmethod
+    def _load_cdv():
+        site_spec = importlib.util.spec_from_file_location(
+            "projects.web.site",
+            Path(__file__).resolve().parents[1] / "projects" / "web" / "site.py",
+        )
+        site_mod = importlib.util.module_from_spec(site_spec)
+        site_spec.loader.exec_module(site_mod)
+
+        projects_mod = types.ModuleType("projects")
+        web_mod = types.ModuleType("projects.web")
+        web_mod.site = site_mod
+        projects_mod.web = web_mod
+        sys.modules.setdefault("projects", projects_mod)
+        sys.modules.setdefault("projects.web", web_mod)
+        sys.modules.setdefault("projects.web.site", site_mod)
+
+        cdv_path = Path(__file__).resolve().parents[1] / "projects" / "cdv.py"
+        spec = importlib.util.spec_from_file_location("cdv_mod", cdv_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    @classmethod
+    def setUpClass(cls):
+        cls.cdv_mod = cls._load_cdv()
     def test_sanitize_cdv_path(self):
         cases = {
             "foo/bar": "foo/bar",
@@ -35,16 +40,16 @@ class CDVUtilsTests(unittest.TestCase):
         }
         for raw, expected in cases.items():
             with self.subTest(raw=raw):
-                self.assertEqual(cdv_mod._sanitize_cdv_path(raw), expected)
+                self.assertEqual(self.cdv_mod._sanitize_cdv_path(raw), expected)
 
     def test_parse_and_serialize_roundtrip(self):
         text = "id1:name=John%20Doe:age=30\nid2:msg=Hello"
-        records = cdv_mod._parse_cdv_text(text)
+        records = self.cdv_mod._parse_cdv_text(text)
         self.assertEqual(records, {
             "id1": {"name": "John Doe", "age": "30"},
             "id2": {"msg": "Hello"},
         })
-        serialized = cdv_mod._records_to_text(records)
+        serialized = self.cdv_mod._records_to_text(records)
         self.assertEqual(serialized, "id1:name=John%20Doe:age=30\nid2:msg=Hello")
 
 

--- a/tests/test_changelog_format.py
+++ b/tests/test_changelog_format.py
@@ -4,33 +4,8 @@ import os
 from pathlib import Path
 
 # Load release module as in other tests
-import importlib.util
-import types
-import sys
+from gway import gw
 
-# Setup pseudo package structure
-site_spec = importlib.util.spec_from_file_location(
-    "projects.web.site",
-    Path(__file__).resolve().parents[1] / "projects" / "web" / "site.py",
-)
-site_mod = importlib.util.module_from_spec(site_spec)
-site_spec.loader.exec_module(site_mod)
-
-projects_mod = types.ModuleType("projects")
-web_mod = types.ModuleType("projects.web")
-web_mod.site = site_mod
-projects_mod.web = web_mod
-sys.modules.setdefault("projects", projects_mod)
-sys.modules.setdefault("projects.web", web_mod)
-sys.modules.setdefault("projects.web.site", site_mod)
-
-# Load release module
-release_spec = importlib.util.spec_from_file_location(
-    "projects.release",
-    Path(__file__).resolve().parents[1] / "projects" / "release.py",
-)
-release_mod = importlib.util.module_from_spec(release_spec)
-release_spec.loader.exec_module(release_mod)
 
 class ChangelogUpdateTests(unittest.TestCase):
     def setUp(self):
@@ -55,7 +30,7 @@ Unreleased
 - first change
 """
         self._write_changelog(content)
-        release_mod.update_changelog("1.2.3", "abcdef")
+        gw.release.update_changelog("1.2.3", "abcdef")
         text = Path("CHANGELOG.rst").read_text()
         lines = text.splitlines()
         header = "1.2.3 [build abcdef]"

--- a/tests/test_conway_web.py
+++ b/tests/test_conway_web.py
@@ -11,14 +11,6 @@ import requests
 from bs4 import BeautifulSoup
 from gway import gw
 from gway.builtins import is_test_flag
-import importlib.util
-from pathlib import Path
-
-# Dynamically load the web.auto helpers so we can capture screenshots
-auto_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "auto.py"
-spec = importlib.util.spec_from_file_location("webauto", auto_path)
-webauto = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(webauto)
 
 class ConwayWebTests(unittest.TestCase):
     @classmethod
@@ -160,7 +152,7 @@ class ConwayWebTests(unittest.TestCase):
         screenshot_dir.mkdir(parents=True, exist_ok=True)
         screenshot_file = screenshot_dir / "conway_game.png"
         try:
-            webauto.capture_page_source(
+            gw.web.auto.capture_page_source(
                 self.base_url + "/games/game-of-life",
                 screenshot=str(screenshot_file),
             )

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -3,12 +3,6 @@ import importlib.util
 from pathlib import Path
 from unittest import mock
 
-# Dynamically load the cookies module from projects/web/cookies.py
-cookies_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "cookies.py"
-spec = importlib.util.spec_from_file_location("webcookies", cookies_path)
-cookies = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(cookies)
-
 class FakeRequest:
     def __init__(self):
         self.cookies = {}
@@ -22,11 +16,23 @@ class FakeResponse:
         self.set_calls.append((name, value, kwargs))
 
 class CookiesUtilTests(unittest.TestCase):
+    @staticmethod
+    def _load_cookies():
+        cookies_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "cookies.py"
+        spec = importlib.util.spec_from_file_location("webcookies", cookies_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cookies = cls._load_cookies()
+
     def setUp(self):
         self.request = FakeRequest()
         self.response = FakeResponse()
-        self.preq = mock.patch.object(cookies, 'request', self.request)
-        self.pres = mock.patch.object(cookies, 'response', self.response)
+        self.preq = mock.patch.object(self.cookies, 'request', self.request)
+        self.pres = mock.patch.object(self.cookies, 'response', self.response)
         self.preq.start()
         self.pres.start()
 
@@ -36,27 +42,27 @@ class CookiesUtilTests(unittest.TestCase):
 
     def test_set_and_get_when_accepted(self):
         self.request.cookies['cookies_accepted'] = 'yes'
-        cookies.set('foo', 'bar')
+        self.cookies.set('foo', 'bar')
         self.assertEqual(len(self.response.set_calls), 1)
         name, value, _ = self.response.set_calls[0]
         self.assertEqual((name, value), ('foo', 'bar'))
         # get should read from request
         self.request.cookies['foo'] = 'bar'
-        self.assertEqual(cookies.get('foo'), 'bar')
-        self.assertIsNone(cookies.get('missing'))
-        self.assertTrue(cookies.accepted())
+        self.assertEqual(self.cookies.get('foo'), 'bar')
+        self.assertIsNone(self.cookies.get('missing'))
+        self.assertTrue(self.cookies.accepted())
 
     def test_set_ignored_when_not_accepted(self):
-        cookies.set('foo', 'bar')
+        self.cookies.set('foo', 'bar')
         self.assertEqual(self.response.set_calls, [])
         # cookies_accepted cookie can always be set
-        cookies.set('cookies_accepted', 'yes')
+        self.cookies.set('cookies_accepted', 'yes')
         self.assertEqual(len(self.response.set_calls), 1)
         self.assertEqual(self.response.set_calls[0][0], 'cookies_accepted')
 
     def test_remove_when_accepted(self):
         self.request.cookies['cookies_accepted'] = 'yes'
-        cookies.remove('foo')
+        self.cookies.remove('foo')
         self.assertEqual(len(self.response.set_calls), 2)
         for call in self.response.set_calls:
             name, value, params = call
@@ -67,30 +73,30 @@ class CookiesUtilTests(unittest.TestCase):
         self.assertTrue(self.response.set_calls[1][2]['secure'])
 
     def test_remove_noop_when_not_accepted(self):
-        cookies.remove('foo')
+        self.cookies.remove('foo')
         self.assertEqual(self.response.set_calls, [])
 
     def test_append_when_accepted(self):
         self.request.cookies['cookies_accepted'] = 'yes'
         self.request.cookies['bag'] = 'a=1|b=2'
-        result = cookies.append('bag', 'c', '3')
+        result = self.cookies.append('bag', 'c', '3')
         self.assertEqual(result, ['a=1', 'b=2', 'c=3'])
         self.assertEqual(self.response.set_calls[-1][0], 'bag')
         self.assertEqual(self.response.set_calls[-1][1], 'a=1|b=2|c=3')
 
     def test_append_noop_when_not_accepted(self):
         self.request.cookies['bag'] = 'a=1|b=2'
-        result = cookies.append('bag', 'c', '3')
+        result = self.cookies.append('bag', 'c', '3')
         self.assertEqual(result, [])
         self.assertEqual(self.response.set_calls, [])
 
     def test_accepted_checks_cookie_value(self):
         self.request.cookies['cookies_accepted'] = 'yes'
-        self.assertTrue(cookies.accepted())
+        self.assertTrue(self.cookies.accepted())
         self.request.cookies['cookies_accepted'] = 'no'
-        self.assertFalse(cookies.accepted())
+        self.assertFalse(self.cookies.accepted())
         del self.request.cookies['cookies_accepted']
-        self.assertFalse(cookies.accepted())
+        self.assertFalse(self.cookies.accepted())
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_is_local.py
+++ b/tests/test_is_local.py
@@ -1,12 +1,6 @@
 import unittest
-import importlib.util
 from pathlib import Path
-
-# Dynamically load the server module to access is_local
-server_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "server.py"
-spec = importlib.util.spec_from_file_location("webserver", server_path)
-webserver = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(webserver)
+from gway import gw
 
 
 class FakeClient:
@@ -23,11 +17,11 @@ class FakeRequest:
 class IsLocalTests(unittest.TestCase):
     def test_local_address_returns_true(self):
         req = FakeRequest("127.0.0.1")
-        self.assertTrue(webserver.is_local(request=req, host="127.0.0.1"))
+        self.assertTrue(gw.web.server.is_local(request=req, host="127.0.0.1"))
 
     def test_non_local_address_returns_false(self):
         req = FakeRequest("8.8.8.8")
-        self.assertFalse(webserver.is_local(request=req, host="127.0.0.1"))
+        self.assertFalse(gw.web.server.is_local(request=req, host="127.0.0.1"))
 
 
 if __name__ == "__main__":

--- a/tests/test_nav_active_style.py
+++ b/tests/test_nav_active_style.py
@@ -3,12 +3,6 @@ import importlib.util
 from pathlib import Path
 from unittest import mock
 
-# Load projects/web/nav.py dynamically since projects is not a package
-nav_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "nav.py"
-spec = importlib.util.spec_from_file_location("webnav", nav_path)
-nav = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(nav)
-
 
 class FakeQuery:
     def __init__(self, params=None):
@@ -34,6 +28,18 @@ class FakeApp:
 
 
 class ActiveStyleTests(unittest.TestCase):
+    @staticmethod
+    def _load_nav():
+        nav_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "nav.py"
+        spec = importlib.util.spec_from_file_location("webnav", nav_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @classmethod
+    def setUpClass(cls):
+        global nav
+        nav = cls._load_nav()
     def setUp(self):
         # Patch list_styles to return a predictable order
         self.styles = [

--- a/tests/test_nav_compass.py
+++ b/tests/test_nav_compass.py
@@ -5,12 +5,6 @@ from urllib.parse import parse_qs
 
 from bs4 import BeautifulSoup
 
-# Load nav.py dynamically
-nav_path = Path(__file__).resolve().parents[1] / 'projects' / 'web' / 'nav.py'
-spec = importlib.util.spec_from_file_location('webnav', nav_path)
-nav = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(nav)
-
 class FakeRequest:
     def __init__(self, path, query=''):
         self.fullpath = path
@@ -19,6 +13,18 @@ class FakeRequest:
         self.query = type('Q', (), {'get': lambda self2, k, d=None, p=params: p.get(k, [d])[0]})()
 
 class NavCompassTests(unittest.TestCase):
+    @staticmethod
+    def _load_nav():
+        nav_path = Path(__file__).resolve().parents[1] / 'projects' / 'web' / 'nav.py'
+        spec = importlib.util.spec_from_file_location('webnav', nav_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @classmethod
+    def setUpClass(cls):
+        global nav
+        nav = cls._load_nav()
     def setUp(self):
         self.orig_request = nav.request
         self.orig_app = nav.gw.web.app

--- a/tests/test_nav_links.py
+++ b/tests/test_nav_links.py
@@ -3,12 +3,6 @@ from pathlib import Path
 import unittest
 from bs4 import BeautifulSoup
 
-# Load nav.py dynamically
-nav_path = Path(__file__).resolve().parents[1] / 'projects' / 'web' / 'nav.py'
-spec = importlib.util.spec_from_file_location('webnav', nav_path)
-nav = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(nav)
-
 class FakeRequest:
     def __init__(self, path):
         self.fullpath = path
@@ -16,6 +10,18 @@ class FakeRequest:
         self.query_string = ''
 
 class NavLinksTests(unittest.TestCase):
+    @staticmethod
+    def _load_nav():
+        nav_path = Path(__file__).resolve().parents[1] / 'projects' / 'web' / 'nav.py'
+        spec = importlib.util.spec_from_file_location('webnav', nav_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @classmethod
+    def setUpClass(cls):
+        global nav
+        nav = cls._load_nav()
     def setUp(self):
         self.orig_request = nav.request
         nav.request = FakeRequest('/games/game-of-life')

--- a/tests/test_nav_styles.py
+++ b/tests/test_nav_styles.py
@@ -6,15 +6,9 @@ import time
 import socket
 import requests
 from bs4 import BeautifulSoup
-import importlib.util
 from pathlib import Path
 from gway.builtins import is_test_flag
-
-# Dynamically load the web.auto helpers for screenshot capture
-auto_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "auto.py"
-spec = importlib.util.spec_from_file_location("webauto", auto_path)
-webauto = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(webauto)
+from gway import gw
 
 class NavStyleTests(unittest.TestCase):
     @classmethod
@@ -165,7 +159,7 @@ class NavStyleTests(unittest.TestCase):
         screenshot_dir.mkdir(parents=True, exist_ok=True)
         screenshot_file = screenshot_dir / "style_switcher.png"
         try:
-            webauto.capture_page_source(
+            gw.web.auto.capture_page_source(
                 self.base_url + "/nav/style-switcher",
                 screenshot=str(screenshot_file),
             )

--- a/tests/test_render_template_css.py
+++ b/tests/test_render_template_css.py
@@ -4,12 +4,19 @@ from pathlib import Path
 from unittest.mock import patch
 from bs4 import BeautifulSoup
 
-app_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "app.py"
-spec = importlib.util.spec_from_file_location("webapp", app_path)
-webapp = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(webapp)
-
 class RenderTemplateThemeCssTests(unittest.TestCase):
+    @staticmethod
+    def _load_webapp():
+        app_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "app.py"
+        spec = importlib.util.spec_from_file_location("webapp", app_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @classmethod
+    def setUpClass(cls):
+        global webapp
+        webapp = cls._load_webapp()
     def test_base_and_theme_css_links(self):
         dummy_theme = "/static/theme.css"
         with patch.object(webapp.gw.web.nav, 'active_style', return_value=dummy_theme), \

--- a/tests/test_screenshot_attachment.py
+++ b/tests/test_screenshot_attachment.py
@@ -4,13 +4,7 @@ import time
 import socket
 from pathlib import Path
 from gway.builtins import is_test_flag
-import importlib.util
-
-# Dynamically import the capture helpers without relying on projects as a package
-auto_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "auto.py"
-spec = importlib.util.spec_from_file_location("webauto", auto_path)
-webauto = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(webauto)
+from gway import gw
 
 class ScreenshotAttachmentTest(unittest.TestCase):
     @classmethod
@@ -51,7 +45,7 @@ class ScreenshotAttachmentTest(unittest.TestCase):
         screenshot_dir.mkdir(parents=True, exist_ok=True)
         screenshot_file = screenshot_dir / "help_page.png"
         try:
-            webauto.capture_page_source(
+            gw.web.auto.capture_page_source(
                 self.base_url + "/site/help",
                 screenshot=str(screenshot_file),
             )

--- a/tests/test_site_help_auto.py
+++ b/tests/test_site_help_auto.py
@@ -5,14 +5,7 @@ import socket
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-import importlib.util
-from pathlib import Path
-
-# Dynamically load the web.auto helpers since projects is not a package
-auto_path = Path(__file__).resolve().parents[1] / "projects" / "web" / "auto.py"
-spec = importlib.util.spec_from_file_location("webauto", auto_path)
-webauto = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(webauto)
+from gway import gw
 
 class SiteHelpAutoTests(unittest.TestCase):
     @classmethod
@@ -36,7 +29,7 @@ class SiteHelpAutoTests(unittest.TestCase):
             except subprocess.TimeoutExpired:
                 cls.proc.kill()
         try:
-            with webauto.browse(close=True):
+            with gw.web.auto.browse(close=True):
                 pass
         except Exception:
             pass
@@ -55,7 +48,7 @@ class SiteHelpAutoTests(unittest.TestCase):
     def test_help_search_finds_builtin(self):
         url = self.base_url + "/site/help"
         try:
-            with webauto.browse(url=url) as drv:
+            with gw.web.auto.browse(url=url) as drv:
                 textarea = drv.find_element(By.ID, "help-search")
                 textarea.clear()
                 textarea.send_keys("hello-world")
@@ -73,7 +66,7 @@ class SiteHelpAutoTests(unittest.TestCase):
         url = self.base_url + "/site/help"
         long_text = "word " * 50
         try:
-            with webauto.browse(url=url) as drv:
+            with gw.web.auto.browse(url=url) as drv:
                 textarea = drv.find_element(By.ID, "help-search")
                 start_height = drv.execute_script(
                     "return arguments[0].clientHeight", textarea

--- a/tests/test_site_sanitize.py
+++ b/tests/test_site_sanitize.py
@@ -1,16 +1,20 @@
 import unittest
-import importlib.util
 from pathlib import Path
-
-# Dynamically import projects/web/site.py since projects isn't a package
-spec = importlib.util.spec_from_file_location(
-    "site", Path(__file__).resolve().parents[1] / "projects" / "web" / "site.py"
-)
-site = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(site)
+import importlib.util
 
 
 class SiteSanitizeTests(unittest.TestCase):
+    @staticmethod
+    def _load_site():
+        spec = importlib.util.spec_from_file_location(
+            "site", Path(__file__).resolve().parents[1] / "projects" / "web" / "site.py"
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    @classmethod
+    def setUpClass(cls):
+        cls.site = cls._load_site()
     def test_sanitize_filename(self):
         cases = {
             "foo/bar": "foobar",
@@ -22,7 +26,7 @@ class SiteSanitizeTests(unittest.TestCase):
         }
         for raw, expected in cases.items():
             with self.subTest(raw=raw):
-                self.assertEqual(site._sanitize_filename(raw), expected)
+                self.assertEqual(self.site._sanitize_filename(raw), expected)
 
     def test_is_hidden_or_private(self):
         true_cases = [
@@ -36,7 +40,7 @@ class SiteSanitizeTests(unittest.TestCase):
         ]
         for fname in true_cases:
             with self.subTest(fname=fname):
-                self.assertTrue(site._is_hidden_or_private(fname))
+                self.assertTrue(self.site._is_hidden_or_private(fname))
 
         false_cases = [
             "normal",
@@ -46,7 +50,7 @@ class SiteSanitizeTests(unittest.TestCase):
         ]
         for fname in false_cases:
             with self.subTest(fname=fname):
-                self.assertFalse(site._is_hidden_or_private(fname))
+                self.assertFalse(self.site._is_hidden_or_private(fname))
 
 
 if __name__ == "__main__":

--- a/tests/test_static_collect.py
+++ b/tests/test_static_collect.py
@@ -1,15 +1,8 @@
 import unittest
-import importlib.util
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import patch
-
-# Dynamically import the static helpers
-spec = importlib.util.spec_from_file_location(
-    "webstatic", Path(__file__).resolve().parents[1] / "projects" / "web" / "static.py"
-)
-webstatic = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(webstatic)
+from gway import gw
 
 class StaticCollectTests(unittest.TestCase):
     def test_collect_concatenates_files(self):
@@ -32,9 +25,9 @@ class StaticCollectTests(unittest.TestCase):
             def fake_resource(*parts, **kw):
                 return tmp_path.joinpath(*parts)
 
-            with patch.object(webstatic.gw, "resource", fake_resource), \
-                 patch.object(webstatic.gw.web.app, "enabled_projects", lambda: {"web.site"}):
-                report = webstatic.collect(root="data/static", target="work/shared")
+            with patch.object(gw, "resource", fake_resource), \
+                 patch.object(gw.web.app, "enabled_projects", lambda: {"web.site"}):
+                report = gw.web.static.collect(root="data/static", target="work/shared")
 
             self.assertEqual(
                 {Path(rel).as_posix() for _, rel, _ in report["css"]},
@@ -75,9 +68,9 @@ class StaticCollectTests(unittest.TestCase):
             def fake_resource(*parts, **kw):
                 return tmp_path.joinpath(*parts)
 
-            with patch.object(webstatic.gw, "resource", fake_resource), \
-                 patch.object(webstatic.gw.web.app, "enabled_projects", lambda: {"monitor"}):
-                report = webstatic.collect(root="data/static", target="work/shared")
+            with patch.object(gw, "resource", fake_resource), \
+                 patch.object(gw.web.app, "enabled_projects", lambda: {"monitor"}):
+                report = gw.web.static.collect(root="data/static", target="work/shared")
 
             js_files = {Path(rel).as_posix() for _, rel, _ in report["js"]}
             self.assertIn("monitor/net_monitors.js", js_files)

--- a/tests/test_vbox.py
+++ b/tests/test_vbox.py
@@ -4,21 +4,26 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 import os
 
-# Dynamically load the vbox project module
-vbox_path = Path(__file__).resolve().parents[1] / "projects" / "vbox.py"
-spec = importlib.util.spec_from_file_location("vbox", vbox_path)
-vbox = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(vbox)
-
 
 class StreamFileResponseTests(unittest.TestCase):
+    @staticmethod
+    def _load_vbox():
+        vbox_path = Path(__file__).resolve().parents[1] / "projects" / "vbox.py"
+        spec = importlib.util.spec_from_file_location("vbox", vbox_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    @classmethod
+    def setUpClass(cls):
+        cls.vbox = cls._load_vbox()
+
     def test_stream_file_response(self):
         content = b"Hello vbox"
         with NamedTemporaryFile(delete=False) as tmp:
             tmp.write(content)
             tmp_path = tmp.name
         try:
-            resp = vbox.stream_file_response(tmp_path, "file.txt")
+            resp = self.vbox.stream_file_response(tmp_path, "file.txt")
             self.assertEqual(resp.status_code, 200)
             self.assertEqual(resp.headers.get("Content-Type"), "application/octet-stream")
             self.assertEqual(
@@ -31,6 +36,17 @@ class StreamFileResponseTests(unittest.TestCase):
 
 
 class SanitizeFilenameTests(unittest.TestCase):
+    @staticmethod
+    def _load_vbox():
+        vbox_path = Path(__file__).resolve().parents[1] / "projects" / "vbox.py"
+        spec = importlib.util.spec_from_file_location("vbox", vbox_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    @classmethod
+    def setUpClass(cls):
+        cls.vbox = cls._load_vbox()
+
     def test_sanitize_filename(self):
         cases = {
             "foo/bar": "foobar",
@@ -39,7 +55,7 @@ class SanitizeFilenameTests(unittest.TestCase):
         }
         for raw, expected in cases.items():
             with self.subTest(raw=raw):
-                self.assertEqual(vbox._sanitize_filename(raw), expected)
+                self.assertEqual(self.vbox._sanitize_filename(raw), expected)
 
 
 if __name__ == "__main__":

--- a/tests/test_view_changelog.py
+++ b/tests/test_view_changelog.py
@@ -1,34 +1,8 @@
 import unittest
 import tempfile
 import os
-import importlib.util
-import types
-import sys
 from pathlib import Path
-
-# Load site module for pseudo package structure
-site_spec = importlib.util.spec_from_file_location(
-    "projects.web.site",
-    Path(__file__).resolve().parents[1] / "projects" / "web" / "site.py",
-)
-site_mod = importlib.util.module_from_spec(site_spec)
-site_spec.loader.exec_module(site_mod)
-
-projects_mod = types.ModuleType("projects")
-web_mod = types.ModuleType("projects.web")
-web_mod.site = site_mod
-projects_mod.web = web_mod
-sys.modules.setdefault("projects", projects_mod)
-sys.modules.setdefault("projects.web", web_mod)
-sys.modules.setdefault("projects.web.site", site_mod)
-
-# Load release module
-release_spec = importlib.util.spec_from_file_location(
-    "projects.release",
-    Path(__file__).resolve().parents[1] / "projects" / "release.py",
-)
-release_mod = importlib.util.module_from_spec(release_spec)
-release_spec.loader.exec_module(release_mod)
+from gway import gw
 
 class ViewChangelogTests(unittest.TestCase):
     def setUp(self):
@@ -57,7 +31,7 @@ Unreleased
 - first change
 """
         self._write_changelog(content)
-        html = release_mod.view_changelog()
+        html = gw.release.view_changelog()
         self.assertNotIn("Unreleased", html)
 
     def test_header_shown_when_has_entries(self):
@@ -74,7 +48,7 @@ Unreleased
 - first change
 """
         self._write_changelog(content)
-        html = release_mod.view_changelog()
+        html = gw.release.view_changelog()
         self.assertIn("Unreleased", html)
 
 

--- a/tests/test_view_reader.py
+++ b/tests/test_view_reader.py
@@ -1,15 +1,8 @@
 import unittest
 import tempfile
-import importlib.util
 from pathlib import Path
 from unittest.mock import patch
 from gway import gw
-
-spec = importlib.util.spec_from_file_location(
-    "site", Path(__file__).resolve().parents[1] / "projects" / "web" / "site.py"
-)
-site = importlib.util.module_from_spec(spec)
-spec.loader.exec_module(site)
 
 
 class ViewReaderTests(unittest.TestCase):
@@ -30,34 +23,34 @@ class ViewReaderTests(unittest.TestCase):
         self.tmp.cleanup()
 
     def test_view_reader_renders(self):
-        html = site.view_reader(tome="README", origin="root")
+        html = gw.web.site.view_reader(tome="README", origin="root")
         self.assertIn("Test RST resource", html)
 
     def test_hidden_or_private_denied(self):
-        self.assertIn("Access denied", site.view_reader(tome=".secret", origin="root"))
-        self.assertIn("Access denied", site.view_reader(tome="_private", origin="root"))
+        self.assertIn("Access denied", gw.web.site.view_reader(tome=".secret", origin="root"))
+        self.assertIn("Access denied", gw.web.site.view_reader(tome="_private", origin="root"))
 
     def test_static_origin_subfolder(self):
         static_dir = self.base / "data" / "static" / "proj"
         static_dir.mkdir(parents=True)
         (static_dir / "README.rst").write_text("Static Doc")
-        html = site.view_reader(tome="proj/README", origin="static")
+        html = gw.web.site.view_reader(tome="proj/README", origin="static")
         self.assertIn("Static Doc", html)
 
     def test_implicit_static_and_directory(self):
         static_dir = self.base / "data" / "static" / "dir"
         static_dir.mkdir(parents=True)
         (static_dir / "README.rst").write_text("Dir Doc")
-        html = site.view_reader(tome="dir")
+        html = gw.web.site.view_reader(tome="dir")
         self.assertIn("Dir Doc", html)
 
-        html = site.view_reader("dir")
+        html = gw.web.site.view_reader("dir")
         self.assertIn("Dir Doc", html)
 
-        html = site.view_reader(tome="dir/")
+        html = gw.web.site.view_reader(tome="dir/")
         self.assertIn("Dir Doc", html)
 
-        html = site.view_reader("dir/")
+        html = gw.web.site.view_reader("dir/")
         self.assertIn("Dir Doc", html)
 
 


### PR DESCRIPTION
## Summary
- add documentation on lazy-loading modules in tests
- load project test modules via helper functions within each test class
- keep built-in tests and behaviours unchanged

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686ef1654bc083269461eac33ebdca04