### PR TITLE
Add VSCode release build launcher

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,6 +24,14 @@
             "module": "gway",
             "args": ["-dv", "-r", "website"],
             "console": "integratedTerminal"
+        },
+        {
+            "name": "Build Release",
+            "type": "python",
+            "request": "launch",
+            "module": "gway",
+            "args": ["release", "build", "--all"],
+            "console": "integratedTerminal"
         }
     ]
 }


### PR DESCRIPTION
## Summary
- add a VSCode launch configuration for running `gway release build --all`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687350f5c03c8326b7a93fb6059ad836