### PR TITLE
Add GitHub hub module and token resolver

### DIFF
--- a/projects/hub.py
+++ b/projects/hub.py
@@ -1,0 +1,99 @@
+# file: projects/hub.py
+
+"""Utilities for interacting with GitHub and the local git repository."""
+
+from gway import gw
+
+
+def get_token(default=None):
+    """Return the first configured GitHub token found."""
+    return gw.resolve("[GITHUB_TOKEN]", "[GH_TOKEN]", "[REPO_TOKEN]", default=default)
+
+
+def create_issue(title: str, body: str, *, repo: str = "arthexis/gway") -> str:
+    """Create an issue in the given repository and return its URL."""
+    import requests
+
+    token = get_token()
+    if not token:
+        raise RuntimeError("GitHub token not configured")
+
+    url = f"https://api.github.com/repos/{repo}/issues"
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "gway-feedback",
+        "Accept": "application/vnd.github+json",
+    }
+    resp = requests.post(url, json={"title": title, "body": body}, headers=headers, timeout=10)
+    if resp.status_code != 201:
+        raise RuntimeError(f"GitHub API error: {resp.status_code} {resp.text}")
+    data = resp.json()
+    return data.get("html_url", "")
+
+
+def commit(length: int = 6) -> str:
+    """Return the current git commit hash (optionally truncated)."""
+    import subprocess
+
+    try:
+        full = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"], text=True, stderr=subprocess.DEVNULL
+        ).strip()
+        return full[-length:] if length else full
+    except Exception:
+        return "unknown"
+
+
+def get_build(length: int = 6) -> str:
+    """Return the build hash stored in the BUILD file."""
+    from pathlib import Path
+
+    build_path = Path("BUILD")
+    if build_path.exists():
+        commit_hash = build_path.read_text().strip()
+        return commit_hash[-length:] if length else commit_hash
+    gw.warning("BUILD file not found.")
+    return "unknown"
+
+
+def changes(*, files=None, staged=False, context=3, max_bytes=200_000, clip=False):
+    """Return a unified diff of recent textual changes in the git repository."""
+    import subprocess
+
+    cmd = ["git", "diff", f"--unified={context}"]
+    if staged:
+        cmd.insert(2, "--staged")
+    if files:
+        if isinstance(files, str):
+            files = [files]
+        cmd += list(files)
+
+    try:
+        diff = subprocess.check_output(cmd, encoding="utf-8", errors="replace")
+    except subprocess.CalledProcessError as e:
+        return f"[ERROR] Unable to get git diff: {e}"
+    except FileNotFoundError:
+        return "[ERROR] git command not found. Are you in a git repo?"
+
+    filtered = []
+    skip = False
+    for line in diff.splitlines(keepends=True):
+        if line.startswith("Binary files "):
+            continue
+        if line.startswith("diff --git"):
+            skip = False
+        if "GIT binary patch" in line:
+            skip = True
+        if skip:
+            continue
+        filtered.append(line)
+
+    result = "".join(filtered)
+    if len(result) > max_bytes:
+        result = result[:max_bytes] + f"\n[...Diff truncated at {max_bytes} bytes...]"
+
+    if clip:
+        gw.clip.copy(result)
+    if not gw.silent:
+        return result or "[No changes detected]"
+

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -451,7 +451,7 @@ def render_template(*, title="GWAY", content="", css_files=None, js_files=None):
     build = ""
     if getattr(gw, "debug_enabled", False):
         try:
-            build = f" Build: {gw.release.commit()}"
+            build = f" Build: {gw.hub.commit()}"
         except Exception:
             build = ""
 

--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -457,22 +457,7 @@ def view_qr_code(*args, value=None, **kwargs):
 
 def _create_github_issue(title: str, body: str) -> str:
     """Create an issue in the GWAY repository and return the issue URL."""
-    import requests
-    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
-    if not token:
-        raise RuntimeError("GitHub token not configured")
-
-    url = "https://api.github.com/repos/arthexis/gway/issues"
-    headers = {
-        "Authorization": f"token {token}",
-        "User-Agent": "gway-feedback",
-        "Accept": "application/vnd.github+json",
-    }
-    resp = requests.post(url, json={"title": title, "body": body}, headers=headers, timeout=10)
-    if resp.status_code != 201:
-        raise RuntimeError(f"GitHub API error: {resp.status_code} {resp.text}")
-    data = resp.json()
-    return data.get("html_url", "")
+    return gw.hub.create_issue(title, body)
 
 
 def view_feedback(*, name=None, email=None, topic=None, message=None, create_issue=None):
@@ -539,7 +524,7 @@ def view_debug_info():
     info.append(f"<b>Method:</b> {_html.escape(request.method or '')}")
     info.append(f"<b>Version:</b> {_html.escape(gw.version())}")
     try:
-        commit = gw.release.commit()
+        commit = gw.hub.commit()
         if commit:
             info.append(f"<b>Commit:</b> {_html.escape(commit)}")
     except Exception:

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -22,7 +22,7 @@ class FeedbackViewTests(unittest.TestCase):
             def __init__(self):
                 self.method = "POST"
         with patch('bottle.request', FakeRequest()):
-            with patch.dict(os.environ, {'GH_TOKEN': 'x'}):
+            with patch.dict(os.environ, {'GITHUB_TOKEN': 'x'}):
                 with patch('requests.post') as p:
                     p.return_value.status_code = 201
                     p.return_value.json.return_value = {'html_url': 'http://example.com'}
@@ -37,7 +37,7 @@ class FeedbackViewTests(unittest.TestCase):
             def __init__(self):
                 self.method = "POST"
         with patch('bottle.request', FakeRequest()):
-            with patch.dict(os.environ, {'GH_TOKEN': 'x'}):
+            with patch.dict(os.environ, {'GITHUB_TOKEN': 'x'}):
                 with patch('requests.post') as p:
                     with patch.object(gw.mail, 'send') as mail_send:
                         html = site.view_feedback(name='A', email='a@example.com', topic='Test', message='Hello')

--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -1,0 +1,31 @@
+import unittest
+from unittest.mock import patch
+import os
+from gway import gw
+
+class HubGithubTokenTests(unittest.TestCase):
+    def test_get_token_priority(self):
+        with patch.dict(os.environ, {}, clear=True):
+            self.assertIsNone(gw.hub.get_token())
+        with patch.dict(os.environ, {'REPO_TOKEN': 'a'}):
+            self.assertEqual(gw.hub.get_token(), 'a')
+        with patch.dict(os.environ, {'GH_TOKEN': 'b', 'REPO_TOKEN': 'a'}):
+            self.assertEqual(gw.hub.get_token(), 'b')
+        with patch.dict(os.environ, {'GITHUB_TOKEN': 'c', 'GH_TOKEN': 'b', 'REPO_TOKEN': 'a'}):
+            self.assertEqual(gw.hub.get_token(), 'c')
+
+
+class HubGitHelpersTests(unittest.TestCase):
+    def test_commit_and_build_helpers(self):
+        commit = gw.hub.commit()
+        self.assertTrue(isinstance(commit, str) and len(commit) == 6)
+
+        build = gw.hub.get_build()
+        self.assertTrue(isinstance(build, str) and len(build) == 6)
+
+    def test_changes_runs(self):
+        diff = gw.hub.changes(max_bytes=10)
+        self.assertIsInstance(diff, str)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new `hub` project for GitHub utilities
- centralize GitHub token resolution and issue creation
- move git helper functions from `release` to `hub`
- update feedback site and app to use new helpers
- add additional hub tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686fff9f44888326b57c1b092587c83c