### PR TITLE
Fix glitch-punk theme background

### DIFF
--- a/data/static/styles/glitch-punk.css
+++ b/data/static/styles/glitch-punk.css
@@ -6,6 +6,7 @@
 :root {
   --bg: #090a10;
   --bg-alt: #16151e;
+  --main-bg: #090a10;
   --fg: #e0e0e0;
   --accent: #00fff3;
   --accent-alt: #ff0080;
@@ -30,8 +31,8 @@
 }
 
 /* Body and backgrounds */
-body {
-  background: var(--bg);
+body, .page-wrap {
+  background: var(--bg) !important;
   color: var(--fg);
   font-family: 'Roboto Mono', 'Fira Mono', 'Consolas', monospace;
 }


### PR DESCRIPTION
## Summary
- ensure the glitch-punk theme forces dark page background on mobile via `--main-bg`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6872dbc6658c8326a14ca03374dfc88f