### PR TITLE
Add project index route support

### DIFF
--- a/projects/dummy.py
+++ b/projects/dummy.py
@@ -1,0 +1,4 @@
+# file: projects/dummy.py
+
+def view_index():
+    return "<h1>Dummy Index</h1>"

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -141,7 +141,7 @@ def setup_app(*,
         _links.clear()
         _registered_routes.clear()
         if home:
-            add_home(home, path)
+            add_home(home, path, project)
             add_links(f"{path}/{home}", links)
 
         def index():
@@ -155,7 +155,7 @@ def setup_app(*,
             return gw.web.error.redirect(f"404 Not Found: {request.url}", err=error)
     
     elif home:
-        add_home(home, path)
+        add_home(home, path, project)
         add_links(f"{path}/{home}", links)
 
     if getattr(gw, "timed_enabled", False):
@@ -245,6 +245,12 @@ def setup_app(*,
                 css_files=(f"{media_origin}/{css}.css",),
                 js_files=(f"{media_origin}/{js}.js",),
             )
+
+        def index_dispatch():
+            return view_dispatch("index")
+
+        add_route(app, f"/{path}", ["GET", "POST"], index_dispatch)
+        add_route(app, f"/{path}/", ["GET", "POST"], index_dispatch)
         add_route(app, f"/{path}/<view:path>", ["GET", "POST"], view_dispatch)
 
     # API dispatcher (only if apis is not None)
@@ -521,9 +527,13 @@ def is_setup(project_name):
     global _enabled
     return project_name in _enabled
 
-def add_home(home, path):
+def add_home(home, path, project=None):
     global _homes
-    title = home.replace('-', ' ').replace('_', ' ').title()
+    if home.lower() == "index" and project:
+        title_src = project
+    else:
+        title_src = home
+    title = title_src.replace('.', ' ').replace('-', ' ').replace('_', ' ').title()
     route = f"{path}/{home}"
     if (title, route) not in _homes:
         _homes.append((title, route))

--- a/tests/test_index_home_title.py
+++ b/tests/test_index_home_title.py
@@ -1,0 +1,12 @@
+import unittest
+import sys
+from gway import gw
+
+class IndexHomeTitleTests(unittest.TestCase):
+    def test_home_title_uses_project_name(self):
+        gw.web.app.setup_app(project="dummy", home="index")
+        mod = sys.modules[gw.web.app.setup_app.__module__]
+        self.assertIn(("Dummy", "dummy/index"), mod._homes)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_index_view.py
+++ b/tests/test_project_index_view.py
@@ -1,0 +1,19 @@
+import unittest
+from gway import gw
+from paste.fixture import TestApp
+
+class ProjectIndexViewTests(unittest.TestCase):
+    def setUp(self):
+        self.app = gw.web.app.setup_app(project="dummy")
+        self.client = TestApp(self.app)
+
+    def test_index_route(self):
+        resp = self.client.get("/dummy")
+        self.assertEqual(resp.status, 200)
+        self.assertIn("Dummy Index", resp.body.decode())
+        resp2 = self.client.get("/dummy/")
+        self.assertEqual(resp2.status, 200)
+        self.assertIn("Dummy Index", resp2.body.decode())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `/project/` paths to call `view_index` if defined
- add dummy project defining `view_index` for tests
- test new project index route functionality
- show project name for index homes in navigation
- refactor index route dispatch

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686f050de41c83269cbf7ebcb561d299