### PR TITLE
Implement view mashup routing

### DIFF
--- a/tests/test_view_mashup.py
+++ b/tests/test_view_mashup.py
@@ -1,0 +1,18 @@
+import unittest
+from gway import gw
+from paste.fixture import TestApp
+
+class ViewMashupTests(unittest.TestCase):
+    def setUp(self):
+        self.app = gw.web.app.setup_app(project="games")
+        self.client = TestApp(self.app)
+
+    def test_mashup_returns_combined_content(self):
+        resp = self.client.get("/games/massive-snake+game-of-life")
+        self.assertEqual(resp.status, 200)
+        text = resp.body.decode()
+        self.assertIn("Massive Snake", text)
+        self.assertIn("Game of Life", text)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support chaining views with `+` in `web.app.setup_app` dispatcher
- log a warning if any view returns a full document
- test mashup route using Massive Snake and Game of Life

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68703a525e1c83269f46e6ba7b9c1f32