### PR TITLE
Add project-readmes view and cleanup README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,53 +186,15 @@ Tests are discovered recursively so directories under ``tests`` may mirror the s
 Project READMEs
 ---------------
 
-The following projects bundle additional documentation.  Each link uses
-``view_reader`` to render the ``README.rst`` file directly from the
-``data/static`` folder.
-
-- `awg </web/site/reader?tome=awg>`_
-- `cdv </web/site/reader?tome=cdv>`_
-- `sql </web/site/reader?tome=sql>`_
-- `games </web/site/reader?tome=games>`_
-  - `conway </web/site/reader?tome=games/conway>`_
-  - `mtg </web/site/reader?tome=games/mtg>`_
-  - `qpig </web/site/reader?tome=games/qpig>`_
-- `monitor </web/site/reader?tome=monitor>`_
-- `ocpp </web/site/reader?tome=ocpp>`_
-  - `csms </web/site/reader?tome=ocpp/csms>`_
-  - `evcs </web/site/reader?tome=ocpp/evcs>`_
-  - `data </web/site/reader?tome=ocpp/data>`_
-- `release </web/site/reader?tome=release>`_
-- `vbox </web/site/reader?tome=vbox>`_
-- `web </web/site/reader?tome=web>`_
-  - `nav </web/site/reader?tome=web/nav>`_
-  - `cookies </web/site/reader?tome=web/cookies>`_
-  - `auth </web/site/reader?tome=web/auth>`_
-  - `chat </web/site/reader?tome=web/chat>`_
-
-.. _/web/site/reader?tome=awg: /web/site/reader?tome=awg
-.. _/web/site/reader?tome=cdv: /web/site/reader?tome=cdv
-.. _/web/site/reader?tome=sql: /web/site/reader?tome=sql
-.. _/web/site/reader?tome=games: /web/site/reader?tome=games
-.. _/web/site/reader?tome=games/conway: /web/site/reader?tome=games/conway
-.. _/web/site/reader?tome=games/mtg: /web/site/reader?tome=games/mtg
-.. _/web/site/reader?tome=games/qpig: /web/site/reader?tome=games/qpig
-.. _/web/site/reader?tome=monitor: /web/site/reader?tome=monitor
-.. _/web/site/reader?tome=ocpp: /web/site/reader?tome=ocpp
-.. _/web/site/reader?tome=ocpp/csms: /web/site/reader?tome=ocpp/csms
-.. _/web/site/reader?tome=ocpp/evcs: /web/site/reader?tome=ocpp/evcs
-.. _/web/site/reader?tome=ocpp/data: /web/site/reader?tome=ocpp/data
-.. _/web/site/reader?tome=release: /web/site/reader?tome=release
-.. _/web/site/reader?tome=vbox: /web/site/reader?tome=vbox
-.. _/web/site/reader?tome=web: /web/site/reader?tome=web
-.. _/web/site/reader?tome=web/nav: /web/site/reader?tome=web/nav
-.. _/web/site/reader?tome=web/cookies: /web/site/reader?tome=web/cookies
-.. _/web/site/reader?tome=web/auth: /web/site/reader?tome=web/auth
-.. _/web/site/reader?tome=web/chat: /web/site/reader?tome=web/chat
-
+Visit `/web/site/project-readmes`_ to browse the documentation bundled with
+each project. The page is generated automatically using ``view_project_readmes``
+so newly added README files appear without edits to this list.
 
 You can generate these links yourself with
 ``gw.web.build_url('web/site/reader', tome='proj')``.
+
+.. _/web/site/project-readmes: /web/site/project-readmes
+
 
 License
 -------

--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -570,3 +570,20 @@ def view_debug_info():
     )
 
 
+def view_project_readmes():
+    """Render an HTML list of README links discovered under ``data/static``."""
+    base_dir = Path(gw.resource('data', 'static'))
+    items = []
+    for path in sorted(base_dir.rglob('README.rst')):
+        rel = path.relative_to(base_dir).with_suffix('')
+        parts = rel.parts
+        if any(_is_hidden_or_private(p) for p in parts):
+            continue
+        tome = '/'.join(parts)
+        url = gw.web.app.build_url('web', 'site', 'reader', tome=tome)
+        label = tome.replace('_', ' ')
+        items.append(f"<li><a href='{url}'>{html.escape(label)}</a></li>")
+    body = '<ul>' + ''.join(items) + '</ul>' if items else '<p>No READMEs found.</p>'
+    return '<h1>Project READMEs</h1>' + body
+
+


### PR DESCRIPTION
## Summary
- shorten README project documentation section
- add `/web/site/project-readmes` view to auto-generate links

## Testing
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_687264f4d9808326845977470989047b