### PR TITLE
Add link back for debug unauthorized page

### DIFF
--- a/projects/web/error.py
+++ b/projects/web/error.py
@@ -8,7 +8,8 @@ def view_debug_error(
     message="An error occurred.",
     err=None,
     status=500,
-    default=None
+    default=None,
+    extra=None
 ):
     """
     Render a debug error view with detailed traceback and request info.
@@ -21,6 +22,7 @@ def view_debug_error(
     if err:
         tb_str = "".join(traceback.format_exception(type(err), err, getattr(err, "__traceback__", None)))
 
+    extra = extra or ""
     debug_content = f"""
     <html>
     <head>
@@ -51,6 +53,7 @@ def view_debug_error(
                 <div class="traceback">{html.escape(tb_str or '(no traceback)')}</div>
             </div>
         </div>
+        {extra}
         <div><a href="{html.escape(default or gw.web.app.default_home())}">&#8592; Back to home</a></div>
     </body>
     </html>
@@ -118,12 +121,16 @@ def unauthorized(message="Unauthorized: You do not have access to this resource.
 
     debug_enabled = bool(getattr(gw, "debug", False))
     if debug_enabled:
+        from bottle import request
+        import html
+        orig_link = f'<div><a href="{html.escape(request.url)}">Go to original page</a></div>'
         return view_debug_error(
             title="401 Unauthorized",
             message=message,
             err=err,
             status=401,
-            default=default
+            default=default,
+            extra=orig_link
         )
 
     # 401 with auth header = browser will prompt for password

--- a/tests/test_unauthorized_debug_link.py
+++ b/tests/test_unauthorized_debug_link.py
@@ -1,0 +1,24 @@
+import unittest
+from gway import gw
+from paste.fixture import TestApp
+
+class UnauthorizedDebugLinkTests(unittest.TestCase):
+    def setUp(self):
+        gw.update_modes(debug=True)
+        self.app = gw.web.app.setup_app(project="dummy")
+        # simple route that always triggers unauthorized
+        self.app.route('/unauth', callback=lambda: gw.web.error.unauthorized("Access denied"))
+        self.client = TestApp(self.app)
+
+    def tearDown(self):
+        gw.update_modes(debug=False)
+
+    def test_link_to_original_page_shown(self):
+        resp = self.client.get('/unauth', expect_errors=True)
+        self.assertEqual(resp.status, 401)
+        body = resp.body.decode()
+        self.assertIn('Go to original page', body)
+        self.assertIn('/unauth', body)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- include optional extra content in `view_debug_error`
- show original request link when unauthorized in debug mode
- add regression test for unauthorized link

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686fc47f118883269bda8f59c00de889