### PR TITLE
Add JWT auth option

### DIFF
--- a/data/static/web/auth/README.rst
+++ b/data/static/web/auth/README.rst
@@ -2,3 +2,5 @@ Web Authentication
 ------------------
 
 Basic account login example used by the website recipe.
+
+JWT token authentication can be configured with ``web.auth.config_jwt``.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Software Project Infrastructure by https://www.gelectriic.com"
 requires-python = ">=3.10"
 license = "MIT"
 classifiers = [ "Programming Language :: Python :: 3", "Operating System :: OS Independent",]
-dependencies = [ "toml", "setuptools", "twine", "build", "colorama", "bottle", "paste", "requests", "dateparser", "fastapi", "uvicorn", "docutils", "croniter", "qrcode[pil]", "cryptography", "jinja2", "pygame", "python-multipart", "httpx", "websockets", "pyperclip; platform_system == \"Windows\"", "plyer", "numpy", "pygetwindow; platform_system == \"Windows\"", "duckdb", "pywin32; platform_system == \"Windows\"", "selenium", "webdriver-manager", "bs4", "markdown", "pandas", "openpyxl", "coverage", "argcomplete",]
+dependencies = [ "toml", "setuptools", "twine", "build", "colorama", "bottle", "paste", "requests", "dateparser", "fastapi", "uvicorn", "docutils", "croniter", "qrcode[pil]", "cryptography", "jinja2", "pygame", "python-multipart", "httpx", "websockets", "pyperclip; platform_system == \"Windows\"", "plyer", "numpy", "pygetwindow; platform_system == \"Windows\"", "duckdb", "pywin32; platform_system == \"Windows\"", "selenium", "webdriver-manager", "bs4", "markdown", "pandas", "openpyxl", "coverage", "argcomplete", "PyJWT",]
 [[project.authors]]
 name = "Rafael J. Guillén-Osorio"
 email = "tecnologia@gelectriic.com"

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ pandas
 openpyxl
 coverage
 argcomplete
+PyJWT

--- a/tests/test_jwt_auth.py
+++ b/tests/test_jwt_auth.py
@@ -1,0 +1,36 @@
+import unittest
+import jwt
+from gway import gw
+
+web = gw.load_project('web')
+
+class JwtAuthChallengeTests(unittest.TestCase):
+    class FakeRequest:
+        def __init__(self, token):
+            self.headers = {'authorization': f'Bearer {token}'}
+
+    class FakeResponse:
+        def __init__(self):
+            self.status_code = None
+            self.headers = {}
+
+    def test_valid_token(self):
+        secret = 'test-secret'
+        token = jwt.encode({'sub': 'alice'}, secret, algorithm='HS256')
+        web.auth.clear()
+        web.auth.config_jwt(secret=secret, algorithms=['HS256'], engine='fastapi')
+        ok = web.auth.is_authorized(strict=True, context={'request': self.FakeRequest(token), 'response': self.FakeResponse()})
+        self.assertTrue(ok)
+        web.auth.clear()
+
+    def test_invalid_token(self):
+        secret = 'test-secret'
+        token = jwt.encode({'sub': 'alice'}, 'wrong', algorithm='HS256')
+        web.auth.clear()
+        web.auth.config_jwt(secret=secret, algorithms=['HS256'], engine='fastapi')
+        ok = web.auth.is_authorized(strict=True, context={'request': self.FakeRequest(token), 'response': self.FakeResponse()})
+        self.assertFalse(ok)
+        web.auth.clear()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_parse_bearer_token_header.py
+++ b/tests/test_parse_bearer_token_header.py
@@ -1,0 +1,19 @@
+import unittest
+from gway import gw
+
+web = gw.load_project('web')
+
+class ParseBearerTokenHeaderTests(unittest.TestCase):
+    def test_valid_header(self):
+        token = 'abc.def.ghi'
+        header = 'Bearer ' + token
+        self.assertEqual(web.auth.parse_bearer_token_header(header), token)
+
+    def test_invalid_headers(self):
+        invalid_headers = [None, '', 'Basic xyz', 'Bearer', 'Bearer ']
+        for hdr in invalid_headers:
+            with self.subTest(hdr=hdr):
+                self.assertIsNone(web.auth.parse_bearer_token_header(hdr))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add Bearer header parsing
- add JWT auth challenge and config helpers
- document JWT setup
- ensure PyJWT is installed
- test JWT auth and bearer header parser

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687082a6f1a0832689fee32bb9960dc2