### PR TITLE
Add rpi project with cloning utility

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -202,6 +202,7 @@ The following projects bundle additional documentation.  Each link uses
   - `evcs <https://arthexis.com/web/site/reader?tome=ocpp/evcs>`_
   - `data <https://arthexis.com/web/site/reader?tome=ocpp/data>`_
 - `release <https://arthexis.com/web/site/reader?tome=release>`_
+- `rpi <https://arthexis.com/web/site/reader?tome=rpi>`_
 - `vbox <https://arthexis.com/web/site/reader?tome=vbox>`_
 - `web <https://arthexis.com/web/site/reader?tome=web>`_
   - `nav <https://arthexis.com/web/site/reader?tome=web/nav>`_
@@ -221,6 +222,7 @@ The following projects bundle additional documentation.  Each link uses
 .. _/web/site/reader?tome=ocpp/evcs: https://arthexis.com/web/site/reader?tome=ocpp/evcs
 .. _/web/site/reader?tome=ocpp/data: https://arthexis.com/web/site/reader?tome=ocpp/data
 .. _/web/site/reader?tome=release: https://arthexis.com/web/site/reader?tome=release
+.. _/web/site/reader?tome=rpi: https://arthexis.com/web/site/reader?tome=rpi
 .. _/web/site/reader?tome=vbox: https://arthexis.com/web/site/reader?tome=vbox
 .. _/web/site/reader?tome=web: https://arthexis.com/web/site/reader?tome=web
 .. _/web/site/reader?tome=web/nav: https://arthexis.com/web/site/reader?tome=web/nav

--- a/data/static/rpi/README.rst
+++ b/data/static/rpi/README.rst
@@ -1,0 +1,29 @@
+Raspberry Pi Utilities
+----------------------
+
+The ``rpi`` project contains helpers for Raspberry Pi management.
+The primary command ``ru`` clones the currently running system to
+another microSD card using ``dd``.
+
+Usage
+=====
+
+From the command line::
+
+    gway rpi ru /dev/sda
+
+Programmatically::
+
+    from gway import gw
+    gw.rpi.ru('/dev/sda')
+
+Ensure the destination device refers to the USB microSD writer
+connected to the Pi.  The entire device will be overwritten and
+requires ``sudo`` permissions.  Cloning may take several minutes.
+
+Web Interface
+=============
+
+Launch the web application and open ``/rpi/pi-remote`` to use a simple
+interface for selecting the target device and starting the copy.  The
+progress bar updates automatically while the clone runs.

--- a/projects/rpi.py
+++ b/projects/rpi.py
@@ -1,0 +1,130 @@
+# file: projects/rpi.py
+"""Raspberry Pi utilities."""
+
+import subprocess
+import os
+import html
+import threading
+from gway import gw
+
+
+def ru(target_device: str, *, bs: str = "4M", sync: bool = True) -> str:
+    """Clone the running Raspberry Pi image to ``target_device`` using ``dd``.
+
+    Parameters
+    ----------
+    target_device: str
+        Path to the destination block device (e.g. ``/dev/sda``).
+    bs: str
+        Block size for ``dd`` (default ``4M``).
+    sync: bool
+        If ``True``, use ``conv=fsync`` to sync writes.
+
+    Returns
+    -------
+    str
+        Standard output from ``dd`` when successful.
+    """
+    cmd = [
+        "sudo",
+        "dd",
+        "if=/dev/mmcblk0",
+        f"of={target_device}",
+        f"bs={bs}",
+        "status=progress",
+    ]
+    if sync:
+        cmd.append("conv=fsync")
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"dd failed: {result.stderr.strip()}")
+    return result.stdout.strip() or "Clone completed."
+
+
+# alias
+clone_sd = ru
+
+
+_CLONE_STATE = {
+    "running": False,
+    "progress": 0.0,
+    "status": "",
+    "target": "",
+}
+
+
+def _run_clone(target: str):
+    """Background thread wrapper around :func:`ru`.
+
+    Updates the global ``_CLONE_STATE`` with progress and final status.
+    """
+    try:
+        ru(target)
+        _CLONE_STATE.update(progress=100.0, status="Clone completed.")
+    except Exception as exc:  # pragma: no cover - error path
+        _CLONE_STATE.update(status=f"Error: {exc}")
+    finally:
+        _CLONE_STATE["running"] = False
+
+
+def _list_devices() -> list[str]:
+    """Return list of potential target devices under ``/dev``."""
+    import re
+
+    try:
+        devs = os.listdir("/dev")
+    except Exception:  # pragma: no cover - inaccessible /dev
+        return []
+    pattern = re.compile(r"^(sd[a-z]|mmcblk\d+)$")
+    return [f"/dev/{d}" for d in devs if pattern.match(d)]
+
+
+def render_clone_progress():
+
+    prog = _CLONE_STATE.get("progress", 0.0)
+    status = _CLONE_STATE.get("status", "")
+    bar = (
+        f"<div class='gw-progress'><div class='gw-progress-bar' "
+        f"style='width:{prog:.1f}%'>{prog:.1f}%</div></div>"
+    )
+    msg = html.escape(status) if status else "Running..." if _CLONE_STATE["running"] else ""
+    if msg:
+        return bar + f"<p>{msg}</p>"
+    return bar
+
+
+def view_pi_remote(*, target: str = None):
+    """Web view to clone the running Pi to another card.
+
+    Providing ``target`` will start the cloning process. Otherwise a form
+    with available devices is shown. The progress bar refreshes automatically
+    using ``render_clone_progress``.
+    """
+    if target and not _CLONE_STATE["running"]:
+        _CLONE_STATE.update(running=True, progress=0.0, status="", target=target)
+        threading.Thread(target=_run_clone, args=(target,), daemon=True).start()
+
+    devices = _list_devices()
+    options = ""
+    for d in devices:
+        sel = " selected" if d == target else ""
+        options += f'<option value="{d}"{sel}>{d}</option>'
+    form = (
+        "<form method='post'>"
+        f"<select name='target'>{options}</select>"
+        "<button type='submit'>Clone</button>"
+        "</form>"
+    )
+
+    progress = (
+        "<div id='clone-progress' data-gw-render='clone_progress' "
+        "data-gw-refresh='1' data-gw-on-load></div>"
+    )
+
+    html = "".join(["<h1>Pi Remote Clone</h1>", form, progress])
+    return gw.web.app.render_template(
+        title="Pi Remote Clone",
+        content=html,
+        css_files=["/static/tabs.css"],
+        js_files=["/static/render.js"],
+    )

--- a/tests/test_rpi.py
+++ b/tests/test_rpi.py
@@ -1,0 +1,53 @@
+import unittest
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+class RpiCloneTests(unittest.TestCase):
+    @staticmethod
+    def _load_rpi():
+        rpi_path = Path(__file__).resolve().parents[1] / 'projects' / 'rpi.py'
+        spec = importlib.util.spec_from_file_location('rpi', rpi_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+    @classmethod
+    def setUpClass(cls):
+        cls.rpi = cls._load_rpi()
+
+    def test_ru_invokes_dd(self):
+        with patch.object(self.rpi.subprocess, 'run') as run_mock:
+            run_mock.return_value = MagicMock(returncode=0, stdout='ok', stderr='')
+            result = self.rpi.ru('/dev/test')
+            run_mock.assert_called_with([
+                'sudo', 'dd', 'if=/dev/mmcblk0', 'of=/dev/test', 'bs=4M',
+                'status=progress', 'conv=fsync'
+            ], capture_output=True, text=True)
+            self.assertEqual(result, 'ok')
+
+    def test_view_pi_remote_lists_devices(self):
+        with patch.object(self.rpi, '_list_devices', return_value=['/dev/sda']), \
+             patch.object(self.rpi.gw.web.app, 'render_template', lambda **kw: kw['content']):
+            html = self.rpi.view_pi_remote()
+        self.assertIn('/dev/sda', html)
+        self.assertIn('clone-progress', html)
+
+    def test_view_pi_remote_starts_clone(self):
+        def fake_thread(target, args=(), daemon=None):
+            class _T:
+                def start(self):
+                    target(*args)
+            return _T()
+
+        with patch.object(self.rpi, '_list_devices', return_value=['/dev/sda']), \
+             patch.object(self.rpi.gw.web.app, 'render_template', lambda **kw: kw['content']), \
+             patch.object(self.rpi, 'ru') as ru_mock, \
+             patch.object(self.rpi.threading, 'Thread', side_effect=fake_thread):
+            html = self.rpi.view_pi_remote(target='/dev/sda')
+        ru_mock.assert_called_with('/dev/sda')
+        self.assertIn('clone-progress', html)
+        self.assertEqual(self.rpi._CLONE_STATE['progress'], 100.0)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new `rpi` project for Raspberry Pi helpers
- implement `ru` function to clone running Pi to another microSD
- document new project
- link to documentation from root README
- test cloning helper
- add web UI `view_pi_remote` to start cloning with a progress bar

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68718f48ed688326850a4d62781a0c6f