### PR TITLE
Fix feedback checkbox alignment

### DIFF
--- a/data/static/base.css
+++ b/data/static/base.css
@@ -192,6 +192,21 @@ input, textarea, select {
     font-family: inherit;
     box-sizing: border-box;
 }
+input[type="checkbox"], input[type="radio"] {
+    width: auto;
+}
+label.checkbox-right {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    margin-bottom: 1em;
+}
+
+button.btn-block {
+    display: block;
+    width: 100%;
+}
 select {
     background: #fff;
     appearance: none;

--- a/data/static/styles/base.css
+++ b/data/static/styles/base.css
@@ -193,6 +193,18 @@ input, textarea, select {
 input[type="checkbox"], input[type="radio"] {
     width: auto;
 }
+label.checkbox-right {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    margin-bottom: 1em;
+}
+
+button.btn-block {
+    display: block;
+    width: 100%;
+}
 select {
     background: #fff;
     appearance: none;

--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -523,8 +523,11 @@ def view_feedback(*, name=None, email=None, topic=None, message=None, create_iss
             <input type="email" name="email" placeholder="Email" required class="main" />
             <input type="text" name="topic" placeholder="Topic" required class="main" />
             <textarea name="message" placeholder="Message" required rows="6" class="main"></textarea>
-            <label><input type="checkbox" name="create_issue" value="1" /> Optional: Create an Issue Report for GWAY or this website.</label>
-            <button type="submit" class="submit">Submit</button>
+            <label class="checkbox-right">
+                Optional: Create an Issue Report for GWAY or this website.
+                <input type="checkbox" name="create_issue" value="1" />
+            </label>
+            <button type="submit" class="submit btn-block">Submit</button>
         </form>
     """
 


### PR DESCRIPTION
## Summary
- move feedback checkbox to right side of label
- add a helper CSS class to anchor checkbox
- style the button so it sits on its own row

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687006466b4c8326ac2410971069287d