### PR TITLE
Rename Lookup Wars to Divination Wars

### DIFF
--- a/projects/games/games.py
+++ b/projects/games/games.py
@@ -34,7 +34,7 @@ _DEF = [
         "https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life",
     ),
     (
-        "Lookup Wars",
+        "Divination Wars",
         "search-games",
         "Look up Magic: The Gathering cards using the Scryfall API.",
         "https://en.wikipedia.org/wiki/Magic:_The_Gathering",

--- a/projects/games/mtg.py
+++ b/projects/games/mtg.py
@@ -12,27 +12,85 @@ NAME_SUGGESTIONS = [
     "Birds of Paradise", "Snapcaster Mage", "Brainstorm", "Thoughtseize", "Giant Growth",
     "Force of Will", "Serra Angel", "Tarmogoyf", "Jace, the Mind Sculptor", "Thragtusk",
     "Ugin, the Spirit Dragon", "Blood Moon", "Phyrexian Obliterator", "Walking Ballista",
+    # Additional options
+    "Mana Crypt", "Mox Pearl", "Mox Sapphire", "Ancestral Recall", "Time Walk",
+    "Counterspell", "Dark Confidant", "Liliana of the Veil", "Goblin Guide", "Vendilion Clique",
+    "Eternal Witness", "Stoneforge Mystic", "Ragavan, Nimble Pilferer", "Fury",
+    "Teferi, Time Raveler", "Mystic Snake", "Karn Liberated", "Primeval Titan",
+    "Treasure Cruise", "Wrenn and Six",
 ]
 TYPE_SUGGESTIONS = [
     "Creature", "Instant", "Artifact", "Planeswalker", "Sorcery", "Enchantment",
     "Land", "Legendary", "Vampire", "Goblin", "Angel", "Dragon", "Zombie", "Elf",
-    "Dinosaur", "Vehicle", "Saga", "God", "Giant", "Wizard",
+    "Dinosaur", "Vehicle", "Saga", "God", "Giant", "Wizard", "Snow", "Basic",
+    "Kindred",
+    # Additional options
+    "Human", "Cleric", "Rogue", "Warrior", "Merfolk", "Treefolk", "Kithkin", "Sliver",
+    "Beast", "Cat", "Druid", "Shaman", "Elemental", "Illusion", "Knight", "Minotaur",
+    "Ooze", "Pirate", "Samurai", "Spirit",
 ]
 TEXT_SUGGESTIONS = [
     "draw a card", "flying", "hexproof", "trample", "protection", "haste", "lifelink",
     "indestructible", "counter target", "exile", "destroy", "untap", "discards",
     "target", "deathtouch", "double strike", "token", "flash", "defender",
     "proliferate", "mill",
+    # Additional options
+    "cycling", "madness", "cascade", "equip", "kicker", "landfall", "scry",
+    "vigilance", "menace", "first strike", "search your library", "discard a card",
+    "enter the battlefield", "monarch", "create a Food token", "draw two cards",
+    "life gain", "modular", "transform", "connive", "venture into the dungeon",
 ]
 SET_SUGGESTIONS = [
     "Alpha", "Beta", "Unlimited", "Revised", "Mirage", "Zendikar", "Theros", "Dominaria",
     "Strixhaven", "Kamigawa", "Innistrad", "Ravnica", "Kaldheim", "Eldraine", "Modern",
     "New Capenna", "Phyrexia", "War", "Tarkir", "Ixalan",
+    # Additional options
+    "Arabian Nights", "Antiquities", "Legends", "Tempest", "Urza's Saga",
+    "Mercadian Masques", "Onslaught", "Lorwyn", "Shadowmoor", "Shards of Alara",
+    "Gatecrash", "Alara Reborn", "Battle for Zendikar", "Amonkhet", "Kaladesh",
+    "Battlebond", "Journey into Nyx", "Ice Age", "Mirrodin", "Return to Ravnica",
 ]
 
 TOTAL_CARD_COUNT = 98256
 
 REMINDER_PATTERN = re.compile(r"\([^)]+reminder text[^)]+\)", re.IGNORECASE)
+
+# Map various color words/letters to Scryfall color identity letters
+COLOR_ALIASES = {
+    "w": "w",
+    "white": "w",
+    "u": "u",
+    "blue": "u",
+    "b": "b",
+    "black": "b",
+    "r": "r",
+    "red": "r",
+    "g": "g",
+    "green": "g",
+    "c": "c",
+    "colorless": "c",
+    "colourless": "c",
+}
+
+
+def _extract_colors(text):
+    """Return text without color tokens and a list of colors found."""
+    if not text:
+        return "", []
+    colors = []
+    words = text.split()
+    kept = []
+    for word in words:
+        cleaned_parts = re.split(r"/+", word)
+        is_color = False
+        for part in cleaned_parts:
+            clean = re.sub(r"[\[\]{}()]+", "", part).lower()
+            if clean in COLOR_ALIASES:
+                colors.append(COLOR_ALIASES[clean])
+                is_color = True
+        if not is_color:
+            kept.append(word)
+    return " ".join(kept), colors
 
 def _remove_reminders(text):
     """Remove reminder text (in parentheses, with 'reminder text' or mana/keyword reminders) from Oracle text."""
@@ -65,9 +123,11 @@ def _scryfall_search(query, limit=3):
         gw.warn(f"Scryfall search error: {e}")
     return []
 
-def _scryfall_random():
+def _scryfall_random(query=None):
+    url = "https://api.scryfall.com/cards/random"
+    params = {"q": query} if query else None
     try:
-        resp = requests.get("https://api.scryfall.com/cards/random", timeout=6)
+        resp = requests.get(url, params=params, timeout=6)
         resp.raise_for_status()
         card = resp.json()
         if card.get("object") == "card":
@@ -148,6 +208,7 @@ def _render_card(card):
 def view_search_games(
     name=None,
     type_line=None,
+    card_type=None,
     oracle_text=None,
     set_name=None,
     discard=None,
@@ -173,11 +234,79 @@ def view_search_games(
 
     # --- Build query string ---
     query_parts = []
-    if name:        query_parts.append(f'name:"{name}"')
-    if type_line:   query_parts.append(f'type:"{type_line}"')
-    if oracle_text: query_parts.append(f'o:"{oracle_text}"')
-    if set_name:    query_parts.append(f'setname:"{set_name}"')
-    query = " ".join(query_parts).strip()
+    colors = set()
+
+    if name:
+        name, cs = _extract_colors(name)
+        colors.update(cs)
+        if name:
+            query_parts.append(f'name:"{name}"')
+
+    if type_line:
+        type_line, cs = _extract_colors(type_line)
+        colors.update(cs)
+        tl = type_line.strip().lower()
+        if tl in ("legendary", "snow"):
+            random_query = f"t:{tl} t:creature"
+        else:
+            m = re.match(r"^\s*(\d+)\s*/\s*(\d+)\s*$", type_line)
+            if m:
+                pw, tu = m.groups()
+                query_parts.append(f"pow={pw} tou={tu}")
+            else:
+                if tl in ("artifact", "enchantment"):
+                    query_parts.append(f"t:creature t:{tl}")
+                elif type_line:
+                    query_parts.append(f'type:"{type_line}"')
+
+    if card_type:
+        card_type, cs = _extract_colors(card_type)
+        colors.update(cs)
+        ct = card_type.strip().lower()
+        if ct in ("legendary", "snow"):
+            random_query = f"t:{ct} -t:creature"
+        else:
+            if ct in ("artifact", "enchantment"):
+                query_parts.append(f"t:{ct} -t:creature")
+            elif card_type:
+                query_parts.append(f'type:{ct}')
+
+    if oracle_text:
+        oracle_text, cs = _extract_colors(oracle_text)
+        colors.update(cs)
+        if oracle_text:
+            query_parts.append(f'o:"{oracle_text}"')
+
+    if set_name:
+        set_name, cs = _extract_colors(set_name)
+        colors.update(cs)
+        if set_name:
+            sn = set_name.strip()
+            if re.fullmatch(r"[A-Za-z0-9]{2,6}", sn):
+                query_parts.append(
+                    f'(e:{sn} or setname:"{sn}" or artist:"{sn}" or tag:{sn})'
+                )
+            else:
+                query_parts.append(
+                    f'(setname:"{sn}" or artist:"{sn}" or tag:{sn})'
+                )
+
+    color_filter = ""
+    if colors:
+        if colors == {"c"}:
+            color_filter = "c=c"
+        else:
+            colors.discard("c")
+            if colors:
+                color_filter = f"c>={''.join(sorted(colors))}"
+
+    if color_filter:
+        if random_query:
+            random_query = f"{random_query} {color_filter}"
+        else:
+            query_parts.append(color_filter)
+
+    query = " ".join(query_parts).strip() if not random_query else ""
     all_discards = set(discards)
 
     turn = _get_cookie_turn() if use_hand else 0
@@ -194,29 +323,36 @@ def view_search_games(
 
     # --- Search for a card if a query is present and hand is not full ---
     main_card = None
-    searched = bool(query)
+    searched = bool(query or random_query)
     message = ""
-    if query and (not use_hand or not hand_full):
-        found = _scryfall_search(query, limit=3)
-        found = [c for c in found if c.get("id") not in hand_ids and c.get("id") not in all_discards]
-        if not found:
-            attempts = 0
-            card = None
-            while attempts < 7:
-                card = _scryfall_random()
-                if not card:
-                    break
-                if card.get("id") not in hand_ids and card.get("id") not in all_discards:
-                    break
-                attempts += 1
+    if (random_query or query) and (not use_hand or not hand_full):
+        if random_query:
+            card = _scryfall_random(random_query)
             if card:
                 main_card = card
-                message = "<b>No cards found for your query. Here's a random card instead:</b>"
             else:
-                message = "<b>No cards found and couldn't fetch a random card.</b>"
+                message = "<b>Couldn't fetch a random card.</b>"
         else:
-            # Pick one at random if 2 or 3 cards are found
-            main_card = random.choice(found) if len(found) > 1 else found[0]
+            found = _scryfall_search(query, limit=3)
+            found = [c for c in found if c.get("id") not in hand_ids and c.get("id") not in all_discards]
+            if not found:
+                attempts = 0
+                card = None
+                while attempts < 7:
+                    card = _scryfall_random()
+                    if not card:
+                        break
+                    if card.get("id") not in hand_ids and card.get("id") not in all_discards:
+                        break
+                    attempts += 1
+                if card:
+                    main_card = card
+                    message = "<b>No cards found for your query. Here's a random card instead:</b>"
+                else:
+                    message = "<b>No cards found and couldn't fetch a random card.</b>"
+            else:
+                # Pick one at random if 2 or 3 cards are found
+                main_card = random.choice(found) if len(found) > 1 else found[0]
 
     # If we got a main_card and use_hand, add it to hand and clear form fields
     card_added = False
@@ -225,7 +361,6 @@ def view_search_games(
         _set_cookie_hand(hand_ids)
         card_added = True
         name = type_line = oracle_text = set_name = ""
-        # <---- RECALCULATE hand_full here:
         hand_full = len(hand_ids) >= HAND_LIMIT
 
     html = []
@@ -236,12 +371,13 @@ def view_search_games(
     window.mtgSuggestions = {{
         name: {json.dumps(NAME_SUGGESTIONS)},
         type_line: {json.dumps(TYPE_SUGGESTIONS)},
+        card_type: {json.dumps(TYPE_SUGGESTIONS)},
         oracle_text: {json.dumps(TEXT_SUGGESTIONS)},
         set_name: {json.dumps(SET_SUGGESTIONS)},
     }};
     </script>
     """)
-    html.append("<h1>Lookup Wars</h1>")
+    html.append("<h1>Divination Wars</h1>")
 
     # Show hand (if enabled and not empty)
     if use_hand and hand_ids:
@@ -297,6 +433,10 @@ def view_search_games(
                 <input type=\"text\" name=\"type_line\" value=\"{type_line}\" placeholder=\"Creature\">
             </div>
             <div class=\"mtg-form-row\">
+                <div class=\"mtg-label-row\"><label>CARD TYPE:</label><button class=\"mtg-random-btn\" type=\"button\" title=\"Random type\" onclick=\"mtgPickRandom('card_type')\">&#x1f3b2;</button></div>
+                <input type=\"text\" name=\"card_type\" value=\"{card_type}\" placeholder=\"Instant\">
+            </div>
+            <div class=\"mtg-form-row\">
                 <div class=\"mtg-label-row\"><label>RULES:</label><button class=\"mtg-random-btn\" type=\"button\" title=\"Random text\" onclick=\"mtgPickRandom('oracle_text')\">&#x1f3b2;</button></div>
                 <input type=\"text\" name=\"oracle_text\" value=\"{oracle_text}\" placeholder=\"draw a card\">
             </div>
@@ -318,6 +458,7 @@ def view_search_games(
     """.format(
         form_class=form_class,
         name=escape(name or ""), type_line=escape(type_line or ""),
+        card_type=escape(card_type or ""),
         oracle_text=escape(oracle_text or ""), set_name=escape(set_name or ""),
         turn=turn, library=library, life=life
     ))


### PR DESCRIPTION
## Summary
- rename Lookup Wars entry to Divination Wars
- add more random card, type, text and set suggestions
- support power/toughness search in the TYPE field
- add special handling for legendary creature and card type searches
- handle "snow" like legendary and allow artifact/enchantment creature lookups
- improve set search to accept set codes, artist names and tags
- strip color words from all fields and add a color filter

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_687043ae85a48326b9cec488a832d640