### PR TITLE
Add nav side option

### DIFF
--- a/data/static/styles/base.css
+++ b/data/static/styles/base.css
@@ -43,6 +43,15 @@ html, body {
     min-height: 0;
     background: none;
 }
+.layout.nav-right {
+    flex-direction: row-reverse;
+}
+
+/* Nav on the right tweaks */
+.layout.nav-right aside {
+    border-right: none;
+    border-left: 1px solid #ccc;
+}
 
 /* 3. Sidebar (aside) */
 aside {
@@ -236,6 +245,9 @@ select {
         position: relative;
         background: none;
     }
+    .layout.nav-right {
+        flex-direction: row-reverse !important;
+    }
     aside {
         width: 76vw;
         max-width: 350px;
@@ -249,6 +261,13 @@ select {
         transition: background 0.22s;
         box-shadow: 3px 0 16px #0004;
     }
+    .layout.nav-right aside {
+        left: auto;
+        right: 0;
+        border-right: none;
+        border-left: 1px solid #222;
+        box-shadow: -3px 0 16px #0004;
+    }
     main {
         padding: 0.8rem 0.3rem 0.3rem 0.7rem;
         width: 100%;
@@ -259,6 +278,9 @@ select {
         z-index: 1;
         background: var(--main-bg, #fff); /* always light by default for readability */
         /* To support dark theme, set --main-bg via JS or a theme class */
+    }
+    .layout.nav-right main {
+        padding: 0.8rem 0.7rem 0.3rem 0.3rem;
     }
 }
 
@@ -328,6 +350,9 @@ p.compass { margin-bottom: 0.5em; }
     pointer-events: none;
     width: 0 !important;
     min-width: 0 !important;
+}
+.layout.nav-right.nav-rolled aside {
+    transform: translateX(110%);
 }
 .layout aside {
     transform: none;

--- a/data/static/web/nav/mobile.js
+++ b/data/static/web/nav/mobile.js
@@ -8,6 +8,11 @@
     const HANDLE_ID = 'nav-handle';
     const SPLITTER_ID = 'nav-splitter';
     const ARROW_WIDTH = 54; // px
+
+    function isNavRight() {
+        const layout = document.querySelector(LAYOUT_SELECTOR);
+        return layout && layout.classList.contains('nav-right');
+    }
     let isOpen = true;
     let initialized = false;
 
@@ -19,40 +24,52 @@
         const layout = document.querySelector(LAYOUT_SELECTOR);
         const main = document.querySelector(MAIN_SELECTOR);
         if (!layout) return;
+        const navRight = isNavRight();
         if (out) {
             layout.classList.add(ROLL_CLASS);
             isOpen = false;
             showHandle();
             if (isMobile() && main) {
-                main.style.marginLeft = ARROW_WIDTH + 'px';
+                if (navRight) {
+                    main.style.marginRight = ARROW_WIDTH + 'px';
+                } else {
+                    main.style.marginLeft = ARROW_WIDTH + 'px';
+                }
             }
         } else {
             layout.classList.remove(ROLL_CLASS);
             isOpen = true;
             hideHandle();
-            if (main) main.style.marginLeft = '';
+            if (main) {
+                main.style.marginLeft = '';
+                main.style.marginRight = '';
+            }
         }
     }
 
     function showHandle() {
-        if (document.getElementById(HANDLE_ID)) {
-            document.getElementById(HANDLE_ID).style.display = 'flex';
+        const existing = document.getElementById(HANDLE_ID);
+        if (existing) {
+            existing.style.display = 'flex';
             return;
         }
+        const navRight = isNavRight();
         const handle = document.createElement('div');
         handle.id = HANDLE_ID;
+        const arrow = navRight
+            ? '<polygon points="38,18 22,32 38,46" fill="var(--accent, #F98C00)"/>'
+            : '<polygon points="22,18 38,32 22,46" fill="var(--accent, #F98C00)"/>';
         handle.innerHTML = `
             <svg width="60" height="64" viewBox="0 0 60 64" fill="none">
-                <rect x="0" y="0" width="56" height="64" rx="18"
-                    fill="var(--bg-alt, #26374a)" fill-opacity="0.98"/>
-                <polygon points="22,18 38,32 22,46"
-                    fill="var(--accent, #F98C00)"/>
+                <rect x="0" y="0" width="56" height="64" rx="18" fill="var(--bg-alt, #26374a)" fill-opacity="0.98"/>
+                ${arrow}
             </svg>
         `;
         handle.setAttribute('aria-label', 'Open navigation');
         handle.style.position = 'fixed';
         handle.style.bottom = '2.1rem';
-        handle.style.left = '0px';
+        handle.style.left = navRight ? '' : '0px';
+        handle.style.right = navRight ? '0px' : '';
         handle.style.zIndex = 3000;
         handle.style.width = ARROW_WIDTH + 'px';
         handle.style.height = '64px';
@@ -61,8 +78,8 @@
         handle.style.alignItems = 'center';
         handle.style.border = 'none';
         handle.style.background = 'none';
-        handle.style.borderRadius = '0 18px 18px 0';
-        handle.style.boxShadow = '2px 2px 18px #0004';
+        handle.style.borderRadius = navRight ? '18px 0 0 18px' : '0 18px 18px 0';
+        handle.style.boxShadow = navRight ? '-2px 2px 18px #0004' : '2px 2px 18px #0004';
         handle.style.cursor = 'pointer';
         handle.style.opacity = '0.98';
         handle.onclick = function(e) {
@@ -86,12 +103,14 @@
         if (document.getElementById(SPLITTER_ID) || isMobile()) return;
         const aside = document.querySelector(NAV_SELECTOR);
         if (!aside) return;
+        const navRight = isNavRight();
         const splitter = document.createElement('div');
         splitter.id = SPLITTER_ID;
         splitter.title = "Collapse navigation";
         splitter.style.position = 'absolute';
         splitter.style.top = '0';
-        splitter.style.right = '-11px';
+        splitter.style.right = navRight ? '' : '-11px';
+        splitter.style.left = navRight ? '-11px' : '';
         splitter.style.width = '18px';
         splitter.style.height = '100%';
         splitter.style.display = 'flex';
@@ -100,18 +119,22 @@
         splitter.style.cursor = 'ew-resize';
         splitter.style.zIndex = 101;
         splitter.style.background = 'transparent';
+        const arrow = navRight
+            ? '<polygon points="3,22 11,12 11,32" fill="var(--accent, #F98C00)"/>'
+            : '<polygon points="13,22 5,12 5,32" fill="var(--accent, #F98C00)"/>';
+        const radius = navRight ? '14px 0 0 14px' : '0 14px 14px 0';
+        const shadow = navRight ? '-2px 2px 8px #0003' : '2px 2px 8px #0003';
         splitter.innerHTML = `
             <div style="
                 width: 16px;
                 height: 64px;
                 background: var(--bg-alt, #26374a);
                 opacity: 0.98;
-                border-radius: 0 14px 14px 0;
-                box-shadow: 2px 2px 8px #0003;
+                border-radius: ${radius};
+                box-shadow: ${shadow};
                 display: flex; align-items: center; justify-content: center;">
                 <svg width="16" height="44" viewBox="0 0 16 44">
-                    <polygon points="13,22 5,12 5,32"
-                        fill="var(--accent, #F98C00)"/>
+                    ${arrow}
                 </svg>
             </div>
         `;
@@ -173,10 +196,18 @@
     function fixMainMargin() {
         const main = document.querySelector(MAIN_SELECTOR);
         if (!main) return;
+        const navRight = isNavRight();
         if (isMobile() && isOpen) {
-            main.style.marginLeft = ARROW_WIDTH + 'px';
+            if (navRight) {
+                main.style.marginRight = ARROW_WIDTH + 'px';
+                main.style.marginLeft = '';
+            } else {
+                main.style.marginLeft = ARROW_WIDTH + 'px';
+                main.style.marginRight = '';
+            }
         } else {
             main.style.marginLeft = '';
+            main.style.marginRight = '';
         }
     }
 

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -536,6 +536,7 @@ def render_template(*, title="GWAY", content="", css_files=None, js_files=None):
         <a href="https://pypi.org">PyPI</a> and <a href="https://github.com/arthexis/gway">Github</a>.</p>
     '''
     nav = gw.web.nav.render(homes=_homes, links=_links) if is_setup('web.nav') else ""
+    nav_side = gw.web.nav.side() if is_setup('web.nav') else "left"
 
     debug_html = ""
     if getattr(gw, "debug_enabled", False):
@@ -573,8 +574,12 @@ def render_template(*, title="GWAY", content="", css_files=None, js_files=None):
         </head>
         <body>
             <div class="page-wrap">
-                <div class="layout">
+                <div class="layout{{' nav-right' if nav_side == 'right' else ''}}">
+                    % if nav_side == 'right':
+                    <main>{{!message_html}}{{!content}}</main>{{!nav}}
+                    % else:
                     {{!nav}}<main>{{!message_html}}{{!content}}</main>
+                    % end
                 </div>
                 <footer><p>This website was <strong>built</strong>, <strong>tested</strong>
                     and <strong>released</strong> with <a href="https://arthexis.com">GWAY</a>

--- a/projects/web/nav.py
+++ b/projects/web/nav.py
@@ -7,6 +7,7 @@ from gway import gw
 from bottle import request
 
 _forced_style = None
+_side = "left"
 
 
 def render(*, homes=None, links=None):
@@ -521,13 +522,24 @@ def list_styles(project=None):
     return styles
 
 
-def setup_app(*, app=None, style=None, **_):
-    """Optional hook to set a default style when the project is added.
+def setup_app(*, app=None, style=None, side="left", **_):
+    """Optional hook to set a default style and nav side when the project is added.
 
     Pass ``style='random'`` to select a random theme on each request.
+    Use ``side='right'`` to place the navigation on the right side.
     """
-    global _forced_style
+    global _forced_style, _side
     if style:
         _forced_style = style
         gw.info(f"web.nav forced style: {style}")
+    if side in {"left", "right"}:
+        _side = side
+        gw.info(f"web.nav side set to {side}")
+    else:
+        gw.error(f"Invalid nav side: {side}")
     return app
+
+
+def side() -> str:
+    """Return the configured navigation side ('left' or 'right')."""
+    return _side


### PR DESCRIPTION
## Summary
- allow choosing nav side in `web.nav.setup_app`
- inject nav to the right when requested
- add base CSS rules for right-side nav
- support right-side nav rollout in mobile.js

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68735d5f2b6c8326b495a3a8e0403cb2