### PR TITLE
Enable setup_home and setup_links defaults

### DIFF
--- a/projects/dummy.py
+++ b/projects/dummy.py
@@ -2,3 +2,13 @@
 
 def view_index():
     return "<h1>Dummy Index</h1>"
+
+
+def setup_home():
+    """Return the default home view for this project."""
+    return "index"
+
+
+def setup_links():
+    """Return default navigation links for this project."""
+    return ["about", "more"]

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -120,6 +120,22 @@ def setup_app(project,
     # Track project for later global static collection
     _enabled.add(project)
 
+    if home is None:
+        setup_home_func = getattr(source, "setup_home", None)
+        if callable(setup_home_func):
+            try:
+                home = setup_home_func()
+            except Exception as exc:
+                gw.warn(f"{project}.setup_home failed: {exc}")
+
+    if links is None:
+        setup_links_func = getattr(source, "setup_links", None)
+        if callable(setup_links_func):
+            try:
+                links = setup_links_func()
+            except Exception as exc:
+                gw.warn(f"{project}.setup_links failed: {exc}")
+
     # Default path is the dotted project name
     if path is None:
         path = project.replace('.', '/')

--- a/tests/test_setup_home_links.py
+++ b/tests/test_setup_home_links.py
@@ -1,0 +1,18 @@
+import unittest
+import sys
+from gway import gw
+from paste.fixture import TestApp
+
+class SetupHomeLinksFuncTests(unittest.TestCase):
+    def test_defaults_from_project_functions(self):
+        app = gw.web.app.setup_app("dummy")
+        mod = sys.modules[gw.web.app.setup_app.__module__]
+        self.assertIn(("Dummy", "dummy/index"), mod._homes)
+        self.assertEqual(mod._links.get("dummy/index"), ["about", "more"])
+        client = TestApp(app)
+        resp = client.get("/dummy")
+        self.assertEqual(resp.status, 200)
+        self.assertIn("Dummy Index", resp.body.decode())
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support `setup_home`/`setup_links` for project defaults
- implement default functions for the dummy project
- test fallback to project-provided defaults

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68712370b308832682c7d8c8780f2dd9