### PR TITLE
Log chat passphrase

### DIFF
--- a/projects/web/chat/actions.py
+++ b/projects/web/chat/actions.py
@@ -95,6 +95,7 @@ def api_post_action(*, request=None, action=None, trust=None, **kwargs):
         secret = _random_passphrase()
         _TRUSTS[sid] = {"trust": secret, "ts": now, "count": 0}
         print(f"[web.chat] Session {sid} requires passphrase: {secret}")
+        gw.info(f"[web.chat] Session {sid} requires passphrase: {secret}")
         res = {
             "auth_required": True,
             "message": "Please provide the passphrase displayed in the server console.",


### PR DESCRIPTION
## Summary
- output chat passphrase to info log as well as console

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687188fa0af48326923bbb45efc7f6eb