### PR TITLE
Support flexible gw- attributes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,7 @@ Unreleased
 
 - da736a6 fix missing setup-app for csms
 
-- support data-gw-on-load for one-time refresh events in render.js
+- support gw-on-load for one-time refresh events in render.js
 - add ChatGPT actions with passphrase trust system (web.chat.actions)
 - add audit log page for chat actions (view_audit_chatlog)
  

--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -28,7 +28,7 @@ connected chargers. Each card refreshes every few seconds so data
 stays current. Click a charger to open its detail page where you can
 send commands like ``Stop`` or ``Soft Reset`` and watch the log update
 in real time. The auto-refresh will collapse any open panels; you can
-temporarily disable it by removing the ``data-gw-refresh`` attribute
+temporarily disable it by removing the ``gw-refresh`` attribute
 from the page.
 
 The charger detail view also lists recent transactions. By default it

--- a/data/static/render.js
+++ b/data/static/render.js
@@ -1,27 +1,37 @@
 /**
  * GWAY Minimal Render Client (render.js)
  *
- * Finds all elements with data-gw-render. If data-gw-refresh is present, 
+ * Finds all elements with gw-render (also supports x-gw-render or data-gw-render).
+ * If gw-refresh is present,
  * auto-refreshes them using the named render endpoint, passing their params.
- * - data-gw-render: name of render function (without 'render_' prefix)
- * - data-gw-refresh: interval in seconds (optional)
- * - data-gw-params: comma-separated data attributes to POST (optional; defaults to all except data-gw-*)
- * - data-gw-target: 'content' (default, replace innerHTML), or 'replace' (replace the whole element)
- * - data-gw-click: any value starting with "re" to manually re-render the block on left click (optional, case-insensitive)
- * - data-gw-left-click: same as data-gw-click (optional)
- * - data-gw-right-click: any value starting with "re" to re-render on right click (optional, case-insensitive)
- * - data-gw-double-click: any value starting with "re" to re-render on double click (optional, case-insensitive)
- * - data-gw-on-load: load block once on page load (optional)
+ * - gw-render: name of render function (without 'render_' prefix)
+ * - gw-refresh: interval in seconds (optional)
+ * - gw-params: comma-separated data attributes to POST (optional; defaults to all except gw-*)
+ * - gw-target: 'content' (default, replace innerHTML), or 'replace' (replace the whole element)
+ * - gw-click: any value starting with "re" to manually re-render the block on left click (optional, case-insensitive)
+ * - gw-left-click: same as gw-click (optional)
+ * - gw-right-click: any value starting with "re" to re-render on right click (optional, case-insensitive)
+ * - gw-double-click: any value starting with "re" to re-render on double click (optional, case-insensitive)
+ * - gw-on-load: load block once on page load (optional)
  *
  * No external dependencies.
  */
 
 (function() {
   let timers = {};
+  const prefixes = ['gw-', 'x-gw-', 'data-gw-'];
 
-  // Extract params from data attributes as specified by data-gw-params or all non-gw- data attrs
+  function getAttr(el, name) {
+    for (let pre of prefixes) {
+      let val = el.getAttribute(pre + name);
+      if (val !== null) return val;
+    }
+    return null;
+  }
+
+  // Extract params from data attributes as specified by gw-params or all non-gw- data attrs
   function extractParams(el) {
-    let paramsAttr = el.getAttribute('data-gw-params');
+    let paramsAttr = getAttr(el, 'params');
     let params = {};
     if (paramsAttr) {
       paramsAttr.split(',').map(s => s.trim()).forEach(key => {
@@ -30,7 +40,7 @@
         if (val !== null) params[key.replace(/-([a-z])/g, g => g[1].toUpperCase())] = val;
       });
     } else {
-      // Use all data- attributes except data-gw-*
+      // Use all data- attributes except gw-* variants
       for (let { name, value } of Array.from(el.attributes)) {
         if (name.startsWith('data-') && !name.startsWith('data-gw-')) {
           let key = name.slice(5).replace(/-([a-z])/g, g => g[1].toUpperCase());
@@ -41,9 +51,9 @@
     return params;
   }
 
-  // Render a block using its data-gw-render attribute
+  // Render a block using its gw-render attribute
   function renderBlock(el) {
-    let func = el.getAttribute('data-gw-render');
+    let func = getAttr(el, 'render');
     if (!func) return;
     let params = extractParams(el);
     let urlBase = location.pathname.replace(/\/$/, '');
@@ -57,7 +67,7 @@
     })
     .then(res => res.text())
     .then(html => {
-      let target = el.getAttribute('data-gw-target') || 'content';
+      let target = getAttr(el, 'target') || 'content';
       if (target === 'replace') {
         let temp = document.createElement('div');
         temp.innerHTML = html;
@@ -74,14 +84,14 @@
     });
   }
 
-  // Set up auto-refresh for all data-gw-render blocks
+  // Set up auto-refresh for all gw-render blocks
   function setupAll() {
     // Clear existing timers
     Object.values(timers).forEach(clearInterval);
     timers = {};
-    // For each data-gw-render element
-    document.querySelectorAll('[data-gw-render]').forEach(el => {
-      let refresh = parseFloat(el.getAttribute('data-gw-refresh'));
+    // For each gw-render element
+    document.querySelectorAll('[gw-render],[x-gw-render],[data-gw-render]').forEach(el => {
+      let refresh = parseFloat(getAttr(el, 'refresh'));
       if (!isNaN(refresh) && refresh > 0) {
         let id = el.id || Math.random().toString(36).slice(2);
         timers[id] = setInterval(() => renderBlock(el), refresh * 1000);
@@ -89,12 +99,12 @@
         renderBlock(el);
         el.dataset.gwLoaded = "1";
       }
-        let onLoad = el.getAttribute("data-gw-on-load");
+        let onLoad = getAttr(el, 'on-load');
         if (onLoad !== null && !el.dataset.gwLoaded) {
           renderBlock(el);
           el.dataset.gwLoaded = "1";
         }
-      let leftClick = el.getAttribute('data-gw-click') || el.getAttribute('data-gw-left-click');
+      let leftClick = getAttr(el, 'click') || getAttr(el, 'left-click');
       if (leftClick && /^re/i.test(leftClick) && !el.dataset.gwLeftClickSetup) {
         el.addEventListener('click', evt => {
           evt.preventDefault();
@@ -103,7 +113,7 @@
         el.dataset.gwLeftClickSetup = '1';
       }
 
-      let rightClick = el.getAttribute('data-gw-right-click');
+      let rightClick = getAttr(el, 'right-click');
       if (rightClick && /^re/i.test(rightClick) && !el.dataset.gwRightClickSetup) {
         el.addEventListener('contextmenu', evt => {
           evt.preventDefault();
@@ -112,7 +122,7 @@
         el.dataset.gwRightClickSetup = '1';
       }
 
-      let dblClick = el.getAttribute('data-gw-double-click');
+      let dblClick = getAttr(el, 'double-click');
       if (dblClick && /^re/i.test(dblClick) && !el.dataset.gwDoubleClickSetup) {
         el.addEventListener('dblclick', evt => {
           evt.preventDefault();

--- a/data/static/web/README.rst
+++ b/data/static/web/README.rst
@@ -23,10 +23,10 @@ insertion via ``render.js`` or inclusion in an ``iframe``.
 
 ``render.js`` also supports manual refresh hooks:
 
-- ``data-gw-click``/``data-gw-left-click`` – refresh on left click.
-- ``data-gw-right-click`` – refresh on right click.
-- ``data-gw-double-click`` – refresh on double click.
-- ``data-gw-on-load`` – refresh once when the page loads.
+- ``gw-click``/``gw-left-click`` – refresh on left click.
+- ``gw-right-click`` – refresh on right click.
+- ``gw-double-click`` – refresh on double click.
+- ``gw-on-load`` – refresh once when the page loads.
 
 Double clicking the QR compass in the sidebar triggers a dynamic refresh via
 ``render.js`` if the active project provides a ``render_compass`` function.

--- a/projects/monitor/rpi.py
+++ b/projects/monitor/rpi.py
@@ -111,8 +111,8 @@ def render_rpi(target: str | None = None) -> str:
         "</form>"
     )
     progress = (
-        "<div id='clone-progress' data-gw-render='clone_progress' "
-        "data-gw-refresh='1' data-gw-on-load></div>"
+        "<div id='clone-progress' gw-render='clone_progress' "
+        "gw-refresh='1' gw-on-load></div>"
     )
     return "".join(["<h2>Pi Remote Clone</h2>", form, progress])
 

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -468,7 +468,7 @@ def _render_charger_card(cid, tx, state, raw_hb, *, show_controls=True):
 def view_charger_status(*, action=None, charger_id=None, show=None, **_):
     """
     Card-based OCPP dashboard: summary of charger connections.
-    Renders <div id="charger-list" data-gw-render="charger_list" data-gw-refresh="5">
+    Renders <div id="charger-list" gw-render="charger_list" gw-refresh="5">
     so the client can periodically refresh the list via render.js.
     ``show=all`` includes historic chargers from the database.
     """
@@ -536,7 +536,7 @@ def view_charger_status(*, action=None, charger_id=None, show=None, **_):
 
     # --- The key block for autorefresh ---
     html.append(
-        f'<div id="charger-list" data-gw-render="charger_list" data-gw-refresh="5" data-gw-click="refresh" data-show="{show or ""}">' 
+        f'<div id="charger-list" gw-render="charger_list" gw-refresh="5" gw-click="refresh" data-show="{show or ""}">'
     )
     if not all_chargers:
         html.append('<p><em>No chargers connected or transactions seen yet.</em></p>')
@@ -634,7 +634,7 @@ def view_charger_detail(*, charger_id=None, **_):
         html.append(f'<p class="error">{msg}</p>')
 
     html.append(
-        f'<div id="charger-info" data-gw-render="charger_info" data-gw-refresh="5" data-gw-click="refresh" data-charger-id="{charger_id}">' +
+        f'<div id="charger-info" gw-render="charger_info" gw-refresh="5" gw-click="refresh" data-charger-id="{charger_id}">' +
         _render_charger_card(charger_id, tx, state, raw_hb) +
         '</div>'
     )
@@ -649,14 +649,14 @@ def view_charger_detail(*, charger_id=None, **_):
     )
 
     html.append(
-        f'<div id="charger-transactions" data-gw-render="charger_transactions" '
+        f'<div id="charger-transactions" gw-render="charger_transactions" '
         f'data-charger-id="{charger_id}" data-since="{since}" data-until="{until}">' +
         render_charger_transactions(charger_id=charger_id, since=since, until=until) +
         '</div>'
     )
 
     html.append(
-        f'<div id="charger-log" data-gw-render="charger_log" data-gw-refresh="2" data-gw-click="refresh" data-charger-id="{charger_id}">' +
+        f'<div id="charger-log" gw-render="charger_log" gw-refresh="2" gw-click="refresh" data-charger-id="{charger_id}">' +
         render_charger_log(charger_id=charger_id) +
         '</div>'
     )

--- a/projects/release.py
+++ b/projects/release.py
@@ -772,7 +772,7 @@ def view_test_cache():
     cov_table += "</table>"
 
     log_block = (
-        "<div id='test-log' data-gw-render='test_log' data-gw-refresh='2'>"
+        "<div id='test-log' gw-render='test_log' gw-refresh='2'>"
         + render_test_log()
         + "</div>"
     )

--- a/projects/rpi.py
+++ b/projects/rpi.py
@@ -117,8 +117,8 @@ def view_pi_remote(*, target: str = None):
     )
 
     progress = (
-        "<div id='clone-progress' data-gw-render='clone_progress' "
-        "data-gw-refresh='1' data-gw-on-load></div>"
+        "<div id='clone-progress' gw-render='clone_progress' "
+        "gw-refresh='1' gw-on-load></div>"
     )
 
     html = "".join(["<h1>Pi Remote Clone</h1>", form, progress])

--- a/projects/web/nav.py
+++ b/projects/web/nav.py
@@ -195,7 +195,7 @@ def render(*, homes=None, links=None):
         data_attr = ""
         if render_compass_exists:
             data_attr = (
-                ' data-gw-render="compass" data-gw-double-click="refresh"'
+                ' gw-render="compass" gw-double-click="refresh"'
             )
         compass = f'<div class="compass"{data_attr}>{compass}</div>'
 

--- a/tests/test_nav_compass.py
+++ b/tests/test_nav_compass.py
@@ -88,8 +88,8 @@ class NavCompassTests(unittest.TestCase):
         soup = BeautifulSoup(html, "html.parser")
         comp = soup.find("div", {"class": "compass"})
         self.assertIsNotNone(comp)
-        self.assertEqual(comp.get("data-gw-render"), "compass")
-        self.assertEqual(comp.get("data-gw-double-click"), "refresh")
+        self.assertEqual(comp.get("gw-render"), "compass")
+        self.assertEqual(comp.get("gw-double-click"), "refresh")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- update `render.js` to recognize `gw-`, `x-gw-`, or `data-gw-` attribute prefixes
- switch all HTML attribute examples and generators to the shorter `gw-` prefix
- adjust docs and tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68734e6e30e08326bdb7aea59bbea27c