### PR TITLE
Handle domain-based WS URLs

### DIFF
--- a/tests/test_web_urls.py
+++ b/tests/test_web_urls.py
@@ -53,7 +53,7 @@ class BaseURLTests(unittest.TestCase):
         }
         with patch.object(gw, "resolve", side_effect=make_resolver(mapping)):
             with patch.object(gw.cast, "to_bool", return_value=True):
-                self.assertEqual(web.base_ws_url(), "wss://example.com:6789")
+                self.assertEqual(web.base_ws_url(), "wss://example.com")
 
     def test_base_ws_url_local_forced_ws(self):
         mapping = {


### PR DESCRIPTION
## Summary
- avoid including the WS port when a valid domain name is used
- adapt tests to new WS URL behavior

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6871b0747f288326a3fb24187b4f06f9