### PR TITLE
Add release test cache view

### DIFF
--- a/data/static/tabs.css
+++ b/data/static/tabs.css
@@ -1,0 +1,52 @@
+/* file: data/static/tabs.css */
+.gw-tabs-bar {
+    display: flex;
+    border-bottom: 1.5px solid #bbb;
+    margin-bottom: 8px;
+    gap: 1px;
+}
+.gw-tab {
+    padding: 8px 18px 7px 18px;
+    cursor: pointer;
+    background: #eee;
+    border: none;
+    border-radius: 6px 6px 0 0;
+    margin-right: 3px;
+    font-weight: bold;
+    color: #555;
+    transition: background 0.18s;
+}
+.gw-tab.active,
+.gw-tab:hover {
+    background: #fff;
+    color: #000;
+    border-bottom: 1.5px solid #fff;
+}
+.gw-tab-block {
+    display: none;
+    border: 1.5px solid #ccc;
+    border-radius: 0 0 12px 12px;
+    padding: 16px 18px 14px 18px;
+    background: #fff;
+    margin-bottom: 20px;
+}
+.gw-tab-block.active {
+    display: block;
+}
+
+.gw-progress {
+    width: 100%;
+    background: #ddd;
+    border-radius: 6px;
+    overflow: hidden;
+    height: 14px;
+    margin-bottom: 12px;
+}
+.gw-progress-bar {
+    height: 100%;
+    background: #4caf50;
+    color: #fff;
+    font-size: 0.75em;
+    text-align: center;
+    white-space: nowrap;
+}

--- a/data/static/tabs.js
+++ b/data/static/tabs.js
@@ -1,0 +1,17 @@
+// file: data/static/tabs.js
+(function(){
+  document.addEventListener('DOMContentLoaded', function(){
+    document.querySelectorAll('.gw-tabs').forEach(function(box){
+      var tabs = box.querySelectorAll('.gw-tab');
+      var blocks = box.querySelectorAll('.gw-tab-block');
+      function activate(i){
+        tabs.forEach(function(t,idx){ t.classList.toggle('active', idx===i); });
+        blocks.forEach(function(b,idx){ b.classList.toggle('active', idx===i); });
+      }
+      tabs.forEach(function(tab,i){
+        tab.addEventListener('click', function(){ activate(i); });
+      });
+      if(tabs.length){ activate(0); }
+    });
+  });
+})();


### PR DESCRIPTION
## Summary
- create generic tabs style and script
- add background test runner in `release` project and expose `view_test_cache`
- start test suite with coverage when release app is set up

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68704e6e1f6083269c07d2468bd22a33