### PR TITLE
Add EVCS simulator alias and docs

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -12,7 +12,12 @@ Launch a simulator session pointing at your CSMS with:
 
 .. code-block:: bash
 
-   gway ocpp.evcs simulate --host 127.0.0.1 --ws-port 9000 --cp-path CPX
+   gway ocpp.evcs simulate \
+       --host 127.0.0.1 --ws-port 9000 \
+       --cp-path ocpp/csms/CPX
+
+The simulator can also be controlled via the web UI at
+``/ocpp/evcs/cp-simulator`` (call ``gw.ocpp.evcs.view_simulator``).
 
 The simulator accepts ``--kwh-min`` and ``--kwh-max`` to control the
 approximate energy delivered per session. For example, ``--kwh-min 40

--- a/data/static/ocpp/evcs/README.rst
+++ b/data/static/ocpp/evcs/README.rst
@@ -2,3 +2,6 @@ EVCS Simulator
 --------------
 
 Mock charge point that connects to the CSMS dashboard.
+Launch it with ``gway ocpp.evcs simulate`` and open
+``/ocpp/evcs/cp-simulator`` (``gw.ocpp.evcs.view_simulator``)
+to start or stop sessions and view status.

--- a/projects/ocpp/evcs.py
+++ b/projects/ocpp/evcs.py
@@ -323,10 +323,6 @@ async def simulate_cp(
                     print(f"[Simulator:{cp_name}] Session reset requested.")
                     continue
 
-                if reset_event.is_set():
-                    print(f"[Simulator:{cp_name}] Session reset requested.")
-                    continue
-
                 loop_count += 1
                 if session_count == float('inf'):
                     continue  # loop forever
@@ -548,3 +544,8 @@ def view_cp_simulator(*args, **kwargs):
     html.append(f'<pre>{_simulator_status_json()}</pre></details>')
 
     return "".join(html)
+
+
+def view_simulator(*args, **kwargs):
+    """Alias for :func:`view_cp_simulator`."""
+    return view_cp_simulator(*args, **kwargs)

--- a/tests/test_charger_refresh.py
+++ b/tests/test_charger_refresh.py
@@ -106,6 +106,7 @@ class ChargerDashboardRefreshTests(unittest.TestCase):
                 timeout=5,
             )
             self.assertIn("SIMDASH", resp.text)
+            self.assertRegex(resp.text, r"kWh\.</td>\s*<td class=\"value\">[0-9.]+")
             await sim_task
         asyncio.run(run_sim_and_check())
 


### PR DESCRIPTION
## Summary
- fix duplicate reset check in `evcs.simulate_cp`
- add `view_simulator` alias in `ocpp.evcs`
- document simulator path and UI in OCPP README
- expand EVCS README with usage notes
- test charger dashboard shows energy

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6871ba03ebd083269328453e28d69e85