### PR TITLE
Improve project readme listing

### DIFF
--- a/data/static/styles/base.css
+++ b/data/static/styles/base.css
@@ -160,6 +160,19 @@ aside ul.sub-links li a {
     padding: 0.2em 0.5em;
 }
 
+/* Project README tree */
+.readme-list,
+.readme-list ul {
+    list-style: none;
+    padding-left: 1em;
+    margin: 0;
+}
+.readme-list > li { margin-bottom: 0.4em; }
+@media (min-width: 700px) {
+    .readme-list { display: flex; flex-wrap: wrap; }
+    .readme-list > li { width: 50%; box-sizing: border-box; padding-right: 1em; }
+}
+
 /* 8. Buttons & form controls */
 button, input[type="submit"], input[type="button"] {
     background: var(--accent-alt, #007bff);


### PR DESCRIPTION
## Summary
- display project docs as a tree
- style README list with optional two columns

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6872d570a1988326a5c7d401f7a81c8a