### PR TITLE
Update MTG view and UI tweaks

### DIFF
--- a/data/static/games/mtg/search_games.css
+++ b/data/static/games/mtg/search_games.css
@@ -110,6 +110,7 @@
 }
 .mtg-life button {
     margin-left: 4px;
-    padding: 2px 6px;
+    padding: 2px 8px;
+    min-width: 28px;
     font-size: 1em;
 }

--- a/projects/games/games.py
+++ b/projects/games/games.py
@@ -36,7 +36,7 @@ _DEF = [
     ),
     (
         "Divination Wars",
-        "search-games",
+        "divination-wars",
         "Look up Magic: The Gathering cards using the Scryfall API.",
         "https://en.wikipedia.org/wiki/Magic:_The_Gathering",
     ),
@@ -77,8 +77,8 @@ def view_game_of_life(*args, **kwargs):
     return conway.view_game_of_life(*args, **kwargs)
 
 
-def view_search_games(*args, **kwargs):
-    return mtg.view_search_games(*args, **kwargs)
+def view_divination_wars(*args, **kwargs):
+    return mtg.view_divination_wars(*args, **kwargs)
 
 
 def view_qpig_farm(*args, **kwargs):

--- a/projects/games/mtg.py
+++ b/projects/games/mtg.py
@@ -204,10 +204,9 @@ def _render_card(card):
     """
     return html
 
-def view_search_games(
+def view_divination_wars(
     name=None,
     type_line=None,
-    card_type=None,
     oracle_text=None,
     set_name=None,
     discard=None,
@@ -259,17 +258,6 @@ def view_search_games(
                 elif type_line:
                     query_parts.append(f'type:"{type_line}"')
 
-    if card_type:
-        card_type, cs = _extract_colors(card_type)
-        colors.update(cs)
-        ct = card_type.strip().lower()
-        if ct in ("legendary", "snow"):
-            random_query = f"t:{ct} -t:creature"
-        else:
-            if ct in ("artifact", "enchantment"):
-                query_parts.append(f"t:{ct} -t:creature")
-            elif card_type:
-                query_parts.append(f'type:{ct}')
 
     if oracle_text:
         oracle_text, cs = _extract_colors(oracle_text)
@@ -377,7 +365,6 @@ def view_search_games(
     window.mtgSuggestions = {{
         name: {json.dumps(NAME_SUGGESTIONS)},
         type_line: {json.dumps(TYPE_SUGGESTIONS)},
-        card_type: {json.dumps(TYPE_SUGGESTIONS)},
         oracle_text: {json.dumps(TEXT_SUGGESTIONS)},
         set_name: {json.dumps(SET_SUGGESTIONS)},
     }};
@@ -439,10 +426,6 @@ def view_search_games(
                 <input type=\"text\" name=\"type_line\" value=\"{type_line}\" placeholder=\"Creature\">
             </div>
             <div class=\"mtg-form-row\">
-                <div class=\"mtg-label-row\"><label>CARD TYPE:</label><button class=\"mtg-random-btn\" type=\"button\" title=\"Random type\" onclick=\"mtgPickRandom('card_type')\">&#x1f3b2;</button></div>
-                <input type=\"text\" name=\"card_type\" value=\"{card_type}\" placeholder=\"Instant\">
-            </div>
-            <div class=\"mtg-form-row\">
                 <div class=\"mtg-label-row\"><label>RULES:</label><button class=\"mtg-random-btn\" type=\"button\" title=\"Random text\" onclick=\"mtgPickRandom('oracle_text')\">&#x1f3b2;</button></div>
                 <input type=\"text\" name=\"oracle_text\" value=\"{oracle_text}\" placeholder=\"draw a card\">
             </div>
@@ -464,7 +447,6 @@ def view_search_games(
     """.format(
         form_class=form_class,
         name=escape(name or ""), type_line=escape(type_line or ""),
-        card_type=escape(card_type or ""),
         oracle_text=escape(oracle_text or ""), set_name=escape(set_name or ""),
         turn=turn, library=library, life=life
     ))

--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -3,7 +3,7 @@
 
 web app setup:
     - web.site --home reader
-    - games --home games --links game-of-life,search-games,qpig-farm,massive-snake,fantastic-client
+    - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.nav --home style-switcher
     - web.cookies --home cookie-jar
 

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -14,7 +14,7 @@ web app setup:
     - ocpp.data --home charger-summary
     - ocpp.csms --auth required --home charger-status
     - ocpp.evcs --auth required --home cp-simulator
-    - games --home games --links game-of-life,search-games,qpig-farm,massive-snake,fantastic-client
+    - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth
 
 web:

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -14,7 +14,7 @@ web app setup:
     - ocpp.evcs --auth required --home cp-simulator
     - ocpp.data --auth required --home charger-summary
     - web.chat.actions --home audit-chatlog --auth required
-    - games --home games --links game-of-life,search-games,qpig-farm,massive-snake,fantastic-client
+    - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth
 
 web:


### PR DESCRIPTION
## Summary
- rename search view to `view_divination_wars`
- drop redundant `Card Type` search field
- widen life counter buttons for consistency
- update games links and recipes

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6872d66151f48326b8ad6263ae055356