### PR TITLE
Use sys.executable when launching gway in tests

### DIFF
--- a/tests/test_auth_charger.py
+++ b/tests/test_auth_charger.py
@@ -4,6 +4,7 @@ import unittest
 import subprocess
 import time
 import socket
+import sys
 import os
 import base64
 import requests
@@ -37,7 +38,7 @@ class AuthChargerStatusTests(unittest.TestCase):
         _remove_test_user()
         # Start the server
         cls.proc = subprocess.Popen(
-            ["gway", "-r", "test/website"],
+            [sys.executable, "-m", "gway", "-r", "test/website"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/tests/test_charger_refresh.py
+++ b/tests/test_charger_refresh.py
@@ -7,6 +7,7 @@ import string
 import subprocess
 import time
 import socket
+import sys
 import asyncio
 import requests
 
@@ -42,7 +43,7 @@ class ChargerDashboardRefreshTests(unittest.TestCase):
     def setUpClass(cls):
         _remove_test_user()
         cls.proc = subprocess.Popen(
-            ["gway", "-r", "test/website"],
+            [sys.executable, "-m", "gway", "-r", "test/website"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/tests/test_conway_web.py
+++ b/tests/test_conway_web.py
@@ -7,6 +7,7 @@ import unittest
 import subprocess
 import time
 import socket
+import sys
 import requests
 from bs4 import BeautifulSoup
 from gway import gw
@@ -17,7 +18,7 @@ class ConwayWebTests(unittest.TestCase):
     def setUpClass(cls):
         # Start the demo website (port 8888)
         cls.proc = subprocess.Popen(
-            ["gway", "-r", "test/website"],
+            [sys.executable, "-m", "gway", "-r", "test/website"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/tests/test_etron_ws.py
+++ b/tests/test_etron_ws.py
@@ -41,7 +41,7 @@ class EtronWebSocketTests(unittest.TestCase):
 
             # --- START SERVER ---
             cls.proc = subprocess.Popen(
-                ["gway", "-r", "test/etron/cloud"],
+                [sys.executable, "-m", "gway", "-r", "test/etron/cloud"],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 text=True,

--- a/tests/test_nav_styles.py
+++ b/tests/test_nav_styles.py
@@ -4,6 +4,7 @@ import unittest
 import subprocess
 import time
 import socket
+import sys
 import requests
 from bs4 import BeautifulSoup
 from pathlib import Path
@@ -15,7 +16,7 @@ class NavStyleTests(unittest.TestCase):
     def setUpClass(cls):
         # Launch the website recipe on a test port (8888)
         cls.proc = subprocess.Popen(
-            ["gway", "-r", "test/website"],
+            [sys.executable, "-m", "gway", "-r", "test/website"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/tests/test_proxy_fallback.py
+++ b/tests/test_proxy_fallback.py
@@ -5,6 +5,7 @@ from gway.builtins import is_test_flag
 import subprocess
 import time
 import socket
+import sys
 import os
 import tempfile
 import shutil
@@ -21,7 +22,7 @@ class ProxyFallbackTests(unittest.TestCase):
     def setUpClass(cls):
         cls.local_dir = tempfile.mkdtemp(prefix="local_gw_")
         cls.local_proc = subprocess.Popen(
-            ["gway", "-r", "test/etron/local_proxy"],
+            [sys.executable, "-m", "gway", "-r", "test/etron/local_proxy"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
@@ -81,7 +82,7 @@ class ProxyFallbackTests(unittest.TestCase):
 
         self.__class__.remote_dir = tempfile.mkdtemp(prefix="remote_gw_")
         self.__class__.remote_proc = subprocess.Popen(
-            ["gway", "-r", "test/etron/cloud"],
+            [sys.executable, "-m", "gway", "-r", "test/etron/cloud"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/tests/test_screenshot_attachment.py
+++ b/tests/test_screenshot_attachment.py
@@ -2,6 +2,7 @@ import unittest
 import subprocess
 import time
 import socket
+import sys
 from pathlib import Path
 from gway.builtins import is_test_flag
 from gway import gw
@@ -10,7 +11,7 @@ class ScreenshotAttachmentTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.proc = subprocess.Popen([
-            "gway", "-r", "test/website"],
+            sys.executable, "-m", "gway", "-r", "test/website"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,

--- a/tests/test_site_help_auto.py
+++ b/tests/test_site_help_auto.py
@@ -2,6 +2,7 @@ import unittest
 import subprocess
 import time
 import socket
+import sys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
@@ -11,7 +12,7 @@ class SiteHelpAutoTests(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.proc = subprocess.Popen(
-            ["gway", "-r", "test/website"],
+            [sys.executable, "-m", "gway", "-r", "test/website"],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,


### PR DESCRIPTION
## Summary
- ensure tests use the Python interpreter to launch `gway`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6873628f5d8c83268e82c4c4630cf406