### PR TITLE
Add shell autocompletion support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,19 @@ framework itself clone the repository and install it in editable mode:
    pip install -r requirements.txt
    pip install -e .
 
+Shell Autocompletion
+--------------------
+
+GWAY uses ``argcomplete`` to offer optional tab completion. Install the
+package and register the completion script for your shell::
+
+   pip install argcomplete
+   register-python-argcomplete gway >> ~/.bashrc
+
+For PowerShell::
+
+   register-python-argcomplete gway -s powershell | Out-String | Invoke-Expression
+
 Core Concepts
 -------------
 

--- a/gway/console.py
+++ b/gway/console.py
@@ -6,6 +6,7 @@ import json
 import time
 import inspect
 import argparse
+import argcomplete
 import csv
 from typing import get_origin, get_args, Literal, Union
 
@@ -36,6 +37,7 @@ def cli_main():
     add("-z", dest="silent", action="store_true", help="Suppress all non-critical output")
     add("commands", nargs=argparse.REMAINDER, help="Project/Function command(s)")
 
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
 
     # Setup logging

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Software Project Infrastructure by https://www.gelectriic.com"
 requires-python = ">=3.10"
 license = "MIT"
 classifiers = [ "Programming Language :: Python :: 3", "Operating System :: OS Independent",]
-dependencies = [ "toml", "setuptools", "twine", "build", "colorama", "bottle", "paste", "requests", "dateparser", "fastapi", "uvicorn", "docutils", "croniter", "qrcode[pil]", "cryptography", "jinja2", "pygame", "python-multipart", "httpx", "websockets", "pyperclip; platform_system == \"Windows\"", "plyer", "numpy", "pygetwindow; platform_system == \"Windows\"", "duckdb", "pywin32; platform_system == \"Windows\"", "selenium", "webdriver-manager", "bs4", "markdown", "pandas", "openpyxl", "coverage",]
+dependencies = [ "toml", "setuptools", "twine", "build", "colorama", "bottle", "paste", "requests", "dateparser", "fastapi", "uvicorn", "docutils", "croniter", "qrcode[pil]", "cryptography", "jinja2", "pygame", "python-multipart", "httpx", "websockets", "pyperclip; platform_system == \"Windows\"", "plyer", "numpy", "pygetwindow; platform_system == \"Windows\"", "duckdb", "pywin32; platform_system == \"Windows\"", "selenium", "webdriver-manager", "bs4", "markdown", "pandas", "openpyxl", "coverage", "argcomplete",]
 [[project.authors]]
 name = "Rafael J. Guillén-Osorio"
 email = "tecnologia@gelectriic.com"

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,3 +31,4 @@ markdown
 pandas
 openpyxl
 coverage
+argcomplete


### PR DESCRIPTION
## Summary
- enable CLI completion via argcomplete
- document how to register completion scripts
- add argcomplete to dependencies

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687026203e7c8326a35fcd110016decc