### PR TITLE
Fix web path prefix handling

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -130,9 +130,9 @@ project with ``gw.web.app.setup`` and then launch the server using
 ``gw.web.server.start_app``. Routes of the form ``/project/view`` map to
 ``view_*`` functions and static files under ``data/static`` are served from
 ``/static``. ``web.site.view_reader`` renders ``.rst`` or ``.md`` files when
-you visit ``/site/reader/PATH``; it first checks the workspace root and
+you visit ``/web/site/reader/PATH``; it first checks the workspace root and
 then ``data/static`` automatically. See the `Web README
-</site/reader?tome=web>`_ for a more complete guide.
+</web/site/reader?tome=web>`_ for a more complete guide.
 
 Folder Structure
 ----------------
@@ -171,46 +171,46 @@ The following projects bundle additional documentation.  Each link uses
 ``data/static`` folder.
 
 
-- `awg </site/reader?tome=awg>`_
-- `cdv </site/reader?tome=cdv>`_
-- `games </site/reader?tome=games>`_
-  - `conway </site/reader?tome=games/conway>`_
-  - `mtg </site/reader?tome=games/mtg>`_
-  - `qpig </site/reader?tome=games/qpig>`_
-- `monitor </site/reader?tome=monitor>`_
-- `ocpp </site/reader?tome=ocpp>`_
-  - `csms </site/reader?tome=ocpp/csms>`_
-  - `evcs </site/reader?tome=ocpp/evcs>`_
-  - `data </site/reader?tome=ocpp/data>`_
-- `release </site/reader?tome=release>`_
-- `vbox </site/reader?tome=vbox>`_
-- `web </site/reader?tome=web>`_
-  - `nav </site/reader?tome=web/nav>`_
-  - `cookies </site/reader?tome=web/cookies>`_
-  - `auth </site/reader?tome=web/auth>`_
-  - `chat </site/reader?tome=web/chat>`_
+- `awg </web/site/reader?tome=awg>`_
+- `cdv </web/site/reader?tome=cdv>`_
+- `games </web/site/reader?tome=games>`_
+  - `conway </web/site/reader?tome=games/conway>`_
+  - `mtg </web/site/reader?tome=games/mtg>`_
+  - `qpig </web/site/reader?tome=games/qpig>`_
+- `monitor </web/site/reader?tome=monitor>`_
+- `ocpp </web/site/reader?tome=ocpp>`_
+  - `csms </web/site/reader?tome=ocpp/csms>`_
+  - `evcs </web/site/reader?tome=ocpp/evcs>`_
+  - `data </web/site/reader?tome=ocpp/data>`_
+- `release </web/site/reader?tome=release>`_
+- `vbox </web/site/reader?tome=vbox>`_
+- `web </web/site/reader?tome=web>`_
+  - `nav </web/site/reader?tome=web/nav>`_
+  - `cookies </web/site/reader?tome=web/cookies>`_
+  - `auth </web/site/reader?tome=web/auth>`_
+  - `chat </web/site/reader?tome=web/chat>`_
 
-.. _/site/reader?tome=awg: /site/reader?tome=awg
-.. _/site/reader?tome=cdv: /site/reader?tome=cdv
-.. _/site/reader?tome=games: /site/reader?tome=games
-.. _/site/reader?tome=games/conway: /site/reader?tome=games/conway
-.. _/site/reader?tome=games/mtg: /site/reader?tome=games/mtg
-.. _/site/reader?tome=games/qpig: /site/reader?tome=games/qpig
-.. _/site/reader?tome=monitor: /site/reader?tome=monitor
-.. _/site/reader?tome=ocpp: /site/reader?tome=ocpp
-.. _/site/reader?tome=ocpp/csms: /site/reader?tome=ocpp/csms
-.. _/site/reader?tome=ocpp/evcs: /site/reader?tome=ocpp/evcs
-.. _/site/reader?tome=ocpp/data: /site/reader?tome=ocpp/data
-.. _/site/reader?tome=release: /site/reader?tome=release
-.. _/site/reader?tome=vbox: /site/reader?tome=vbox
-.. _/site/reader?tome=web: /site/reader?tome=web
-.. _/site/reader?tome=web/nav: /site/reader?tome=web/nav
-.. _/site/reader?tome=web/cookies: /site/reader?tome=web/cookies
-.. _/site/reader?tome=web/auth: /site/reader?tome=web/auth
-.. _/site/reader?tome=web/chat: /site/reader?tome=web/chat
+.. _/web/site/reader?tome=awg: /web/site/reader?tome=awg
+.. _/web/site/reader?tome=cdv: /web/site/reader?tome=cdv
+.. _/web/site/reader?tome=games: /web/site/reader?tome=games
+.. _/web/site/reader?tome=games/conway: /web/site/reader?tome=games/conway
+.. _/web/site/reader?tome=games/mtg: /web/site/reader?tome=games/mtg
+.. _/web/site/reader?tome=games/qpig: /web/site/reader?tome=games/qpig
+.. _/web/site/reader?tome=monitor: /web/site/reader?tome=monitor
+.. _/web/site/reader?tome=ocpp: /web/site/reader?tome=ocpp
+.. _/web/site/reader?tome=ocpp/csms: /web/site/reader?tome=ocpp/csms
+.. _/web/site/reader?tome=ocpp/evcs: /web/site/reader?tome=ocpp/evcs
+.. _/web/site/reader?tome=ocpp/data: /web/site/reader?tome=ocpp/data
+.. _/web/site/reader?tome=release: /web/site/reader?tome=release
+.. _/web/site/reader?tome=vbox: /web/site/reader?tome=vbox
+.. _/web/site/reader?tome=web: /web/site/reader?tome=web
+.. _/web/site/reader?tome=web/nav: /web/site/reader?tome=web/nav
+.. _/web/site/reader?tome=web/cookies: /web/site/reader?tome=web/cookies
+.. _/web/site/reader?tome=web/auth: /web/site/reader?tome=web/auth
+.. _/web/site/reader?tome=web/chat: /web/site/reader?tome=web/chat
 
 You can generate these links yourself with
-``gw.web.build_url('site/reader', tome='proj')``.
+``gw.web.build_url('web/site/reader', tome='proj')``.
 
 License
 -------

--- a/data/static/web/README.rst
+++ b/data/static/web/README.rst
@@ -32,7 +32,7 @@ For example, to embed the ``reader`` page:
 
 .. code-block:: html
 
-   <iframe src="https://your.domain.com/render/site/reader?title=README"></iframe>
+   <iframe src="https://your.domain.com/render/web/site/reader?title=README"></iframe>
 
 Only self-contained views display correctly when framed.
 

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -120,11 +120,9 @@ def setup_app(*,
     # Track project for later global static collection
     _enabled.add(project)
 
-    # Default path is the dotted project name, minus any leading web/
+    # Default path is the dotted project name
     if path is None:
         path = project.replace('.', '/')
-        if path.startswith('web/'):
-            path = path.removeprefix('web/')
             
     oapp = app
     match app:
@@ -538,7 +536,7 @@ def render_template(*, title="GWAY", content="", css_files=None, js_files=None):
                 var close=document.getElementById('gw-debug-close');
                 function show(){
                     overlay.style.display='block';
-                    fetch('/render/site/debug_info').then(r=>r.text()).then(t=>{document.getElementById('gw-debug-content').innerHTML=t;});
+                    fetch('/render/web/site/debug_info').then(r=>r.text()).then(t=>{document.getElementById('gw-debug-content').innerHTML=t;});
                 }
                 btn.addEventListener('click',function(e){e.preventDefault();show();});
                 close.addEventListener('click',function(e){e.preventDefault();overlay.style.display='none';});
@@ -580,7 +578,7 @@ def default_home():
     for _, route in _homes:
         if route:
             return "/" + route.lstrip("/")
-    return "/site/reader"
+    return "/web/site/reader"
 
 def debug_routes(app):
     for route in app.routes:

--- a/projects/web/cookies.py
+++ b/projects/web/cookies.py
@@ -83,13 +83,13 @@ def append(name: str, label: str, value: str, sep: str = "|") -> list:
 
 # --- Views ---
 
-def view_accept(*, next="/cookies/cookie-jar"):
+def view_accept(*, next="/web/cookies/cookie-jar"):
     set("cookies_accepted", "yes")
     response.status = 303
     response.set_header("Location", next)
     return ""
 
-def view_remove(*, next="/cookies/cookie-jar", confirm = False):
+def view_remove(*, next="/web/cookies/cookie-jar", confirm = False):
     # Only proceed if the confirmation checkbox was passed in the form
     if not confirm:
         response.status = 303
@@ -118,7 +118,7 @@ def view_cookie_jar(*, eat=None):
                 eaten_count = 0
             set("cookies_eaten", str(eaten_count + 1))
             response.status = 303
-            response.set_header("Location", "/cookies/cookie-jar")
+            response.set_header("Location", "/web/cookies/cookie-jar")
             return ""
 
     def describe_cookie(key, value):
@@ -128,7 +128,7 @@ def view_cookie_jar(*, eat=None):
         x_link = ""
         if not protected:
             x_link = (
-                f" <a href='/cookies/cookie-jar?eat={key}' "
+                f" <a href='/web/cookies/cookie-jar?eat={key}' "
                 "style='color:#a00;text-decoration:none;font-weight:bold;font-size:1.1em;margin-left:0.5em;' "
                 "title='Remove this cookie' onclick=\"return confirm('Remove cookie: {0}?');\">[X]</a>".format(key)
             )
@@ -155,7 +155,7 @@ def view_cookie_jar(*, eat=None):
         on this site will not be recorded, but your interaction may also be limited.</p>
         <p>This restriction exists because some functionality (like navigation history,
         styling preferences, or shopping carts) depends on cookies.</p>
-        <form method="POST" action="/cookies/accept" style="margin-top: 2em;">
+        <form method="POST" action="/web/cookies/accept" style="margin-top: 2em;">
             <button type="submit" style="font-size:1.2em; padding:0.5em 2em;">Accept our cookies</button>
         </form>
         """
@@ -168,7 +168,7 @@ def view_cookie_jar(*, eat=None):
         cookies_html = "<ul>" + "".join(stored) + "</ul>" if stored else "<p>No stored cookies found.</p>"
 
         removal_form = """
-            <form method="POST" action="/cookies/remove" style="margin-top:2em;">
+            <form method="POST" action="/web/cookies/remove" style="margin-top:2em;">
                 <div style="display: flex; align-items: center; margin-bottom: 1em; gap: 0.5em;">
                     <input type="checkbox" id="confirm" name="confirm" value="1" required
                         style="width:1.2em; height:1.2em; vertical-align:middle; margin:0;" />

--- a/projects/web/nav.py
+++ b/projects/web/nav.py
@@ -81,7 +81,7 @@ def render(*, homes=None, links=None):
 
     # --- Search box ---
     search_box = '''
-        <form action="/site/help" method="get" class="nav">
+        <form action="/web/site/help" method="get" class="nav">
             <textarea name="topic" id="help-search"
                 placeholder="Search this GWAY"
                 class="help" rows="1"
@@ -369,13 +369,13 @@ def style_selector_form(all_styles, selected_style, cookies_enabled, cookies_acc
 
     info = ""
     if cookies_enabled and not cookies_accepted:
-        info = "<p><b><a href='/cookies/cookie-jar'>Accept cookies to save your style preference.</a></b></p>"
+        info = "<p><b><a href='/web/cookies/cookie-jar'>Accept cookies to save your style preference.</a></b></p>"
 
     # No JS redirect actually needed.
     if cookies_enabled and cookies_accepted:
         return f"""
             {info}
-            <form method="post" action="/nav/style-switcher" class="style-form" style="margin-bottom: 0.5em">
+            <form method="post" action="/web/nav/style-switcher" class="style-form" style="margin-bottom: 0.5em">
                 <select id="css-style" name="css" class="style-selector" style="width:100%" onchange="this.form.submit()">
                     {''.join(options)}
                 </select>

--- a/tests/test_auth_charger.py
+++ b/tests/test_auth_charger.py
@@ -100,17 +100,17 @@ class AuthChargerStatusTests(unittest.TestCase):
         self.assertIn("OCPP", resp.text)
 
     def test_cookie_jar_no_auth_required(self):
-        url = self.base_url + "/cookies/cookie-jar"
+        url = self.base_url + "/web/cookies/cookie-jar"
         resp = requests.get(url)
         self.assertEqual(
             resp.status_code, 200,
-            f"Expected 200 for unauthenticated /cookies/cookie-jar, got {resp.status_code}"
+            f"Expected 200 for unauthenticated /web/cookies/cookie-jar, got {resp.status_code}"
         )
         headers = self._auth_header(TEST_USER, TEST_PASS)
         resp2 = requests.get(url, headers=headers)
         self.assertEqual(
             resp2.status_code, 200,
-            f"Expected 200 for authenticated /cookies/cookie-jar, got {resp2.status_code}"
+            f"Expected 200 for authenticated /web/cookies/cookie-jar, got {resp2.status_code}"
         )
         self.assertIn("cookie", resp2.text.lower())
 

--- a/tests/test_nav_styles.py
+++ b/tests/test_nav_styles.py
@@ -56,7 +56,7 @@ class NavStyleTests(unittest.TestCase):
 
     def test_one_theme_css_link_in_head(self):
         """Ensure exactly one active theme CSS link in <head> and it's the correct one."""
-        soup, _ = self._get_soup(self.base_url + "/nav/style-switcher?css=dark-material.css")
+        soup, _ = self._get_soup(self.base_url + "/web/nav/style-switcher?css=dark-material.css")
         head = soup.head
         theme_links = [link for link in head.find_all('link', rel="stylesheet") if "styles" in link.get('href', '')]
         self.assertEqual(
@@ -70,7 +70,7 @@ class NavStyleTests(unittest.TestCase):
 
     def test_style_switcher_preview_injects_theme(self):
         """Style preview must inject the selected theme as a <link> for preview."""
-        soup, _ = self._get_soup(self.base_url + "/nav/style-switcher?css=palimpsesto.css")
+        soup, _ = self._get_soup(self.base_url + "/web/nav/style-switcher?css=palimpsesto.css")
         preview_links = [link for link in soup.find_all('link', rel="stylesheet") if "palimpsesto.css" in link.get('href', '')]
         self.assertTrue(preview_links, "Preview theme link for palimpsesto.css not found.")
         preview_div = soup.find('div', class_="style-preview")
@@ -82,10 +82,10 @@ class NavStyleTests(unittest.TestCase):
         """Test POST to change theme sets cookie and updates <head> <link>."""
         session = requests.Session()
         # Accept cookies
-        session.post(self.base_url + "/cookies/accept")
+        session.post(self.base_url + "/web/cookies/accept")
         # POST to set theme to classic-95.css
         resp = session.post(
-            self.base_url + "/nav/style-switcher",
+            self.base_url + "/web/nav/style-switcher",
             data={"css": "classic-95.css"},
             allow_redirects=True
         )
@@ -95,14 +95,14 @@ class NavStyleTests(unittest.TestCase):
             f"Theme change did not set css cookie, got cookies: {session.cookies.get_dict()}"
         )
         # Now reload style-switcher and check <head>
-        soup, _ = self._get_soup(self.base_url + "/nav/style-switcher", session)
+        soup, _ = self._get_soup(self.base_url + "/web/nav/style-switcher", session)
         head = soup.head
         links = [l for l in head.find_all('link', rel="stylesheet") if "classic-95.css" in l.get('href', '')]
         self.assertTrue(links, "Theme change did not update main <link> to classic-95.css")
 
     def test_sidebar_has_no_theme_link(self):
         """Sidebar should NOT contain a <link> for the current theme."""
-        resp = requests.get(self.base_url + "/nav/style-switcher")
+        resp = requests.get(self.base_url + "/web/nav/style-switcher")
         soup = BeautifulSoup(resp.text, "html.parser")
         aside = soup.find("aside")
         links = aside.find_all("link", rel="stylesheet") if aside else []
@@ -119,13 +119,13 @@ class NavStyleTests(unittest.TestCase):
         """
         session = requests.Session()
         # 1. Accept cookies (must be a POST)
-        resp = session.post(self.base_url + "/cookies/accept")
+        resp = session.post(self.base_url + "/web/cookies/accept")
         self.assertIn(
             "cookies_accepted", session.cookies.get_dict(),
             f"Did not set cookies_accepted cookie: {session.cookies.get_dict()}"
         )
         # 2. Visit style switcher and pick a theme
-        resp = session.get(self.base_url + "/nav/style-switcher")
+        resp = session.get(self.base_url + "/web/nav/style-switcher")
         soup = BeautifulSoup(resp.text, "html.parser")
         select = soup.find("select", id="css-style")
         assert select, "Could not find theme selector"
@@ -135,7 +135,7 @@ class NavStyleTests(unittest.TestCase):
 
         # 3. POST to switch theme
         resp = session.post(
-            self.base_url + "/nav/style-switcher",
+            self.base_url + "/web/nav/style-switcher",
             data={"css": "classic-95.css"},
             allow_redirects=True
         )
@@ -144,8 +144,8 @@ class NavStyleTests(unittest.TestCase):
             f"Theme change did not set css cookie, got cookies: {session.cookies.get_dict()}"
         )
 
-        # 4. Now visit /site/reader (or any other page)
-        resp2 = session.get(self.base_url + "/site/reader")
+        # 4. Now visit /web/site/reader (or any other page)
+        resp2 = session.get(self.base_url + "/web/site/reader")
         soup2 = BeautifulSoup(resp2.text, "html.parser")
         link = soup2.find("link", rel="stylesheet", href=lambda h: h and "classic-95.css" in h)
         self.assertIsNotNone(
@@ -155,9 +155,9 @@ class NavStyleTests(unittest.TestCase):
 
     def test_random_cookie_and_css_link(self):
         session = requests.Session()
-        session.post(self.base_url + "/cookies/accept")
+        session.post(self.base_url + "/web/cookies/accept")
         resp = session.post(
-            self.base_url + "/nav/style-switcher",
+            self.base_url + "/web/nav/style-switcher",
             data={"css": "random"},
             allow_redirects=True,
         )
@@ -165,7 +165,7 @@ class NavStyleTests(unittest.TestCase):
             session.cookies.get_dict().get("css"), "random",
             f"Random theme did not set cookie: {session.cookies.get_dict()}"
         )
-        resp2 = session.get(self.base_url + "/site/reader")
+        resp2 = session.get(self.base_url + "/web/site/reader")
         soup2 = BeautifulSoup(resp2.text, "html.parser")
         link = soup2.find("link", rel="stylesheet", href=lambda h: h and "styles/" in h and h.endswith(".css"))
         self.assertIsNotNone(link, "Page missing stylesheet link for random theme")
@@ -178,7 +178,7 @@ class NavStyleTests(unittest.TestCase):
         screenshot_file = screenshot_dir / "style_switcher.png"
         try:
             gw.web.auto.capture_page_source(
-                self.base_url + "/nav/style-switcher",
+                self.base_url + "/web/nav/style-switcher",
                 screenshot=str(screenshot_file),
             )
         except Exception as e:

--- a/tests/test_proxy_fallback.py
+++ b/tests/test_proxy_fallback.py
@@ -75,7 +75,7 @@ class ProxyFallbackTests(unittest.TestCase):
         self.assertTrue(os.path.isdir(records))
         self.assertTrue(os.listdir(records))
 
-        resp = requests.get("http://127.0.0.1:18888/cookies/cookie-jar")
+        resp = requests.get("http://127.0.0.1:18888/web/cookies/cookie-jar")
         self.assertNotEqual(resp.status_code, 200)
 
         self.__class__.remote_dir = tempfile.mkdtemp(prefix="remote_gw_")
@@ -88,7 +88,7 @@ class ProxyFallbackTests(unittest.TestCase):
         self._wait_for_port(19000, timeout=15)
         time.sleep(2)
 
-        resp2 = requests.get("http://127.0.0.1:18888/cookies/cookie-jar")
+        resp2 = requests.get("http://127.0.0.1:18888/web/cookies/cookie-jar")
         self.assertEqual(resp2.status_code, 200)
 
 

--- a/tests/test_screenshot_attachment.py
+++ b/tests/test_screenshot_attachment.py
@@ -46,7 +46,7 @@ class ScreenshotAttachmentTest(unittest.TestCase):
         screenshot_file = screenshot_dir / "help_page.png"
         try:
             gw.web.auto.capture_page_source(
-                self.base_url + "/site/help",
+                self.base_url + "/web/site/help",
                 screenshot=str(screenshot_file),
             )
         except Exception as e:

--- a/tests/test_site_help_auto.py
+++ b/tests/test_site_help_auto.py
@@ -46,7 +46,7 @@ class SiteHelpAutoTests(unittest.TestCase):
         raise TimeoutError(f"Port {port} not responding after {timeout} seconds")
 
     def test_help_search_finds_builtin(self):
-        url = self.base_url + "/site/help"
+        url = self.base_url + "/web/site/help"
         try:
             with gw.web.auto.browse(url=url) as drv:
                 textarea = drv.find_element(By.ID, "help-search")
@@ -63,7 +63,7 @@ class SiteHelpAutoTests(unittest.TestCase):
 
     def test_search_box_autoexpands(self):
         """Search box should grow taller when text wraps to new lines."""
-        url = self.base_url + "/site/help"
+        url = self.base_url + "/web/site/help"
         long_text = "word " * 50
         try:
             with gw.web.auto.browse(url=url) as drv:


### PR DESCRIPTION
## Summary
- keep `web` prefix when setting up apps so routes are stable
- update default home and debug overlay paths
- adjust nav search form URL
- update docs and tests for new `/web/site` paths
- fix remaining `/web` links in nav and cookies

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68703e91eec0832692aaa8d52e4beceb