### PR TITLE
Fix env isolation in hub token tests

### DIFF
--- a/tests/test_hub.py
+++ b/tests/test_hub.py
@@ -7,11 +7,11 @@ class HubGithubTokenTests(unittest.TestCase):
     def test_get_token_priority(self):
         with patch.dict(os.environ, {}, clear=True):
             self.assertIsNone(gw.hub.get_token())
-        with patch.dict(os.environ, {'REPO_TOKEN': 'a'}):
+        with patch.dict(os.environ, {'REPO_TOKEN': 'a'}, clear=True):
             self.assertEqual(gw.hub.get_token(), 'a')
-        with patch.dict(os.environ, {'GH_TOKEN': 'b', 'REPO_TOKEN': 'a'}):
+        with patch.dict(os.environ, {'GH_TOKEN': 'b', 'REPO_TOKEN': 'a'}, clear=True):
             self.assertEqual(gw.hub.get_token(), 'b')
-        with patch.dict(os.environ, {'GITHUB_TOKEN': 'c', 'GH_TOKEN': 'b', 'REPO_TOKEN': 'a'}):
+        with patch.dict(os.environ, {'GITHUB_TOKEN': 'c', 'GH_TOKEN': 'b', 'REPO_TOKEN': 'a'}, clear=True):
             self.assertEqual(gw.hub.get_token(), 'c')
 
 


### PR DESCRIPTION
## Summary
- ensure `test_get_token_priority` isn't affected by external env vars

## Testing
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_687092c057b8832683e46834e2a3384d