### PR TITLE
Add relief border to Massive Snake board

### DIFF
--- a/data/static/games/massive_snake/board.css
+++ b/data/static/games/massive_snake/board.css
@@ -1,5 +1,17 @@
 /* file: data/static/games/massive_snake/board.css */
-.snake-board { border-collapse: collapse; margin-top: 1em; }
+.snake-board {
+    border-collapse: collapse;
+    margin-top: 1em;
+    border: 6px solid #8b5a2b;
+    box-shadow: inset 0 0 8px rgba(0, 0, 0, 0.5);
+    background: repeating-linear-gradient(
+        45deg,
+        #d2b48c,
+        #d2b48c 10px,
+        #deb887 10px,
+        #deb887 20px
+    );
+}
 .snake-board td { width: 26px; height: 26px; border: 1px solid #555; text-align: center; font-size: 0.78em; line-height: 1.1; }
 .snake-board td.snake { background: #ffecec; position: relative; }
 .snake-board td.ladder { background: #ecffec; position: relative; }


### PR DESCRIPTION
## Summary
- tweak Snake board CSS for a wooden-like border with inset shadow

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687137d5b3488326ad2cd8b22481c269