### PR TITLE
Add VS Code launch configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,22 @@
             "module": "gway",
             "args": ["-dr", "website"],
             "console": "integratedTerminal"
+        },
+        {
+            "name": "Run Gway Website (Normal)",
+            "type": "python",
+            "request": "launch",
+            "module": "gway",
+            "args": ["-r", "website"],
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Debug Gway Website Verbose",
+            "type": "python",
+            "request": "launch",
+            "module": "gway",
+            "args": ["-dv", "-r", "website"],
+            "console": "integratedTerminal"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- add VSCode launch option to run website normally
- add VSCode launch option to run website with verbose debugging

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687264a3958483269aa7ce5e98540208