### PR TITLE
Add tabs to Quantum Piggy Farm

### DIFF
--- a/data/static/games/qpig/farm.css
+++ b/data/static/games/qpig/farm.css
@@ -35,3 +35,25 @@
     margin-top: 1em;
     color: #a00;
 }
+
+.qpig-tabs {
+    display: flex;
+    gap: 4px;
+    margin-bottom: 8px;
+}
+
+.qpig-tab {
+    flex: 1;
+    padding: 4px;
+    border: 1px solid #333;
+    color: #fff;
+    cursor: pointer;
+}
+
+.qpig-tab[data-tab='garden'] { background: green; }
+.qpig-tab[data-tab='market'] { background: orange; }
+.qpig-tab[data-tab='lab'] { background: purple; }
+.qpig-tab[data-tab='travel'] { background: blue; }
+
+.qpig-panel { display: none; padding: 4px; }
+.qpig-panel.active { display: block; }

--- a/projects/games/qpig.py
+++ b/projects/games/qpig.py
@@ -276,8 +276,15 @@ def view_qpig_farm(*, action: str = None, **_):
 
     html = [
         '<link rel="stylesheet" href="/static/games/qpig/farm.css">',
+        '<h1>Quantum Piggy Farm</h1>',
         '<div class="qpig-garden">',
-        "<h1>Quantum Piggy Farm</h1>",
+        '<div class="qpig-tabs">',
+        '<button class="qpig-tab active" data-tab="garden">Garden</button>',
+        '<button class="qpig-tab" data-tab="market">Market</button>',
+        '<button class="qpig-tab" data-tab="lab">Lab</button>',
+        '<button class="qpig-tab" data-tab="travel">Travel</button>',
+        '</div>',
+        '<div id="qpig-panel-garden" class="qpig-panel active">',
         "<canvas id='qpig-canvas' width='32' height='32'></canvas>",
         '<div id="qpig-stats">',
         render_qpig_farm_stats(state),
@@ -305,7 +312,11 @@ def view_qpig_farm(*, action: str = None, **_):
         "<button type='button' id='qpig-save' title='Save'>💾</button>",
         "<button type='button' id='qpig-load' title='Load'>📂</button>",
         "</form>",
-        "</div>",
+        "</div>",  # close qpig-panel-garden
+        '<div id="qpig-panel-market" class="qpig-panel">Market coming soon</div>',
+        '<div id="qpig-panel-lab" class="qpig-panel">Lab coming soon</div>',
+        '<div id="qpig-panel-travel" class="qpig-panel">Travel coming soon</div>',
+        "</div>",  # close qpig-garden
     ])
 
     script = """
@@ -321,6 +332,15 @@ const load=document.getElementById('qpig-load');
 if(load){{load.addEventListener('click',()=>{{const inp=document.createElement('input');inp.type='file';inp.accept='.qpg';inp.onchange=e=>{{const f=e.target.files[0];if(!f)return;const r=new FileReader();r.onload=ev=>{{sessionStorage.setItem(KEY, ev.target.result.trim());location.reload();}};r.readAsText(f);}};inp.click();}});}}
 const canvas=document.getElementById('qpig-canvas');
 if(canvas){{const ctx=canvas.getContext('2d');const img=new Image();img.src='/static/games/qpig/pig.png';img.onload=()=>{{ctx.imageSmoothingEnabled=false;ctx.drawImage(img,0,0);}};}}
+const tabs=document.querySelectorAll('.qpig-tab');
+const panels=document.querySelectorAll('.qpig-panel');
+tabs.forEach(t=>t.addEventListener('click',()=>{{
+  tabs.forEach(x=>x.classList.remove('active'));
+  panels.forEach(p=>p.classList.remove('active'));
+  t.classList.add('active');
+  const panel=document.getElementById('qpig-panel-'+t.dataset.tab);
+  if(panel) panel.classList.add('active');
+}}));
 </script>
 """.format(state_b64=state_b64)
 


### PR DESCRIPTION
## Summary
- add tabbed sections to the Quantum Piggy Farm UI
- style tabs and panels with new colors

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687357bc1720832695dd353d06d2102b