### PR TITLE
Add WhatsApp chat helper

### DIFF
--- a/data/static/web/chat/whats.rst
+++ b/data/static/web/chat/whats.rst
@@ -1,0 +1,13 @@
+WhatsApp Integration
+--------------------
+
+The ``web.chat.whats`` module provides helpers to send text messages using the
+`WhatsApp Cloud API <https://developers.facebook.com/docs/whatsapp>`_.
+
+Example::
+
+    gw.web.chat.whats.send_message("+15551234567", "Hello from GWAY")
+
+Set ``WHATS_TOKEN`` and ``WHATS_PHONE_ID`` environment variables with your
+Cloud API credentials. The ``api_post_send`` endpoint can be invoked via
+``/api/web/chat/whats/send`` once the web server is running.

--- a/projects/web/chat/whats.py
+++ b/projects/web/chat/whats.py
@@ -1,0 +1,56 @@
+# file: projects/web/chat/whats.py
+"""Minimal WhatsApp Cloud API helpers."""
+
+import os
+import requests
+from gway import gw
+
+
+def send_message(to: str, body: str, *, token: str | None = None, phone_id: str | None = None, preview_url: bool = False):
+    """Send a text message using the WhatsApp Cloud API.
+
+    Parameters
+    ----------
+    to : str
+        Destination phone number in international format ("+123...").
+    body : str
+        Text body to send.
+    token : str, optional
+        Access token. Defaults to ``WHATS_TOKEN`` environment variable.
+    phone_id : str, optional
+        Business phone number ID. Defaults to ``WHATS_PHONE_ID`` environment variable.
+    preview_url : bool, optional
+        Enable link preview in message body.
+
+    Returns
+    -------
+    dict
+        Parsed JSON response or ``{"error": ...}`` on failure.
+    """
+    token = token or os.environ.get("WHATS_TOKEN")
+    phone_id = phone_id or os.environ.get("WHATS_PHONE_ID")
+    if not token or not phone_id:
+        gw.error("WhatsApp credentials missing.")
+        return {"error": "Missing WhatsApp token or phone id."}
+
+    url = f"https://graph.facebook.com/v17.0/{phone_id}/messages"
+    headers = {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+    payload = {
+        "messaging_product": "whatsapp",
+        "to": to,
+        "type": "text",
+        "text": {"body": gw.resolve(body), "preview_url": bool(preview_url)},
+    }
+    try:
+        resp = requests.post(url, json=payload, headers=headers, timeout=30)
+        return resp.json()
+    except Exception as e:
+        gw.error(f"WhatsApp send error: {e}")
+        return {"error": str(e)}
+
+
+def api_post_send(*, to=None, body=None, preview_url=False, token=None, phone_id=None, **kwargs):
+    """POST /chat/whats/send - Send a WhatsApp message."""
+    if not (to and body):
+        return {"error": "'to' and 'body' are required"}
+    return send_message(str(to), str(body), token=token, phone_id=phone_id, preview_url=preview_url)

--- a/tests/test_whats.py
+++ b/tests/test_whats.py
@@ -1,0 +1,30 @@
+import unittest
+import os
+from unittest.mock import patch, MagicMock
+from gway import gw
+
+class WhatsAppSendTests(unittest.TestCase):
+    def setUp(self):
+        os.environ['WHATS_TOKEN'] = 'tkn'
+        os.environ['WHATS_PHONE_ID'] = '123'
+
+    def tearDown(self):
+        os.environ.pop('WHATS_TOKEN', None)
+        os.environ.pop('WHATS_PHONE_ID', None)
+
+    def test_send_message_calls_api(self):
+        fake_resp = MagicMock()
+        fake_resp.json.return_value = {'ok': True}
+        with patch('requests.post', return_value=fake_resp) as mock_post:
+            res = gw.web.chat.whats.send_message('+1', 'hi', preview_url=True)
+            self.assertEqual(res, {'ok': True})
+            mock_post.assert_called_once()
+
+    def test_missing_credentials_returns_error(self):
+        os.environ.pop('WHATS_TOKEN')
+        os.environ.pop('WHATS_PHONE_ID')
+        res = gw.web.chat.whats.send_message('+1', 'hi')
+        self.assertIn('error', res)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add basic WhatsApp Cloud API helpers under `web.chat.whats`
- document WhatsApp integration
- cover new helper with tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68704980c79c8326a0b035de55c73664