### PR TITLE
Make project argument mandatory for web app setup_app

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,8 +90,8 @@ Example Recipe
 
 .. code-block:: text
 
-   web app setup --project web.navbar --home style-changer
-   web app setup --project web.site --home reader
+   web app setup-app web.navbar --home style-changer
+   web app setup-app web.site --home reader
    web server start-app --host 127.0.0.1 --port 8888
    until --forever
 
@@ -110,9 +110,9 @@ next non-indented command.
 
    # Configure multiple projects
    web app setup-app:
-       --project web.site --home reader
-       --project web.nav --style random
-       --project games.qpig --home qpig-farm
+       - web.site --home reader
+       - web.nav --style random
+       - games.qpig --home qpig-farm
 
    # Start the server
    web:

--- a/gway/console.py
+++ b/gway/console.py
@@ -472,9 +472,10 @@ def load_recipe(recipe_filename):
     non-whitespace characters are `--`, prepend the last full non-indented command prefix.
     
     Example:
-        web app setup --home reader
-            --project vbox --home upload
-            --project games.conway --home board --path conway
+        web app setup-app:
+            - web.site --home reader
+            - vbox --home upload
+            - games.conway --home board --path conway
         web server start-app --host 127.0.0.1 --port 8888
 
     This parses the indented lines as continuations of the previous non-indented command.

--- a/projects/vbox.py
+++ b/projects/vbox.py
@@ -18,7 +18,7 @@ This virtual box (vbox) system allows users with admin access to upload and down
 files to/from a secure folder in the remote server. 
 
 In CLI/Recipes you may use:
-> [gway] web app setup --project vbox --home upload
+> [gway] web app setup-app vbox --home upload
 
 To deploy it and sey the home to [BASE_URL]/vbox/upload.
 """

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -67,9 +67,9 @@ def current_endpoint():
     """
     return gw.context.get('current_endpoint')
 
-def setup_app(*,
+def setup_app(project,
+    *,
     app=None,
-    project="web.site",
     path=None,
     home: str = None,
     links=None,

--- a/recipes/etron/cloud.gwr
+++ b/recipes/etron/cloud.gwr
@@ -2,13 +2,13 @@
 # OCPP 1.6 CSMS Recipe for Central Cloud Server
 
 web app setup-app:
-    --project ocpp.data --home charger-summary
-    --project ocpp.csms --home charger-status
-    --project ocpp.csms --home cp-simulator
-    --project web.cookies
-    --project web.nav
-    --project vbox
-    --project ocpp.data --home charger-summary
+    - ocpp.data --home charger-summary
+    - ocpp.csms --home charger-status
+    - ocpp.csms --home cp-simulator
+    - web.cookies
+    - web.nav
+    - vbox
+    - ocpp.data --home charger-summary
    
 # Toggle this version to apply the allow list  
 ocpp csms setup-app:

--- a/recipes/etron/local.gwr
+++ b/recipes/etron/local.gwr
@@ -2,13 +2,13 @@
 # OCPP 1.6 CSMS runnable GWAY Recipe with basic RFID auth
 
 web app setup-app:
-    --project ocpp.data --home charger-summary
-    --project web.nav
-    --project vbox
-    --project ocpp.csms --home charger-status
-    --project ocpp.evcs --home cp-simulator
-    --project monitor --home monitor-panel
-    --project ocpp.data --home charger-summary
+    - ocpp.data --home charger-summary
+    - web.nav
+    - vbox
+    - ocpp.csms --home charger-status
+    - ocpp.evcs --home cp-simulator
+    - monitor --home monitor-panel
+    - ocpp.data --home charger-summary
 
 # Toggle this version to apply the allowlist  
 # ocpp csms setup-app --allow data/etron/rfids.cdv --location porsche_centre

--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -2,10 +2,10 @@
 # Games-only demo with cookies, navbar and style switcher
 
 web app setup-app:
-    --home reader
-    --project games --home games --links game-of-life,search-games,qpig-farm,massive-snake,fantastic-client
-    --project web.nav --home style-switcher
-    --project web.cookies --home cookie-jar
+    - web.site --home reader
+    - games --home games --links game-of-life,search-games,qpig-farm,massive-snake,fantastic-client
+    - web.nav --home style-switcher
+    - web.cookies --home cookie-jar
 
 web:
  - static collect

--- a/recipes/skeleton.gwr
+++ b/recipes/skeleton.gwr
@@ -1,9 +1,9 @@
 # file: recipes/skeleton.gwr
 
 web app setup-app:
-    --project web.site --home reader
-    --project web.nav --style random
-    --project cdv --home data-editor
+    - web.site --home reader
+    - web.nav --style random
+    - cdv --home data-editor
 web:
  - static collect
 - server start-app

--- a/recipes/test/etron/cloud.gwr
+++ b/recipes/test/etron/cloud.gwr
@@ -2,13 +2,13 @@
 # OCPP 1.6 CSMS Recipe for Central Cloud Server
 
 web app setup-app:
-    --project ocpp.data --home charger-summary
-    --project ocpp.csms --home charger-status
-    --project ocpp.csms --home cp-simulator
-    --project web.cookies
-    --project web.nav
-    --project vbox
-    --project ocpp.data --home charger-summary
+    - ocpp.data --home charger-summary
+    - ocpp.csms --home charger-status
+    - ocpp.csms --home cp-simulator
+    - web.cookies
+    - web.nav
+    - vbox
+    - ocpp.data --home charger-summary
    
 # Toggle this version to apply the allow list  
 ocpp csms setup-app:

--- a/recipes/test/etron/local_proxy.gwr
+++ b/recipes/test/etron/local_proxy.gwr
@@ -2,12 +2,12 @@
 # Local OCPP CSMS with proxy fallback for tests
 
 web app setup-app:
-    --project ocpp.data --home charger-summary
-    --project web.nav
-    --project vbox
-    --project ocpp.csms --home charger-status
-    --project ocpp.evcs --home cp-simulator
-    --project ocpp.data --home charger-summary
+    - ocpp.data --home charger-summary
+    - web.nav
+    - vbox
+    - ocpp.csms --home charger-status
+    - ocpp.evcs --home cp-simulator
+    - ocpp.data --home charger-summary
 
 ocpp csms setup-app:
     --location proxy_test

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -4,18 +4,18 @@
 # Lines without a starting command repeat the previous with new params
 
 web app setup-app:
-    --home reader --links feedback
-    --project awg --home cable-finder
-    --project web.nav --home style-switcher
-    --project web.cookies --home cookie-jar
-    --project web.message
-    --project web.chat
-    --project vbox --home uploads
-    --project ocpp.data --home charger-summary
-    --project ocpp.csms --auth required --home charger-status
-    --project ocpp.evcs --auth required --home cp-simulator
-    --project games --home games --links game-of-life,search-games,qpig-farm,massive-snake,fantastic-client
-    --project web.auth
+    - web.site --home reader --links feedback
+    - awg --home cable-finder
+    - web.nav --home style-switcher
+    - web.cookies --home cookie-jar
+    - web.message
+    - web.chat
+    - vbox --home uploads
+    - ocpp.data --home charger-summary
+    - ocpp.csms --auth required --home charger-status
+    - ocpp.evcs --auth required --home cp-simulator
+    - games --home games --links game-of-life,search-games,qpig-farm,massive-snake,fantastic-client
+    - web.auth
 
 web:
  - static collect

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -3,7 +3,7 @@
 
 # Lines without a starting command repeat the previous with new params
 
-web app setup-app --project:
+web app setup-app:
     - web.site --home reader --links feedback 
     - web.nav --home style-switcher
     - web.cookies --home cookie-jar

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -117,8 +117,8 @@ class TestLoadRecipeColonSyntax(unittest.TestCase):
     def test_load_recipe_with_colon_repetition(self):
         content = (
             """web app setup-app:
-    --project one --home first
-    --project two
+    - one --home first
+    - two
 web:
  - static collect
  - server start-app --host 1 --port 2
@@ -133,8 +133,8 @@ web:
             os.remove(temp_name)
 
         expected = [
-            ['web', 'app', 'setup-app', '--project', 'one', '--home', 'first'],
-            ['web', 'app', 'setup-app', '--project', 'two'],
+            ['web', 'app', 'setup-app', 'one', '--home', 'first'],
+            ['web', 'app', 'setup-app', 'two'],
             ['web', 'static', 'collect'],
             ['web', 'server', 'start-app', '--host', '1', '--port', '2'],
         ]
@@ -143,8 +143,8 @@ web:
     def test_load_recipe_colon_without_indentation(self):
         content = (
             """web app setup-app:
---project one
---project two
+- one
+- two
 web:
 - static collect
 - server start-app --host 1 --port 2
@@ -159,8 +159,8 @@ web:
             os.remove(temp_name)
 
         expected = [
-            ['web', 'app', 'setup-app', '--project', 'one'],
-            ['web', 'app', 'setup-app', '--project', 'two'],
+            ['web', 'app', 'setup-app', 'one'],
+            ['web', 'app', 'setup-app', 'two'],
             ['web', 'static', 'collect'],
             ['web', 'server', 'start-app', '--host', '1', '--port', '2'],
         ]

--- a/tests/test_index_home_title.py
+++ b/tests/test_index_home_title.py
@@ -4,7 +4,7 @@ from gway import gw
 
 class IndexHomeTitleTests(unittest.TestCase):
     def test_home_title_uses_project_name(self):
-        gw.web.app.setup_app(project="dummy", home="index")
+        gw.web.app.setup_app("dummy", home="index")
         mod = sys.modules[gw.web.app.setup_app.__module__]
         self.assertIn(("Dummy", "dummy/index"), mod._homes)
 

--- a/tests/test_project_index_view.py
+++ b/tests/test_project_index_view.py
@@ -4,7 +4,7 @@ from paste.fixture import TestApp
 
 class ProjectIndexViewTests(unittest.TestCase):
     def setUp(self):
-        self.app = gw.web.app.setup_app(project="dummy")
+        self.app = gw.web.app.setup_app("dummy")
         self.client = TestApp(self.app)
 
     def test_index_route(self):

--- a/tests/test_setup_app_fallback.py
+++ b/tests/test_setup_app_fallback.py
@@ -6,7 +6,7 @@ from paste.fixture import TestApp
 
 class SetupAppFallbackTests(unittest.TestCase):
     def test_first_available_project_is_loaded(self):
-        app = gw.web.app.setup_app(project=["nope", "dummy"])
+        app = gw.web.app.setup_app(["nope", "dummy"])
         client = TestApp(app)
         resp = client.get("/dummy")
         self.assertEqual(resp.status, 200)

--- a/tests/test_unauthorized_debug_link.py
+++ b/tests/test_unauthorized_debug_link.py
@@ -5,7 +5,7 @@ from paste.fixture import TestApp
 class UnauthorizedDebugLinkTests(unittest.TestCase):
     def setUp(self):
         gw.update_modes(debug=True)
-        self.app = gw.web.app.setup_app(project="dummy")
+        self.app = gw.web.app.setup_app("dummy")
         # simple route that always triggers unauthorized
         self.app.route('/unauth', callback=lambda: gw.web.error.unauthorized("Access denied"))
         self.client = TestApp(self.app)

--- a/tests/test_view_mashup.py
+++ b/tests/test_view_mashup.py
@@ -4,7 +4,7 @@ from paste.fixture import TestApp
 
 class ViewMashupTests(unittest.TestCase):
     def setUp(self):
-        self.app = gw.web.app.setup_app(project="games")
+        self.app = gw.web.app.setup_app("games")
         self.client = TestApp(self.app)
 
     def test_mashup_returns_combined_content(self):


### PR DESCRIPTION
## Summary
- require `project` positional arg for `web.app.setup_app`
- document updated project configuration syntax
- adjust example recipes and README
- update vbox project docs
- fix recipe parsing tests and update recipes for new format

## Testing
- `pip install -q -r requirements.txt && pip install -q -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687116739544832691c5509beca20121