### PR TITLE
Handle missing project lookups quietly

### DIFF
--- a/gway/gateway.py
+++ b/gway/gateway.py
@@ -321,6 +321,10 @@ class Gateway(Resolver, Runner):
         try:
             project_obj = self.load_project(project_name=name)
             return project_obj
+        except FileNotFoundError as e:
+            # Avoid noisy stack traces for expected missing modules
+            self.debug(f"Project not found for attribute '{name}': {e}")
+            raise AttributeError(f"Unable to find GWAY attribute ({str(e)})")
         except Exception as e:
             self.exception(e)
             raise AttributeError(f"Unable to find GWAY attribute ({str(e)})")


### PR DESCRIPTION
## Summary
- avoid noisy stack traces when a project doesn't exist

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686fc24906a483269bf924a0c7808fa7