### PR TITLE
Use verbose log for optional auth failure

### DIFF
--- a/projects/web/auth.py
+++ b/projects/web/auth.py
@@ -27,7 +27,9 @@ class Challenge:
         if result:
             return True
         if not self.required and not strict:
-            gw.info(f"[auth] Optional challenge '{self.name}' failed (user not blocked).")
+            gw.verbose(
+                f"[auth] Optional challenge '{self.name}' failed (user not blocked)."
+            )
             return True
         # Set 401 if running under bottle
         if info.get("engine") == "bottle":


### PR DESCRIPTION
## Summary
- downgrade optional auth failure log to `gw.verbose`

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686f2d00821483269682d6965c6c9433