### PR TITLE
Fix nmcli run view recipe

### DIFF
--- a/recipes/etron/local.gwr
+++ b/recipes/etron/local.gwr
@@ -8,6 +8,7 @@ web app setup:
     - ocpp.csms --home charger-status
     - ocpp.evcs --home cp-simulator
     - monitor --home monitor-panel
+    - monitor.nmcli --home run
     - ocpp.data --home charger-summary
 
 # Toggle this version to apply the allowlist  


### PR DESCRIPTION
## Summary
- register `monitor.nmcli` in the etron example recipe so `/monitor/nmcli/run` works

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6871b36dca748326a21baf6bbfc0c999