### PR TITLE
Enable project setup hooks in web app

### DIFF
--- a/data/static/web/README.rst
+++ b/data/static/web/README.rst
@@ -3,6 +3,7 @@ Web Project Notes
 
 * `setup_app` can be invoked multiple times. Each call adds routes and homes for a single project.
 * Routes are registered with `add_route`, which skips duplicates so repeated setups won't register the same handler twice.
+* If the added project defines its own ``setup_app`` function, it is invoked with the app object.
 * When reusing `setup_app`, provide unique paths or homes to avoid collisions.
 * CLI flags resolve to a single value. Lists like ``--home a,b,c`` are not supported. Call the command once per value instead.
 * `web.site.view_reader` serves ``.md`` or ``.rst`` files from the resource root and can be used for a lightweight blog. Subfolders and hidden files are not allowed.

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -407,6 +407,17 @@ def setup_app(*,
         gw.info(f"Registered homes: {_homes}")
         debug_routes(app)
 
+    # --- Call project-level setup_app if defined ---
+    project_setup = getattr(source, "setup_app", None)
+    if callable(project_setup) and project_setup is not setup_app:
+        gw.verbose(f"Delegating to {project}.setup_app")
+        try:
+            maybe_app = project_setup(app=app)
+            if maybe_app is not None:
+                app = maybe_app
+        except Exception as exc:
+            gw.warn(f"{project}.setup_app failed: {exc}")
+
     return oapp if oapp else app
 
 # Use current_endpoint to get the current project route


### PR DESCRIPTION
## Summary
- call a project's `setup_app()` when configuring the web app
- document automatic hook in web README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686f186c31fc8326b9b5c21e01dcd17b