### PR TITLE
Remove CLI completion docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,28 +39,6 @@ framework itself clone the repository and install it in editable mode:
    pip install -r requirements.txt
    pip install -e .
 
-Shell Autocompletion
---------------------
-
-GWAY uses ``argcomplete`` to offer optional tab completion. Install the
-package and register the completion script for your shell::
-
-   pip install argcomplete
-   register-python-argcomplete gway >> ~/.bashrc
-
-For PowerShell::
-
-   register-python-argcomplete gway -s powershell | Out-String | Invoke-Expression
-
-CLI Helpers
------------
-
-An experimental project ``cli`` exposes utilities related to the command
-line interface. The ``cli.completions`` function lists available
-builtin and project commands and can aid in building custom completion
-scripts::
-
-   gway cli completions
 
 Core Concepts
 -------------


### PR DESCRIPTION
## Summary
- drop `Shell Autocompletion` and `CLI Helpers` sections from README

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6871c9c158308326b3e1b5b73546a9f0