### PR TITLE
Rename until flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -103,7 +103,7 @@ Example Recipe
    web app setup web.navbar --home style-changer
    web app setup web.site --home reader
    web server start-app --host 127.0.0.1 --port 8888
-   until --forever
+   until --done
 
 
 Run ``gway -r recipes/site.gwr`` and visit ``http://127.0.0.1:8888`` to browse

--- a/gway/runner.py
+++ b/gway/runner.py
@@ -46,8 +46,8 @@ class Runner:
                     self.log(f"[timed] {func_name} (async) took {time.perf_counter() - start_time:.3f}s")
 
     def until(self, *, file=None, url=None, pypi=False, version=False, build=False,
-              forever=False, notify=False, notify_only=False, abort=False):
-        assert file or url or pypi or version or build or forever, "Use --forever for unconditional looping."
+              done=False, notify=False, notify_only=False, abort=False):
+        assert file or url or pypi or version or build or done, "Use --done for unconditional looping."
 
         if not self._async_threads and hasattr(self, "critical"):
             self.critical("No async threads detected before entering loop.")

--- a/recipes/crud_site.gwr
+++ b/recipes/crud_site.gwr
@@ -12,4 +12,4 @@ web app setup:
 web:
  - static collect
  - server start-app --port 8888
-until --forever
+until --done

--- a/recipes/etron/cloud.gwr
+++ b/recipes/etron/cloud.gwr
@@ -23,4 +23,4 @@ web:
  - auth config-basic
  - server start-app --host 0.0.0.0 --port 8000 --ws-port 9000
 
-until --file VERSION
+until --version

--- a/recipes/etron/local.gwr
+++ b/recipes/etron/local.gwr
@@ -22,4 +22,4 @@ web:
 # This only makes sense for NetworkManager in Linux 
 monitor start-watch nmcli 
 
-until --file VERSION
+until --version

--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -11,5 +11,5 @@ web:
  - static collect
 - server start-app --port 8888
 
-until --forever
+until --done
 

--- a/recipes/skeleton.gwr
+++ b/recipes/skeleton.gwr
@@ -7,4 +7,4 @@ web app setup:
 web:
  - static collect
 - server start-app
-until --forever
+until --done

--- a/recipes/test/etron/cloud.gwr
+++ b/recipes/test/etron/cloud.gwr
@@ -23,4 +23,4 @@ web:
  - auth config-basic --temp-link
  - server start-app --host 0.0.0.0 --port 18000 --ws-port 19000
 
-until --file VERSION
+until --version

--- a/recipes/test/etron/local_proxy.gwr
+++ b/recipes/test/etron/local_proxy.gwr
@@ -16,4 +16,4 @@ web:
  - static collect
  - server start-app --host 0.0.0.0 --port 18888 --ws-port 19900 --proxy http://127.0.0.1:18000
 
-until --file VERSION
+until --version


### PR DESCRIPTION
## Summary
- rename the `forever` option in `Runner.until` to `done`
- update recipes that used `until --forever`
- replace uses of `--file VERSION` with `--version`
- adjust README snippet

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68719747a8b08326b09d746602da7be8