### PR TITLE
Ensure CLI test uses current interpreter

### DIFF
--- a/tests/test_init_root.py
+++ b/tests/test_init_root.py
@@ -2,6 +2,7 @@ import unittest
 import tempfile
 import subprocess
 import os
+import sys
 from pathlib import Path
 from gway import gw
 
@@ -34,6 +35,8 @@ class InitRootTests(unittest.TestCase):
             env['GWAY_ROOT'] = str(root_path)
 
             cmd = [
+                sys.executable,
+                '-m',
                 'gway',
                 '-p', str(project_dir),
                 'demo',


### PR DESCRIPTION
## Summary
- fix `test_cli_runs_project_from_anywhere` to call the gway module via `sys.executable`

## Testing
- `python -m unittest tests.test_init_root.InitRootTests.test_cli_runs_project_from_anywhere`
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_6873e69e9d6083269bf31a57013bdf01