### PR TITLE
Fix nmcli monitor input HTML

### DIFF
--- a/projects/monitor/nmcli.py
+++ b/projects/monitor/nmcli.py
@@ -20,6 +20,7 @@ Renders:
 
 import subprocess
 import shlex
+import html
 from bottle import request
 from gway import gw
 from gway.sigils import _unquote
@@ -518,12 +519,12 @@ def _render_run_form(cmd: str = "", output: str = "") -> str:
     url = gw.web.app.build_url("run") if hasattr(gw, "web") else "run"
     form = [
         f"<form method='post' action='{url}' style='margin-top:8px;'>",
-        f"<input type='text' name='cmd' value='{gw.cast.to_html(cmd)}' placeholder='nmcli arguments' style='width:70%;'>",
+        f"<input type='text' name='cmd' value='{html.escape(cmd, quote=True)}' placeholder='nmcli arguments' style='width:70%;'>",
         "<button type='submit'>Run</button>",
         "</form>",
     ]
     if output:
-        form.append(f"<pre>{gw.cast.to_html(output)}</pre>")
+        form.append(f"<pre>{html.escape(output)}</pre>")
     return "".join(form)
 
 


### PR DESCRIPTION
## Summary
- escape cmd and output strings in NMCLI monitor forms

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687199060fa883269a42ab872397c084