### PR TITLE
Use sessionStorage for qpig state

### DIFF
--- a/data/static/games/qpig/README.rst
+++ b/data/static/games/qpig/README.rst
@@ -10,3 +10,7 @@ chewed. QPellets are produced about every 30 seconds with a base 50\% chance,
 modified by ±25\% depending on your Certainty. The whole interface is wrapped
 in a tiny pixelated garden so outside styles don't leak in.
 
+The farm view draws a 32x32 PNG sprite named ``pig.png`` on a canvas.
+Create this image yourself (a small guinea pig with a transparent background) and
+place it in this directory under ``static/games/qpig/``.
+

--- a/data/static/games/qpig/farm.css
+++ b/data/static/games/qpig/farm.css
@@ -23,6 +23,13 @@
     color: #000;
 }
 
+.qpig-garden #qpig-canvas {
+    display: block;
+    margin: 8px auto;
+    image-rendering: pixelated;
+    border: 1px solid #333;
+}
+
 .qpig-garden .qpig-warning {
 
     margin-top: 1em;

--- a/tests/test_auth_charger.py
+++ b/tests/test_auth_charger.py
@@ -61,7 +61,7 @@ class AuthChargerStatusTests(unittest.TestCase):
         start = time.time()
         while time.time() - start < timeout:
             try:
-                with socket.create_connection(("localhost", port), timeout=1):
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
                     return
             except OSError:
                 time.sleep(0.2)

--- a/tests/test_conway_web.py
+++ b/tests/test_conway_web.py
@@ -41,7 +41,7 @@ class ConwayWebTests(unittest.TestCase):
         start = time.time()
         while time.time() - start < timeout:
             try:
-                with socket.create_connection(("localhost", port), timeout=1):
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
                     return
             except OSError:
                 time.sleep(0.2)

--- a/tests/test_etron_ws.py
+++ b/tests/test_etron_ws.py
@@ -107,7 +107,7 @@ class EtronWebSocketTests(unittest.TestCase):
         start = time.time()
         while time.time() - start < timeout:
             try:
-                with socket.create_connection(("localhost", port), timeout=1):
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
                     return
             except OSError:
                 time.sleep(0.2)
@@ -122,7 +122,7 @@ class EtronWebSocketTests(unittest.TestCase):
 
     def test_websocket_connection(self):
         """Confirm we can connect to the OCPP server and receive BootNotification response."""
-        uri = "ws://localhost:19000/charger123?token=foo"
+        uri = "ws://127.0.0.1:19000/charger123?token=foo"
         async def run_ws_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"], open_timeout=15) as websocket:
                 message_id = "boot-test"
@@ -141,7 +141,7 @@ class EtronWebSocketTests(unittest.TestCase):
     def test_authorize_valid_rfid(self):
         """RFID in allowlist with balance >=1 should be Accepted"""
         self._set_balance(KNOWN_GOOD_TAG, 100)
-        uri = "ws://localhost:19000/tester1?token=foo"
+        uri = "ws://127.0.0.1:19000/tester1?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-valid"
@@ -158,7 +158,7 @@ class EtronWebSocketTests(unittest.TestCase):
     def test_authorize_with_extra_fields(self):
         """RFID with additional fields in CDV still authorizes correctly"""
         self.__class__.gw_cdv_update(KNOWN_GOOD_TAG, balance="55", foo="bar", baz="qux")
-        uri = "ws://localhost:19000/tester2?token=foo"
+        uri = "ws://127.0.0.1:19000/tester2?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-extra"
@@ -175,7 +175,7 @@ class EtronWebSocketTests(unittest.TestCase):
     def test_authorize_low_balance(self):
         """RFID present but balance <1 should be Rejected"""
         self._set_balance(KNOWN_GOOD_TAG, 0)
-        uri = "ws://localhost:19000/tester3?token=foo"
+        uri = "ws://127.0.0.1:19000/tester3?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-lowbal"
@@ -192,7 +192,7 @@ class EtronWebSocketTests(unittest.TestCase):
     def test_authorize_admin_tag(self):
         """Admin tag should be accepted (if balance >=1)"""
         self._set_balance(ADMIN_TAG, 150)
-        uri = "ws://localhost:19000/admin?token=foo"
+        uri = "ws://127.0.0.1:19000/admin?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-admin"
@@ -208,7 +208,7 @@ class EtronWebSocketTests(unittest.TestCase):
 
     def test_authorize_unknown_rfid(self):
         """Unknown tag must be rejected"""
-        uri = "ws://localhost:19000/unknown?token=foo"
+        uri = "ws://127.0.0.1:19000/unknown?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-unknown"
@@ -227,8 +227,8 @@ class EtronWebSocketTests(unittest.TestCase):
         self._set_balance(KNOWN_GOOD_TAG, 100)
         self._set_balance(ADMIN_TAG, 0)
         uris = [
-            "ws://localhost:19000/chargerA?token=foo",
-            "ws://localhost:19000/chargerB?token=foo"
+            "ws://127.0.0.1:19000/chargerA?token=foo",
+            "ws://127.0.0.1:19000/chargerB?token=foo"
         ]
         async def run_concurrent():
             async def connect_and_auth(uri, idtag):
@@ -250,7 +250,7 @@ class EtronWebSocketTests(unittest.TestCase):
     def test_authorize_missing_balance(self):
         """If balance is missing, should be treated as 0 and Rejected."""
         self.__class__.gw_cdv_update(KNOWN_GOOD_TAG, user="test")  # No balance field!
-        uri = "ws://localhost:19000/missingbal?token=foo"
+        uri = "ws://127.0.0.1:19000/missingbal?token=foo"
         async def run_authorize_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "auth-missingbal"
@@ -266,7 +266,7 @@ class EtronWebSocketTests(unittest.TestCase):
 
     def test_server_ignores_callresult_messages(self):
         """Server should ignore valid [3, ...] CALLRESULT messages from client."""
-        uri = "ws://localhost:19000/callresult1?token=foo"
+        uri = "ws://127.0.0.1:19000/callresult1?token=foo"
         async def run_ignore_callresult():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "irrelevant-id"
@@ -286,7 +286,7 @@ class EtronWebSocketTests(unittest.TestCase):
 
     def test_server_ignores_callerror_messages(self):
         """Server should ignore valid [4, ...] CALLERROR messages from client."""
-        uri = "ws://localhost:19000/callerror1?token=foo"
+        uri = "ws://127.0.0.1:19000/callerror1?token=foo"
         async def run_ignore_callerror():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as websocket:
                 message_id = "irrelevant-id"
@@ -393,7 +393,7 @@ class EtronWebSocketTests(unittest.TestCase):
     @unittest.skip("integration environment unavailable")
     def test_remote_stop_transaction(self):
         """Dashboard Stop action triggers RemoteStopTransaction on the CP."""
-        uri = "ws://localhost:19000/stopper?token=foo"
+        uri = "ws://127.0.0.1:19000/stopper?token=foo"
 
         async def run_stop_check():
             async with websockets.connect(uri, subprotocols=["ocpp1.6"]) as ws:
@@ -433,7 +433,7 @@ class EtronWebSocketTests(unittest.TestCase):
             with contextlib.redirect_stdout(buf):
                 await gw.ocpp.evcs.simulate_cp.__wrapped__(
                     0,
-                    "localhost",
+                    "127.0.0.1",
                     19000,
                     KNOWN_GOOD_TAG,
                     "SIMTEST",

--- a/tests/test_nav_styles.py
+++ b/tests/test_nav_styles.py
@@ -40,7 +40,7 @@ class NavStyleTests(unittest.TestCase):
         start = time.time()
         while time.time() - start < timeout:
             try:
-                with socket.create_connection(("localhost", port), timeout=1):
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
                     return
             except OSError:
                 time.sleep(0.2)

--- a/tests/test_proxy_fallback.py
+++ b/tests/test_proxy_fallback.py
@@ -50,7 +50,7 @@ class ProxyFallbackTests(unittest.TestCase):
         start = time.time()
         while time.time() - start < timeout:
             try:
-                with socket.create_connection(("localhost", port), timeout=1):
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
                     return
             except OSError:
                 time.sleep(0.2)
@@ -60,7 +60,7 @@ class ProxyFallbackTests(unittest.TestCase):
         async def run_session():
             await gw.ocpp.evcs.simulate_cp.__wrapped__(
                 0,
-                "localhost",
+                "127.0.0.1",
                 19900,
                 KNOWN_TAG,
                 "SIM1",

--- a/tests/test_screenshot_attachment.py
+++ b/tests/test_screenshot_attachment.py
@@ -33,7 +33,7 @@ class ScreenshotAttachmentTest(unittest.TestCase):
         start = time.time()
         while time.time() - start < timeout:
             try:
-                with socket.create_connection(("localhost", port), timeout=1):
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
                     return
             except OSError:
                 time.sleep(0.2)

--- a/tests/test_site_help_auto.py
+++ b/tests/test_site_help_auto.py
@@ -39,7 +39,7 @@ class SiteHelpAutoTests(unittest.TestCase):
         start = time.time()
         while time.time() - start < timeout:
             try:
-                with socket.create_connection(("localhost", port), timeout=1):
+                with socket.create_connection(("127.0.0.1", port), timeout=1):
                     return
             except OSError:
                 time.sleep(0.2)


### PR DESCRIPTION
## Summary
- replace cookie storage in the qpig game with JSON stored in sessionStorage
- add save/load buttons to export/import `.qpg` files
- display a guinea pig sprite on a canvas element (image must be created manually)
- update qpig tests for new state handling and use 127.0.0.1 for webserver checks
- remove the binary sprite from the repo and document how to add it

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68707af5407083269f9f8d5a70e843ca