### PR TITLE
Improve CLI completions helper

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -52,6 +52,16 @@ For PowerShell::
 
    register-python-argcomplete gway -s powershell | Out-String | Invoke-Expression
 
+CLI Helpers
+-----------
+
+An experimental project ``cli`` exposes utilities related to the command
+line interface. The ``cli.completions`` function lists available
+builtin and project commands and can aid in building custom completion
+scripts::
+
+   gway cli completions
+
 Core Concepts
 -------------
 

--- a/projects/cli.py
+++ b/projects/cli.py
@@ -1,0 +1,49 @@
+# file: projects/cli.py
+"""CLI helper utilities.
+
+This project provides functions related to the command
+line interface. The ``completions`` function is a prototype
+to inspect available project commands for custom shell
+completion scripts.
+"""
+
+from __future__ import annotations
+
+import inspect
+from gway import gw
+from gway.structs import Project
+
+
+def _walk(ns: Project, parts: list[str]) -> list[list[str]]:
+    commands: list[list[str]] = []
+    for name in dir(ns):
+        if name.startswith("_"):
+            continue
+        obj = getattr(ns, name)
+        if isinstance(obj, Project):
+            commands.extend(_walk(obj, parts + [name]))
+        elif inspect.isfunction(obj):
+            commands.append(parts + [name])
+    return commands
+
+
+def completions() -> list[str]:
+    """Return a list of available command paths, including builtins."""
+
+    commands: list[str] = []
+
+    # builtins appear as top-level commands
+    for name in gw.builtins():
+        commands.append(name.replace("_", "-"))
+
+    # discover project functions recursively
+    for proj in gw.projects():
+        try:
+            project = gw.load_project(proj)
+        except Exception:
+            continue
+        for parts in _walk(project, [proj]):
+            commands.append(" ".join(p.replace("_", "-") for p in parts))
+
+    return sorted(commands)
+

--- a/tests/test_cli_project.py
+++ b/tests/test_cli_project.py
@@ -1,0 +1,16 @@
+import unittest
+from gway import gw
+
+
+class CliCompletionTests(unittest.TestCase):
+    def test_completions_include_web_server(self):
+        cmds = gw.cli.completions()
+        self.assertIn('web server start-app', cmds)
+
+    def test_completions_include_builtin(self):
+        cmds = gw.cli.completions()
+        self.assertIn('hello-world', cmds)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- include builtins in `cli.completions`
- document that completions list builtins and project commands
- test that `hello-world` appears in the completions list

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_687115106d3483269e81ab7c7a9a6f36