### PR TITLE
Fix AWG conduit lookup error

### DIFF
--- a/projects/awg.py
+++ b/projects/awg.py
@@ -232,7 +232,7 @@ def find_conduit(awg, cables, *, conduit="emt"):
         cursor.execute(sql, {"conduit": conduit, "cables": cables})
         rows = cursor.fetchall()
         if not rows:
-            return {"trade_size": "n/a"}
+            return {"size_inch": "n/a"}
 
         def _to_float(value: str) -> float:
             total = 0.0


### PR DESCRIPTION
## Summary
- avoid KeyError from awg.find_conduit when no conduit entry is found

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686f3f477c1483268c35e0a7e6ebc054