### PR TITLE
Support UTF-8 mail sending

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Thumbs.db
 
 # Coverage & test results (if using Jest, Mocha, etc.)
 coverage/
+\.coverage
 *.lcov
 
 # Package lock (optional; use only one lockfile)

--- a/projects/mail.py
+++ b/projects/mail.py
@@ -56,8 +56,8 @@ def send(subject, body=None, to=None, threaded=None, **kwargs):
             gw.debug("Missing one or more required email configuration details.")
             return "Missing email configuration details."
 
-        # Construct the MIMEText message
-        msg = MIMEText(body)
+        # Construct the MIMEText message with explicit UTF-8 encoding
+        msg = MIMEText(body, _charset="utf-8")
         msg['Subject'] = gw.resolve(subject)
         msg['From']    = sender_email
         msg['To']      = _to

--- a/tests/test_mail_send_utf8.py
+++ b/tests/test_mail_send_utf8.py
@@ -1,0 +1,45 @@
+import unittest
+import os
+from unittest.mock import patch
+from email.header import decode_header, make_header
+from gway import gw
+
+class FakeSMTP:
+    instances = []
+    def __init__(self, server, port):
+        self.server = server
+        self.port = port
+        FakeSMTP.instances.append(self)
+    def starttls(self):
+        pass
+    def login(self, user, password):
+        pass
+    def send_message(self, msg):
+        self.message = msg
+    def quit(self):
+        pass
+
+class MailSendUTF8Tests(unittest.TestCase):
+    def setUp(self):
+        os.environ['MAIL_SENDER'] = 'test@example.com'
+        os.environ['MAIL_PASSWORD'] = 'secret'
+        os.environ['SMTP_SERVER'] = 'smtp.example.com'
+        os.environ['SMTP_PORT'] = '587'
+        FakeSMTP.instances.clear()
+
+    def tearDown(self):
+        for var in ['MAIL_SENDER','MAIL_PASSWORD','SMTP_SERVER','SMTP_PORT']:
+            os.environ.pop(var, None)
+
+    def test_send_utf8_subject_and_body(self):
+        with patch('smtplib.SMTP', FakeSMTP):
+            result = gw.mail.send('Suj\u00e9', 'Cuerpo con acci\u00f3n', to='a@example.com', threaded=False)
+            self.assertEqual(result, 'Email sent successfully to a@example.com')
+            fake = FakeSMTP.instances[0]
+            subject = str(make_header(decode_header(fake.message['Subject'])))
+            self.assertEqual(subject, 'Suj\u00e9')
+            body = fake.message.get_payload(decode=True).decode('utf-8')
+            self.assertEqual(body, 'Cuerpo con acci\u00f3n')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure mails are created with UTF‑8 encoded bodies so accented characters work
- ignore coverage database in git
- test mail sending with accented characters

## Testing
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686f3e143b8883269991601d25cc9faf