### PR TITLE
Enable project setup hooks in web app

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ next non-indented command.
    # Configure multiple projects
    web app setup-app:
        --project web.site --home reader
-       --project web.nav
+       --project web.nav --style random
        --project games.qpig --home qpig-farm
 
    # Start the server

--- a/data/static/web/README.rst
+++ b/data/static/web/README.rst
@@ -3,6 +3,9 @@ Web Project Notes
 
 * `setup_app` can be invoked multiple times. Each call adds routes and homes for a single project.
 * Routes are registered with `add_route`, which skips duplicates so repeated setups won't register the same handler twice.
+* If the added project defines its own ``setup_app`` function, it is invoked with the app object.
+* Extra keyword arguments are passed to that project's ``setup_app``. If no such function exists, the unused argument names are logged as an error.
+* ``web.nav`` supports ``--style`` to force a theme; pass ``random`` to pick a different theme each request.
 * When reusing `setup_app`, provide unique paths or homes to avoid collisions.
 * CLI flags resolve to a single value. Lists like ``--home a,b,c`` are not supported. Call the command once per value instead.
 * `web.site.view_reader` serves ``.md`` or ``.rst`` files from the resource root and can be used for a lightweight blog. Subfolders and hidden files are not allowed.

--- a/data/static/web/nav/README.rst
+++ b/data/static/web/nav/README.rst
@@ -2,3 +2,7 @@ Web Navigation
 --------------
 
 JavaScript helpers for responsive navigation menus.
+
+``web.nav`` accepts a ``--style`` parameter during setup to select the
+initial theme without exposing the style switcher. Use ``--style random``
+to pick a random theme on each request.

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -81,6 +81,7 @@ def setup_app(*,
     js="global",            # Default JS  (without .js extension)
     auth="disabled",       # Accept "optional"/"disabled" words to disable
     engine="bottle",
+    **setup_kwargs,
 ):
     """
     Setup Bottle web application with symmetrical static/shared public folders.
@@ -406,6 +407,21 @@ def setup_app(*,
     if gw.verbose:
         gw.info(f"Registered homes: {_homes}")
         debug_routes(app)
+
+    # --- Call project-level setup_app if defined ---
+    project_setup = getattr(source, "setup_app", None)
+    if callable(project_setup) and project_setup is not setup_app:
+        gw.verbose(f"Delegating to {project}.setup_app")
+        try:
+            maybe_app = project_setup(app=app, **setup_kwargs)
+            if maybe_app is not None:
+                app = maybe_app
+        except Exception as exc:
+            gw.warn(f"{project}.setup_app failed: {exc}")
+    elif setup_kwargs:
+        gw.error(
+            f"Extra setup arguments ignored for {project}: {', '.join(setup_kwargs.keys())}"
+        )
 
     return oapp if oapp else app
 

--- a/recipes/skeleton.gwr
+++ b/recipes/skeleton.gwr
@@ -2,7 +2,7 @@
 
 web app setup-app:
     --project web.site --home reader
-    --project web.nav
+    --project web.nav --style random
     --project cdv --home data-editor
 web:
  - static collect

--- a/tests/test_nav_active_style.py
+++ b/tests/test_nav_active_style.py
@@ -82,6 +82,15 @@ class ActiveStyleTests(unittest.TestCase):
         result = nav.active_style()
         self.assertEqual(result, "/static/styles/classic-95.css")
 
+    def test_random_forced_style(self):
+        with mock.patch.object(nav.random, "choice", return_value=("global", "dark-material.css")) as mock_choice:
+            nav.setup_app(style="random")
+            nav.gw.web.cookies.store = {}
+            nav.request = FakeRequest({})
+            result = nav.active_style()
+            self.assertEqual(result, "/static/styles/dark-material.css")
+            mock_choice.assert_called_once()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- call a project's `setup_app()` when configuring the web app
- document automatic hook in web README
- forward extra keyword arguments to the project's `setup_app` and log an error if unused
- allow `web.nav` to set a style via `--style`
- set `classic-95.css` as the skeleton recipe's theme
- support `random` style selection for `web.nav`
- default skeleton recipe and example now use `--style random`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686f186c31fc8326b9b5c21e01dcd17b