### PR TITLE
Fix AWG calculator button layout

### DIFF
--- a/projects/awg.py
+++ b/projects/awg.py
@@ -339,8 +339,13 @@ def view_awg_calculator(
                             </select>
                         </td>
                     </tr>
+                    <tr>
+                        <td>
+                            <button type="submit" class="submit">Calculate</button>
+                        </td>
+                        <td></td>
+                    </tr>
                 </table>
-                <button type="submit" class="submit">Calculate</button>
             </form>
         '''
     if max_awg in (None, ""):


### PR DESCRIPTION
## Summary
- make the AWG calculator submit button fit inside the form table

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6873e74299748326b709ae28bfa72c5b