### PR TITLE
Add arthexis_com recipe and dotted name support

### DIFF
--- a/gway/builtins/recipes.py
+++ b/gway/builtins/recipes.py
@@ -16,28 +16,7 @@ def run_recipe(*scripts: str, **context):
 
     results = []
     for script in scripts:
-        orig_script = script
-        if not script.endswith('.gwr'):
-            script += '.gwr'
-            gw.debug(f"Appended .gwr extension: {script!r}")
-
-        try:
-            script_path = gw.resource(script, check=True)
-            gw.debug(f"Found script at: {script_path}")
-        except (FileNotFoundError, KeyError) as first_exc:
-            gw.debug(f"Script not found at {script!r}: {first_exc!r}")
-            try:
-                script_path = gw.resource("recipes", script)
-                gw.debug(f"Found script in 'recipes/': {script_path}")
-            except Exception as second_exc:
-                msg = (
-                    f"Could not locate script {script!r} "
-                    f"(tried direct lookup and under 'recipes/')."
-                )
-                gw.debug(f"{msg} Last error: {second_exc!r}")
-                raise FileNotFoundError(msg) from second_exc
-
-        command_sources, comments = load_recipe(script_path)
+        command_sources, comments = load_recipe(script)
         if comments:
             gw.debug("Recipe comments:\n" + "\n".join(comments))
         result = process(command_sources, **context)

--- a/gway/console.py
+++ b/gway/console.py
@@ -489,9 +489,24 @@ def load_recipe(recipe_filename):
 
     # --- Recipe file resolution (unchanged) ---
     if not os.path.isabs(recipe_filename):
-        candidate_names = [recipe_filename]
-        if not os.path.splitext(recipe_filename)[1]:
-            candidate_names += [f"{recipe_filename}.gwr", f"{recipe_filename}.txt"]
+        candidate_names = []
+        base_names = [recipe_filename]
+        if "." in recipe_filename:
+            base_names.append(recipe_filename.replace(".", "_"))
+            base_names.append(recipe_filename.replace(".", os.sep))
+
+        seen = set()
+        for base in base_names:
+            if base not in seen:
+                candidate_names.append(base)
+                seen.add(base)
+            if not os.path.splitext(base)[1]:
+                for ext in (".gwr", ".txt"):
+                    name = base + ext
+                    if name not in seen:
+                        candidate_names.append(name)
+                        seen.add(name)
+
         for name in candidate_names:
             recipe_path = gw.resource("recipes", name)
             if os.path.isfile(recipe_path):

--- a/recipes/arthexis_com.gwr
+++ b/recipes/arthexis_com.gwr
@@ -1,0 +1,31 @@
+# file: recipes/arthexis_com.gwr
+# Minimal GWAY demo website ingredients
+
+# Lines without a starting command repeat the previous with new params
+
+web app setup:
+    - web.site --home reader --links feedback 
+    - web.nav --home style-switcher
+    - web.cookies --home cookie-jar
+    - web.message
+    - awg --home cable-finder
+    - vbox --home uploads
+    - ocpp.csms --auth required --home charger-status
+    - ocpp.evcs --auth required --home cp-simulator
+    - ocpp.data --auth required --home charger-summary
+    - web.chat.actions --home audit-chatlog --auth required
+    - games --home games --links game-of-life,search-games,qpig-farm,massive-snake,fantastic-client
+    - web.auth
+
+web:
+ - static collect
+ - auth config-basic --optional --temp-link
+
+ocpp csms setup-app:
+    --location simulator
+
+web:
+ - server start-app --port 8888 --ws-port 9999
+
+# Loop until VERSION or BUILD or PyPI changes
+until --version --build --pypi

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -112,6 +112,18 @@ app start --port 8000
         self.assertEqual(commands, expected_commands)
         self.assertEqual(comments, expected_comments)
 
+    def test_load_recipe_accepts_dotted_name(self):
+        # File exists as arthexis_com.gwr but load with dot
+        (self.recipes_dir / 'arthexis_com.gwr').write_text('cmd run')
+        commands, _ = console.load_recipe('arthexis.com')
+        self.assertEqual(commands, [['cmd', 'run']])
+
+    def test_load_recipe_accepts_dotted_path(self):
+        (self.recipes_dir / 'foo').mkdir()
+        (self.recipes_dir / 'foo' / 'bar.gwr').write_text('cmd go')
+        commands, _ = console.load_recipe('foo.bar')
+        self.assertEqual(commands, [['cmd', 'go']])
+
 
 class TestLoadRecipeColonSyntax(unittest.TestCase):
     def test_load_recipe_with_colon_repetition(self):


### PR DESCRIPTION
## Summary
- duplicate website recipe as arthexis_com.gwr
- search dotted recipe names in `load_recipe`
- simplify `run_recipe` lookup to use `load_recipe`
- allow dots as separators in recipe names
- test dotted recipe lookup

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6871879cd4348326b82e12520638c21f