### PR TITLE
Add flag usage mapping

### DIFF
--- a/TESTING.rst
+++ b/TESTING.rst
@@ -20,17 +20,28 @@ can enable them by passing feature flags to ``gway test``:
 
 .. code-block:: bash
 
-   gway test --flags screenshot
+   gway test --flags screen
 
-Integration suites that launch helper servers are disabled unless the
-``integration`` flag is present:
+Integration suites that launch helper servers require specific flags.
+Use ``ocpp`` for the charger and Etron tests or ``proxy`` for the
+fallback proxy suite:
 
 .. code-block:: bash
 
-   gway test --flags integration
+   gway test --flags ocpp
+
+.. code-block:: bash
+
+   gway test --flags proxy
 
 The flags are stored in the ``GW_TEST_FLAGS`` environment variable, which test
 cases can check via ``is_test_flag('flag')``.
+
+To list all available flags, run:
+
+.. code-block:: bash
+
+   gway help --list-flags
 
 Importing Project Modules
 -------------------------

--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -52,8 +52,9 @@ Run them via ``gway run <recipe>``. For example:
 
 The integration suite includes ``tests/test_proxy_fallback.py`` which
 starts both the local and cloud recipes to verify that requests are
-proxied once the cloud is available. This harness can serve as a
-template for offline-first deployments.
+proxied once the cloud is available. Enable it with the ``proxy`` test
+flag. This harness can serve as a template for offline-first
+deployments.
 
 OCPP Data Storage
 -----------------

--- a/gway/builtins/help_utils.py
+++ b/gway/builtins/help_utils.py
@@ -8,8 +8,11 @@ __all__ = [
 ]
 
 
-def help(*args, full: bool = False):
+def help(*args, full: bool = False, list_flags: bool = False):
     from gway import gw
+    if list_flags:
+        from .testing import list_flags as _list_flags
+        return {"Test Flags": _list_flags()}
     gw.info(f"Help on {' '.join(args)} requested")
 
     def extract_gw_refs(source: str):

--- a/tests/test_auth_charger.py
+++ b/tests/test_auth_charger.py
@@ -114,7 +114,7 @@ class AuthChargerStatusTests(unittest.TestCase):
         )
         self.assertIn("cookie", resp2.text.lower())
 
-    @unittest.skipUnless(is_test_flag("screenshot"), "Screenshot tests disabled")
+    @unittest.skipUnless(is_test_flag("screen"), "Screen tests disabled")
     def test_charger_status_screenshot(self):
         """Capture charger status page screenshot using basic auth."""
         screenshot_dir = Path("work/screenshots")

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -67,6 +67,13 @@ class GatewayBuiltinsTests(unittest.TestCase):
         help_result = gw.help('hello-world')
         self.assertEqual(help_result['Sample CLI'], 'gway hello-world')
 
+    def test_help_list_flags(self):
+        flags = gw.help(list_flags=True)["Test Flags"]
+        expected = {"failure", "ocpp", "proxy", "screen"}
+        self.assertEqual(set(flags.keys()), expected)
+        for tests in flags.values():
+            self.assertIsInstance(tests, list)
+
     def test_abort(self):
         """Test that the abort function raises a SystemExit exception."""
         with self.assertRaises(SystemExit):

--- a/tests/test_charger_refresh.py
+++ b/tests/test_charger_refresh.py
@@ -36,7 +36,7 @@ def _auth_header(username, password):
     b64 = base64.b64encode(up.encode()).decode()
     return {"Authorization": f"Basic {b64}"}
 
-@unittest.skipUnless(is_test_flag("integration"), "Integration tests disabled")
+@unittest.skipUnless(is_test_flag("ocpp"), "OCPP tests disabled")
 class ChargerDashboardRefreshTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -79,7 +79,7 @@ class ChargerDashboardRefreshTests(unittest.TestCase):
             except OSError:
                 time.sleep(0.2)
         raise TimeoutError(f"Port {port} not responding after {timeout} seconds")
-    @unittest.skipUnless(is_test_flag("integration"), "Integration tests disabled")
+    @unittest.skipUnless(is_test_flag("ocpp"), "OCPP tests disabled")
 
     def test_dashboard_updates_with_simulator(self):
         async def run_sim_and_check():

--- a/tests/test_conway_web.py
+++ b/tests/test_conway_web.py
@@ -145,7 +145,7 @@ class ConwayWebTests(unittest.TestCase):
         js_links = [script['src'] for script in body.find_all('script', src=True)]
         self.assertIn("/shared/global.js", js_links, f"/shared/global.js not linked before </body>: {js_links}")
 
-    @unittest.skipUnless(is_test_flag("screenshot"), "Screenshot tests disabled")
+    @unittest.skipUnless(is_test_flag("screen"), "Screen tests disabled")
     def test_conway_game_page_screenshot(self):
         """Capture a screenshot of the Game of Life page for manual review."""
         screenshot_dir = Path("work/screenshots")

--- a/tests/test_etron_ws.py
+++ b/tests/test_etron_ws.py
@@ -20,7 +20,7 @@ UNKNOWN_TAG = "ZZZZZZZZ"
 
 import signal
 
-@unittest.skipUnless(is_test_flag("integration"), "Integration tests disabled")
+@unittest.skipUnless(is_test_flag("ocpp"), "OCPP tests disabled")
 class EtronWebSocketTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -392,7 +392,7 @@ class EtronWebSocketTests(unittest.TestCase):
         self.assertAlmostEqual(gw.ocpp.power_consumed(js), 1.0, places=2)
         self.assertAlmostEqual(gw.ocpp.extract_meter(js), 1.0, places=2)
 
-    @unittest.skipUnless(is_test_flag("integration"), "Integration tests disabled")
+    @unittest.skipUnless(is_test_flag("ocpp"), "OCPP tests disabled")
     def test_remote_stop_transaction(self):
         """Dashboard Stop action triggers RemoteStopTransaction on the CP."""
         uri = "ws://127.0.0.1:19000/stopper?token=foo"

--- a/tests/test_nav_styles.py
+++ b/tests/test_nav_styles.py
@@ -170,7 +170,7 @@ class NavStyleTests(unittest.TestCase):
         link = soup2.find("link", rel="stylesheet", href=lambda h: h and "styles/" in h and h.endswith(".css"))
         self.assertIsNotNone(link, "Page missing stylesheet link for random theme")
 
-    @unittest.skipUnless(is_test_flag("screenshot"), "Screenshot tests disabled")
+    @unittest.skipUnless(is_test_flag("screen"), "Screen tests disabled")
     def test_style_switcher_screenshot(self):
         """Capture a screenshot of the style switcher page."""
         screenshot_dir = Path("work/screenshots")

--- a/tests/test_proxy_fallback.py
+++ b/tests/test_proxy_fallback.py
@@ -15,7 +15,7 @@ from gway import gw
 
 KNOWN_TAG = "FFFFFFFF"
 
-@unittest.skipUnless(is_test_flag("integration"), "Integration tests disabled")
+@unittest.skipUnless(is_test_flag("proxy"), "Proxy tests disabled")
 class ProxyFallbackTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):

--- a/tests/test_screenshot_attachment.py
+++ b/tests/test_screenshot_attachment.py
@@ -39,7 +39,7 @@ class ScreenshotAttachmentTest(unittest.TestCase):
                 time.sleep(0.2)
         raise TimeoutError(f"Port {port} not responding after {timeout} seconds")
 
-    @unittest.skipUnless(is_test_flag("screenshot"), "Screenshot tests disabled")
+    @unittest.skipUnless(is_test_flag("screen"), "Screen tests disabled")
     def test_capture_help_page_screenshot(self):
         screenshot_dir = Path("work/screenshots")
         screenshot_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- rename the `screenshot` test flag to `screen`
- enhance `list_flags` to return a mapping of flags to tests
- make `gw.help --list-flags` expose the mapping
- adjust docs and tests for the new flag and API

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6871bd2780e88326972bca997ddddf7f