### PR TITLE
Add form handling and gw-view to render.js

### DIFF
--- a/data/static/render.js
+++ b/data/static/render.js
@@ -1,12 +1,17 @@
 /**
  * GWAY Minimal Render Client (render.js)
  *
- * Finds all elements with gw-render (also supports x-gw-render or data-gw-render).
+ * Finds all elements with gw-render (also supports x-gw-render or data-gw-render)
+ * or gw-api (also supports x-gw-api or data-gw-api)
+ * or gw-view (also supports x-gw-view or data-gw-view).
  * If gw-refresh is present,
- * auto-refreshes them using the named render endpoint, passing their params.
+ * auto-refreshes them using the named render, api or view endpoint, passing their params.
  * - gw-render: name of render function (without 'render_' prefix)
+ * - gw-api: name of api function (without 'api_' prefix)
+ * - gw-view: name of view function (without 'view_' prefix)
  * - gw-refresh: interval in seconds (optional)
  * - gw-params: comma-separated data attributes to POST (optional; defaults to all except gw-*)
+ * - gw-form: form id to read values from (optional; defaults to child form if present)
  * - gw-target: 'content' (default, replace innerHTML), or 'replace' (replace the whole element)
  * - gw-click: any value starting with "re" to manually re-render the block on left click (optional, case-insensitive)
  * - gw-left-click: same as gw-click (optional)
@@ -14,12 +19,17 @@
  * - gw-double-click: any value starting with "re" to re-render on double click (optional, case-insensitive)
  * - gw-on-load: load block once on page load (optional)
  *
+ * When gw-api is used and the element contains [sigils], the API result is used
+ * to replace them. A hidden template clone of the original element ensures the
+ * placeholders persist across refreshes.
+ *
  * No external dependencies.
  */
 
 (function() {
   let timers = {};
   const prefixes = ['gw-', 'x-gw-', 'data-gw-'];
+  const templates = new WeakMap();
 
   function getAttr(el, name) {
     for (let pre of prefixes) {
@@ -51,11 +61,54 @@
     return params;
   }
 
+  function getTemplate(el) {
+    if (!templates.has(el)) {
+      templates.set(el, el.cloneNode(true));
+    }
+    return templates.get(el);
+  }
+
+  function getForm(el) {
+    let formId = getAttr(el, 'form');
+    let form = null;
+    if (formId) {
+      form = document.getElementById(formId);
+    } else if (el.tagName.toLowerCase() === 'form') {
+      form = el;
+    } else {
+      form = el.querySelector('form');
+    }
+    return form;
+  }
+
+  function replaceSigilsInString(str, data) {
+    return str.replace(/\[([^\[\]]+)\]/g, (m, key) => {
+      key = key.split('|')[0].trim();
+      return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : m;
+    });
+  }
+
+  function replaceSigils(node, data) {
+    if (node.nodeType === Node.TEXT_NODE) {
+      node.textContent = replaceSigilsInString(node.textContent, data);
+    } else if (node.nodeType === Node.ELEMENT_NODE) {
+      Array.from(node.attributes).forEach(attr => {
+        let val = replaceSigilsInString(attr.value, data);
+        if (val !== attr.value) node.setAttribute(attr.name, val);
+      });
+      Array.from(node.childNodes).forEach(child => replaceSigils(child, data));
+    }
+  }
+
   // Render a block using its gw-render attribute
   function renderBlock(el) {
     let func = getAttr(el, 'render');
     if (!func) return;
     let params = extractParams(el);
+    let form = getForm(el);
+    if (form) {
+      new FormData(form).forEach((v, k) => { params[k] = v; });
+    }
     let urlBase = location.pathname.replace(/\/$/, '');
     let url = '/render' + urlBase + '/' + func;
 
@@ -84,52 +137,125 @@
     });
   }
 
-  // Set up auto-refresh for all gw-render blocks
+  function apiBlock(el) {
+    let func = getAttr(el, 'api');
+    if (!func) return;
+    let params = extractParams(el);
+    let form = getForm(el);
+    if (form) {
+      new FormData(form).forEach((v, k) => { params[k] = v; });
+    }
+    let urlBase = location.pathname.replace(/\/$/, '');
+    let url = '/api' + urlBase + '/' + func;
+
+    fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+      cache: "no-store"
+    })
+    .then(res => res.json())
+    .then(data => {
+      let template = getTemplate(el).cloneNode(true);
+      replaceSigils(template, data);
+      Array.from(el.attributes).forEach(a => el.removeAttribute(a.name));
+      Array.from(template.attributes).forEach(a => el.setAttribute(a.name, a.value));
+      el.innerHTML = template.innerHTML;
+    })
+    .catch(err => {
+      console.error("GWAY api block update failed:", func, err);
+    });
+  }
+
+  function viewBlock(el) {
+    let func = getAttr(el, 'view');
+    if (!func) return;
+    let params = extractParams(el);
+    let form = getForm(el);
+    if (form) {
+      new FormData(form).forEach((v, k) => { params[k] = v; });
+    }
+    let path = location.pathname.replace(/\/$/, '');
+    let base = path.substring(0, path.lastIndexOf('/'));
+    if (!base) base = path; // fallback
+    let url = '/render' + base + '/' + func;
+
+    fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(params),
+      cache: "no-store"
+    })
+    .then(res => res.text())
+    .then(html => {
+      let target = getAttr(el, 'target') || 'content';
+      if (target === 'replace') {
+        let temp = document.createElement('div');
+        temp.innerHTML = html;
+        let newEl = temp.firstElementChild;
+        if (newEl) el.replaceWith(newEl);
+        else el.innerHTML = html;
+      } else {
+        el.innerHTML = html;
+      }
+    })
+    .catch(err => {
+      console.error("GWAY view block update failed:", func, err);
+    });
+  }
+
+  function setupElement(el) {
+    let refreshFunc = renderBlock;
+    if (getAttr(el, 'api')) {
+      refreshFunc = apiBlock;
+      getTemplate(el);
+    } else if (getAttr(el, 'view')) {
+      refreshFunc = viewBlock;
+    }
+    let refresh = parseFloat(getAttr(el, 'refresh'));
+    if (!isNaN(refresh) && refresh > 0) {
+      let id = el.id || Math.random().toString(36).slice(2);
+      timers[id] = setInterval(() => refreshFunc(el), refresh * 1000);
+      refreshFunc(el);
+      el.dataset.gwLoaded = "1";
+    }
+    let onLoad = getAttr(el, 'on-load');
+    if (onLoad !== null && !el.dataset.gwLoaded) {
+      refreshFunc(el);
+      el.dataset.gwLoaded = "1";
+    }
+    let leftClick = getAttr(el, 'click') || getAttr(el, 'left-click');
+    if (leftClick && /^re/i.test(leftClick) && !el.dataset.gwLeftClickSetup) {
+      el.addEventListener('click', evt => {
+        evt.preventDefault();
+        refreshFunc(el);
+      });
+      el.dataset.gwLeftClickSetup = '1';
+    }
+    let rightClick = getAttr(el, 'right-click');
+    if (rightClick && /^re/i.test(rightClick) && !el.dataset.gwRightClickSetup) {
+      el.addEventListener('contextmenu', evt => {
+        evt.preventDefault();
+        refreshFunc(el);
+      });
+      el.dataset.gwRightClickSetup = '1';
+    }
+    let dblClick = getAttr(el, 'double-click');
+    if (dblClick && /^re/i.test(dblClick) && !el.dataset.gwDoubleClickSetup) {
+      el.addEventListener('dblclick', evt => {
+        evt.preventDefault();
+        refreshFunc(el);
+      });
+      el.dataset.gwDoubleClickSetup = '1';
+    }
+  }
+
+  // Set up auto-refresh for all gw-render, gw-api or gw-view blocks
   function setupAll() {
-    // Clear existing timers
     Object.values(timers).forEach(clearInterval);
     timers = {};
-    // For each gw-render element
-    document.querySelectorAll('[gw-render],[x-gw-render],[data-gw-render]').forEach(el => {
-      let refresh = parseFloat(getAttr(el, 'refresh'));
-      if (!isNaN(refresh) && refresh > 0) {
-        let id = el.id || Math.random().toString(36).slice(2);
-        timers[id] = setInterval(() => renderBlock(el), refresh * 1000);
-        // Render once immediately
-        renderBlock(el);
-        el.dataset.gwLoaded = "1";
-      }
-        let onLoad = getAttr(el, 'on-load');
-        if (onLoad !== null && !el.dataset.gwLoaded) {
-          renderBlock(el);
-          el.dataset.gwLoaded = "1";
-        }
-      let leftClick = getAttr(el, 'click') || getAttr(el, 'left-click');
-      if (leftClick && /^re/i.test(leftClick) && !el.dataset.gwLeftClickSetup) {
-        el.addEventListener('click', evt => {
-          evt.preventDefault();
-          renderBlock(el);
-        });
-        el.dataset.gwLeftClickSetup = '1';
-      }
-
-      let rightClick = getAttr(el, 'right-click');
-      if (rightClick && /^re/i.test(rightClick) && !el.dataset.gwRightClickSetup) {
-        el.addEventListener('contextmenu', evt => {
-          evt.preventDefault();
-          renderBlock(el);
-        });
-        el.dataset.gwRightClickSetup = '1';
-      }
-
-      let dblClick = getAttr(el, 'double-click');
-      if (dblClick && /^re/i.test(dblClick) && !el.dataset.gwDoubleClickSetup) {
-        el.addEventListener('dblclick', evt => {
-          evt.preventDefault();
-          renderBlock(el);
-        });
-        el.dataset.gwDoubleClickSetup = '1';
-      }
+    document.querySelectorAll('[gw-render],[x-gw-render],[data-gw-render],[gw-api],[x-gw-api],[data-gw-api],[gw-view],[x-gw-view],[data-gw-view]').forEach(el => {
+      setupElement(el);
     });
   }
 

--- a/data/static/web/README.rst
+++ b/data/static/web/README.rst
@@ -21,12 +21,20 @@ Parameters are handled exactly like the regular ``/project/view`` route, so you
 can use GET or POST to pass values. Returned content is suitable for dynamic
 insertion via ``render.js`` or inclusion in an ``iframe``.
 
-``render.js`` also supports manual refresh hooks:
+``render.js`` also supports manual refresh hooks and a lightweight API helper.
 
 - ``gw-click``/``gw-left-click`` – refresh on left click.
 - ``gw-right-click`` – refresh on right click.
 - ``gw-double-click`` – refresh on double click.
 - ``gw-on-load`` – refresh once when the page loads.
+- ``gw-render`` – refresh using the named ``render_*`` function. If the element
+  is or contains a form, fields are posted along with data attributes.
+- ``gw-view`` – call the named ``view_*`` function without the page layout. Form
+  values are sent just like ``gw-render``.
+- ``gw-api`` – call the named ``api_*`` function and replace any ``[sigils]``
+  in the element with values from the JSON response. If the element is a form,
+  or contains one, form fields are posted as parameters. A different form can
+  be specified with ``gw-form``.
 
 Double clicking the QR compass in the sidebar triggers a dynamic refresh via
 ``render.js`` if the active project provides a ``render_compass`` function.


### PR DESCRIPTION
## Summary
- include form fields when refreshing `gw-render`
- add `gw-view` attribute to render.js for view functions
- support auto-refresh for `gw-render`, `gw-api`, and `gw-view`
- document the new attributes and behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68735dbb595083269b104bb1ebbfcfe3