### PR TITLE
Add cookie-based message banner

### DIFF
--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -6,6 +6,7 @@ import bottle
 import json
 import datetime
 import time
+import html
 from bottle import Bottle, static_file, request, response, template, HTTPResponse
 from gway import gw
 
@@ -507,6 +508,8 @@ def render_template(*, title="GWAY", content="", css_files=None, js_files=None):
             </script>
         """
 
+    message_html = gw.web.message.render() if is_setup('web.message') else ""
+
     html = template("""<!DOCTYPE html>
         <html lang="en">
         <head>
@@ -519,7 +522,7 @@ def render_template(*, title="GWAY", content="", css_files=None, js_files=None):
         <body>
             <div class="page-wrap">
                 <div class="layout">
-                    {{!nav}}<main>{{!content}}</main>
+                    {{!nav}}<main>{{!message_html}}{{!content}}</main>
                 </div>
                 <footer><p>This website was <strong>built</strong>, <strong>tested</strong>
                     and <strong>released</strong> with <a href="https://arthexis.com">GWAY</a>

--- a/projects/web/cookies.py
+++ b/projects/web/cookies.py
@@ -80,6 +80,7 @@ def append(name: str, label: str, value: str, sep: str = "|") -> list:
     set(name, cookie_value)
     return items
 
+
 # --- Views ---
 
 def view_accept(*, next="/cookies/cookie-jar"):

--- a/projects/web/message.py
+++ b/projects/web/message.py
@@ -1,0 +1,66 @@
+# file: projects/web/message.py
+
+"""Cookie-backed message banner utilities."""
+
+import html
+import re
+from gway import gw
+
+
+def write(text: str, *, sep: str = "\n", max_messages: int = 4, max_len: int = 180) -> None:
+    """Store a short message in the ``message`` cookie if the project is enabled."""
+    app = getattr(gw.web, "app", None)
+    if not (app and getattr(app, "is_setup", lambda x: False)("web.message")):
+        gw.warning("web.message not enabled; message discarded")
+        return
+    if not (app.is_setup("web.cookies") and gw.web.cookies.accepted()):
+        gw.warning(f"Cannot store message without cookie consent: {text!r}")
+        return
+
+    if not isinstance(text, str):
+        text = str(text)
+    clean = re.sub(r"\s+", " ", text.strip())
+    clean = re.sub(r"[<>]", "", clean)
+    if len(clean) > max_len:
+        clean = clean[:max_len]
+    if not clean:
+        return
+
+    raw = gw.web.cookies.get("message", "") or ""
+    msgs = [m for m in raw.split(sep) if m]
+    msgs.append(clean)
+    if len(msgs) > max_messages:
+        msgs = msgs[-max_messages:]
+    gw.web.cookies.set("message", sep.join(msgs))
+
+
+def render(*, sep: str = "\n") -> str:
+    """Return HTML for any stored messages, or an empty string."""
+    app = getattr(gw.web, "app", None)
+    if not (app and getattr(app, "is_setup", lambda x: False)("web.message")):
+        return ""
+    if not app.is_setup("web.cookies"):
+        return ""
+    try:
+        raw_msg = gw.web.cookies.get("message", "")
+    except Exception:
+        raw_msg = ""
+    if not raw_msg:
+        return ""
+    parts = [html.escape(m.strip()) for m in raw_msg.split(sep) if m.strip()]
+    if not parts:
+        return ""
+    rows = "".join(f"<div>{p}</div>" for p in parts)
+    return (
+        "<div id='gw-message' style='background:#fffae6;color:#000;"
+        "border:2px solid #d69e00;padding:0.7em 1.6em 0.7em 1em;"
+        "margin-bottom:1em;position:relative;font-weight:bold;'>"
+        + rows +
+        "<a href='#' onclick=\"gwDismissMessage();return false;\" "
+        "style='position:absolute;top:0.2em;right:0.6em;color:#900;"
+        "text-decoration:none;font-size:1.2em;font-weight:bold;'>\u2715</a>"
+        "</div>"
+        "<script>function gwDismissMessage(){document.cookie='message=;path=/;"
+        "expires=Thu, 01 Jan 1970 00:00:00 GMT';var m=document.getElementById('gw-message');"
+        "if(m)m.style.display='none';}</script>"
+    )

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -8,6 +8,7 @@ web app setup-app:
     --project awg --home cable-finder
     --project web.nav --home style-switcher
     --project web.cookies --home cookie-jar
+    --project web.message
     --project vbox --home uploads
     --project ocpp.data --home charger-summary
     --project ocpp.csms --auth required --home charger-status

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -8,6 +8,7 @@ web app setup-app:
     --project awg --home cable-finder
     --project web.nav --home style-switcher
     --project web.cookies --home cookie-jar
+    --project web.message
     --project vbox --home uploads
     --project ocpp.csms --auth required --home charger-status
     --project ocpp.evcs --auth required --home cp-simulator

--- a/tests/test_cookies.py
+++ b/tests/test_cookies.py
@@ -98,5 +98,6 @@ class CookiesUtilTests(unittest.TestCase):
         del self.request.cookies['cookies_accepted']
         self.assertFalse(self.cookies.accepted())
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,0 +1,89 @@
+import unittest
+import importlib.util
+from pathlib import Path
+from unittest import mock
+
+
+class FakeRequest:
+    def __init__(self):
+        self.cookies = {}
+    def get_cookie(self, name, default=None):
+        return self.cookies.get(name, default)
+
+
+class FakeResponse:
+    def __init__(self):
+        self.set_calls = []
+    def set_cookie(self, name, value, **kwargs):
+        self.set_calls.append((name, value, kwargs))
+
+
+class FakeApp:
+    def __init__(self, message=True, cookies=True):
+        self._message = message
+        self._cookies = cookies
+    def is_setup(self, name):
+        if name == 'web.message':
+            return self._message
+        if name == 'web.cookies':
+            return self._cookies
+        return False
+
+
+class MessageTests(unittest.TestCase):
+    @staticmethod
+    def _load_module(rel):
+        path = Path(__file__).resolve().parents[1] / 'projects' / 'web' / rel
+        spec = importlib.util.spec_from_file_location(rel.replace('.py',''), path)
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        return mod
+
+    @classmethod
+    def setUpClass(cls):
+        cls.message = cls._load_module('message.py')
+        cls.cookies = cls._load_module('cookies.py')
+
+    def setUp(self):
+        self.request = FakeRequest()
+        self.response = FakeResponse()
+        # patch cookies request/response
+        self.preq = mock.patch.object(self.cookies, 'request', self.request)
+        self.pres = mock.patch.object(self.cookies, 'response', self.response)
+        self.preq.start()
+        self.pres.start()
+        # patch gw.web modules
+        self.orig_app = self.message.gw.web.app
+        self.orig_cookies = self.message.gw.web.cookies
+        self.message.gw.web.app = FakeApp(message=True, cookies=True)
+        self.message.gw.web.cookies = self.cookies
+
+    def tearDown(self):
+        self.preq.stop()
+        self.pres.stop()
+        self.message.gw.web.app = self.orig_app
+        self.message.gw.web.cookies = self.orig_cookies
+
+    def test_write_appends_and_limits(self):
+        self.request.cookies['cookies_accepted'] = 'yes'
+        for i in range(5):
+            self.message.write(f'm{i}')
+            self.request.cookies['message'] = self.response.set_calls[-1][1]
+        value = self.cookies.get('message')
+        self.assertEqual(value.split('\n'), ['m1', 'm2', 'm3', 'm4'])
+
+    def test_write_noop_without_consent(self):
+        self.message.write('hi')
+        self.assertIsNone(self.cookies.get('message'))
+        self.assertEqual(self.response.set_calls, [])
+
+    def test_write_noop_when_disabled(self):
+        self.request.cookies['cookies_accepted'] = 'yes'
+        self.message.gw.web.app = FakeApp(message=False, cookies=True)
+        self.message.write('hello')
+        self.assertIsNone(self.cookies.get('message'))
+        self.assertEqual(self.response.set_calls, [])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract message cookie handling into new `web.message` project
- call `gw.web.message.render()` from the main template
- add message project to website recipes
- update cookie utilities tests and new message tests

## Testing
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686fc7c9003083268100cb39fcf96a6f