### PR TITLE
Add verbose logging for charger status view

### DIFF
--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -474,6 +474,10 @@ def view_charger_status(*, action=None, charger_id=None, show=None, **_):
     """
     msg = ""
     show = show or request.query.get("show")
+    gw.verbose(
+        f"view_charger_status start: action={action} charger_id={charger_id} show={show}",
+        func="view_charger_status",
+    )
     if request.method == "POST":
         action = request.forms.get("action")
         charger_id = request.forms.get("charger_id")
@@ -485,12 +489,23 @@ def view_charger_status(*, action=None, charger_id=None, show=None, **_):
                 gw.error(f"Failed to dispatch action {action} to {charger_id}: {e}")
                 msg = f"Error: {e}"
 
+    gw.verbose(
+        f"active_cons={list(_active_cons.keys())}", func="view_charger_status"
+    )
+    gw.verbose(
+        f"transactions={list(_transactions.keys())}", func="view_charger_status"
+    )
+
     all_chargers = set(_active_cons) | set(_transactions)
     if show == "all":
         try:
             all_chargers |= set(gw.ocpp.data.list_chargers())
         except Exception:
             pass
+    gw.verbose(
+        f"all_chargers={sorted(all_chargers)} show={show}",
+        func="view_charger_status",
+    )
     html = [
         '<link rel="stylesheet" href="/static/ocpp/csms/charger_status.css">',
         '<script src="/static/render.js"></script>',


### PR DESCRIPTION
## Summary
- instrument ocpp dashboard to log active connections and transactions

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68725680a2608326ae3308ef635a68c0