### PR TITLE
Add destination filter to email search

### DIFF
--- a/tests/test_mail_search_sort_limit.py
+++ b/tests/test_mail_search_sort_limit.py
@@ -1,0 +1,73 @@
+import unittest
+import os
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from email.mime.text import MIMEText
+from gway import gw
+
+class FakeIMAP:
+    instances = []
+    count = 3
+    def __init__(self, server, port):
+        self.server = server
+        self.port = port
+        self._encoding = 'ascii'
+        self.utf8_enabled = False
+        FakeIMAP.instances.append(self)
+    def login(self, user, password):
+        pass
+    def enable(self, capability):
+        if capability.upper() == 'UTF8=ACCEPT':
+            self._encoding = 'utf-8'
+            self.utf8_enabled = True
+            return 'OK', [b'enabled']
+        raise Exception('unsupported')
+    def select(self, mailbox):
+        pass
+    def search(self, charset, *criteria):
+        self.last_search = (charset, list(criteria))
+        ids = ' '.join(str(i+1) for i in range(self.count))
+        return 'OK', [ids.encode()]
+    def fetch(self, mail_id, mode):
+        idx = int(mail_id.decode() if isinstance(mail_id, bytes) else mail_id)
+        msg = MIMEText('body')
+        msg['Subject'] = f'subject {idx}'
+        msg['From'] = 'sender@example.com'
+        dt = datetime(2024, 1, 1) + timedelta(days=idx)
+        msg['Date'] = dt.strftime('%a, %d %b %Y %H:%M:%S +0000')
+        return 'OK', [(None, msg.as_bytes())]
+    def close(self):
+        pass
+    def logout(self):
+        pass
+
+class MailSearchSortLimitTests(unittest.TestCase):
+    def setUp(self):
+        os.environ['MAIL_SENDER'] = 'test@example.com'
+        os.environ['MAIL_PASSWORD'] = 'secret'
+        os.environ['IMAP_SERVER'] = 'imap.example.com'
+        os.environ['IMAP_PORT'] = '993'
+        FakeIMAP.instances.clear()
+
+    def tearDown(self):
+        for var in ['MAIL_SENDER','MAIL_PASSWORD','IMAP_SERVER','IMAP_PORT']:
+            os.environ.pop(var, None)
+
+    def test_default_sort_descending_limit_10(self):
+        FakeIMAP.count = 12
+        with patch('imaplib.IMAP4_SSL', FakeIMAP):
+            results = gw.mail.search('hello')
+            self.assertEqual(len(results), 10)
+            self.assertEqual(results[0]['subject'], 'subject 12')
+            self.assertEqual(results[-1]['subject'], 'subject 3')
+
+    def test_reverse_sort_and_custom_limit(self):
+        FakeIMAP.count = 5
+        with patch('imaplib.IMAP4_SSL', FakeIMAP):
+            results = gw.mail.search('hello', limit=2, reverse=True)
+            self.assertEqual(len(results), 2)
+            self.assertEqual(results[0]['subject'], 'subject 1')
+            self.assertEqual(results[1]['subject'], 'subject 2')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_mail_search_to.py
+++ b/tests/test_mail_search_to.py
@@ -1,0 +1,68 @@
+import unittest
+import os
+from unittest.mock import patch
+from email.mime.text import MIMEText
+from gway import gw
+
+class FakeIMAP:
+    instances = []
+    def __init__(self, server, port):
+        self.server = server
+        self.port = port
+        self._encoding = 'ascii'
+        self.utf8_enabled = False
+        FakeIMAP.instances.append(self)
+    def login(self, user, password):
+        pass
+    def enable(self, capability):
+        if capability.upper() == 'UTF8=ACCEPT':
+            self._encoding = 'utf-8'
+            self.utf8_enabled = True
+            return 'OK', [b'enabled']
+        raise Exception('unsupported')
+    def select(self, mailbox):
+        pass
+    def search(self, charset, *criteria):
+        self.last_search = (charset, list(criteria))
+        return 'OK', [b'1']
+    def fetch(self, mail_id, mode):
+        msg = MIMEText('body')
+        return 'OK', [(None, msg.as_bytes())]
+    def close(self):
+        pass
+    def logout(self):
+        pass
+
+class MailSearchToTests(unittest.TestCase):
+    def setUp(self):
+        os.environ['MAIL_SENDER'] = 'test@example.com'
+        os.environ['MAIL_PASSWORD'] = 'secret'
+        os.environ['IMAP_SERVER'] = 'imap.example.com'
+        os.environ['IMAP_PORT'] = '993'
+        os.environ['ADMIN_EMAIL'] = 'admin@example.com'
+        FakeIMAP.instances.clear()
+
+    def tearDown(self):
+        for var in ['MAIL_SENDER','MAIL_PASSWORD','IMAP_SERVER','IMAP_PORT','ADMIN_EMAIL']:
+            os.environ.pop(var, None)
+
+    def test_to_flag_defaults_admin(self):
+        with patch('imaplib.IMAP4_SSL', FakeIMAP):
+            gw.mail.search('hello', to=True)
+            fake = FakeIMAP.instances[0]
+            self.assertEqual(
+                fake.last_search[1],
+                ['SUBJECT', '"hello"', 'TO', '"admin@example.com"']
+            )
+
+    def test_to_custom_address(self):
+        with patch('imaplib.IMAP4_SSL', FakeIMAP):
+            gw.mail.search('hello', to='user@example.com')
+            fake = FakeIMAP.instances[0]
+            self.assertEqual(
+                fake.last_search[1],
+                ['SUBJECT', '"hello"', 'TO', '"user@example.com"']
+            )
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend `gw.mail.search` with a `to` parameter
- use `ADMIN_EMAIL` when `to=True`
- add `limit` and `reverse` search parameters
- sort search results by date and apply limit
- test searching by destination address and result ordering

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6873509fa86c83268727fb8f67985326