### PR TITLE
Stop bundling envs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ venv/
 
 # Client/server environments
 *.env
+envs/
 
 # Temporary files
 temp/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,8 @@ include VERSION
 include requirements.txt
 include pyproject.toml
 recursive-include projects *
+recursive-include data *
+recursive-include recipes *
+# NOTE: environment files under envs/ are intentionally
+# excluded from the package because they may contain
+# sensitive user-specific data.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,13 @@ Sponsor = "https://www.gelectriic.com/"
 
 [tool.setuptools]
 packages = [ "gway",]
+include-package-data = true
+
+[tool.setuptools.package-data]
+"*" = [
+    "data/**/*",
+    "projects/**/*",
+    "recipes/**/*",
+]
+# envs/ is intentionally excluded to avoid packaging
+# user-specific environment files


### PR DESCRIPTION
## Summary
- exclude `envs/` from release bundles
- document exclusion in MANIFEST and pyproject
- ignore `envs/` directory in git

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6872ce9049d4832689d0b2df34794733