### PR TITLE
Remove invalid func kwargs from log calls

### DIFF
--- a/gway/gateway.py
+++ b/gway/gateway.py
@@ -158,7 +158,7 @@ class Gateway(Resolver, Runner):
 
         result = set(discover_projects(projects_path))
         sorted_result = sorted(result)
-        self.verbose(f"Discovered projects: {sorted_result}", func="projects")
+        self.verbose(f"[projects] Discovered projects: {sorted_result}")
         return sorted_result
 
     def builtins(self):
@@ -223,7 +223,7 @@ class Gateway(Resolver, Runner):
                         if (value is inspect.Parameter.empty or value is None) and name in type(self).defaults:
                             value = type(self).defaults[name]
                             if self.verbose:
-                                self.verbose(f"Injected default {name}={value!r} from Gateway.defaults", func="wrap_callable")
+                                self.verbose(f"[wrap_callable] Injected default {name}={value!r} from Gateway.defaults")
 
                     ann = param.annotation
                     if ann in (int, float, str, bool) and value is not None and not isinstance(value, ann):

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -475,8 +475,7 @@ def view_charger_status(*, action=None, charger_id=None, show=None, **_):
     msg = ""
     show = show or request.query.get("show")
     gw.verbose(
-        f"view_charger_status start: action={action} charger_id={charger_id} show={show}",
-        func="view_charger_status",
+        f"[view_charger_status] start: action={action} charger_id={charger_id} show={show}"
     )
     if request.method == "POST":
         action = request.forms.get("action")
@@ -490,10 +489,10 @@ def view_charger_status(*, action=None, charger_id=None, show=None, **_):
                 msg = f"Error: {e}"
 
     gw.verbose(
-        f"active_cons={list(_active_cons.keys())}", func="view_charger_status"
+        f"[view_charger_status] active_cons={list(_active_cons.keys())}"
     )
     gw.verbose(
-        f"transactions={list(_transactions.keys())}", func="view_charger_status"
+        f"[view_charger_status] transactions={list(_transactions.keys())}"
     )
 
     all_chargers = set(_active_cons) | set(_transactions)
@@ -503,8 +502,7 @@ def view_charger_status(*, action=None, charger_id=None, show=None, **_):
         except Exception:
             pass
     gw.verbose(
-        f"all_chargers={sorted(all_chargers)} show={show}",
-        func="view_charger_status",
+        f"[view_charger_status] all_chargers={sorted(all_chargers)} show={show}"
     )
     html = [
         '<link rel="stylesheet" href="/static/ocpp/csms/charger_status.css">',


### PR DESCRIPTION
## Summary
- fix `gw.verbose` calls that used `func=` which caused `TypeError`
- fold the function name into the log message

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6872793f27888326896d2a3c62718cf4