### PR TITLE
Fix text input styles for classic-95

### DIFF
--- a/data/static/styles/classic-95.css
+++ b/data/static/styles/classic-95.css
@@ -35,7 +35,8 @@ h1, h2, h3, h4 {
 }
 
 .search-box input[type="text"],
-input[type="text"], input[type="password"], input[type="email"], textarea {
+input:not([type="submit"]):not([type="button"]):not([type="checkbox"]):not([type="radio"]),
+textarea {
     background-color: #ffffff;
     color: #000000;
     border: 2px inset #fff;

--- a/data/static/styles/glitch-punk.css
+++ b/data/static/styles/glitch-punk.css
@@ -159,12 +159,7 @@ code {
 }
 
 /* Inputs */
-input[type="text"],
-input[type="email"],
-input[type="password"],
-input[type="search"],
-input[type="number"],
-input[type="url"],
+input:not([type="submit"]):not([type="button"]):not([type="checkbox"]):not([type="radio"]),
 textarea,
 select {
   background: #13131a;


### PR DESCRIPTION
## Summary
- fix text input styling for the classic-95 theme
- ensure glitch-punk theme styles text inputs without relying on explicit type

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_686fcd7889008326a5db511d7d7d82cb