### PR TITLE
Fix qpig farm emoji

### DIFF
--- a/projects/games/qpig.py
+++ b/projects/games/qpig.py
@@ -302,8 +302,8 @@ def view_qpig_farm(*, action: str = None, **_):
                 html.append(f"<button type='submit' name='action' value='place_{k}'>Feed {k}</button>")
 
     html.extend([
-        "<button type='button' id='qpig-save' title='Save'>\ud83d\udcbe</button>",
-        "<button type='button' id='qpig-load' title='Load'>\ud83d\udcc2</button>",
+        "<button type='button' id='qpig-save' title='Save'>💾</button>",
+        "<button type='button' id='qpig-load' title='Load'>📂</button>",
         "</form>",
         "</div>",
     ])


### PR DESCRIPTION
## Summary
- fix Unicode escape sequences for qpig save/load buttons

## Testing
- `pip install -e .`
- `gway test > /tmp/test.log && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_6872d5a63fe48326bac2ba666c903e21