### PR TITLE
Enhance Q-Pig Farm UI

### DIFF
--- a/data/static/games/qpig/farm.css
+++ b/data/static/games/qpig/farm.css
@@ -67,4 +67,31 @@
 .qpig-top {
     font-weight: bold;
     margin-bottom: 4px;
+    display: flex;
+    justify-content: space-between;
+    color: #fff;
+}
+
+.qpig-pigs { margin-top: 4px; }
+
+.qpig-pig-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    background: #d6f5d6;
+    border: 1px solid #333;
+    padding: 4px;
+    margin-bottom: 4px;
+    box-sizing: border-box;
+}
+
+.qpig-pig-name { font-weight: bold; }
+.qpig-pig-stats { font-size: 0.9em; }
+.qpig-photo {
+    width: 30px;
+    height: 30px;
+    object-fit: cover;
+    border-radius: 4px;
+    margin-left: 8px;
 }

--- a/tests/test_qpig_farm.py
+++ b/tests/test_qpig_farm.py
@@ -15,6 +15,8 @@ class QPigFarmTests(unittest.TestCase):
         self.assertIn('qpig-canvas', html)
         self.assertIn('qpig-save', html)
         self.assertIn('qpig-load', html)
+        self.assertIn('Q-Pellets', html)
+        self.assertIn('qpig-pig-card', html)
 
     def test_tab_names_updated(self):
         html = self.qpig_mod.view_qpig_farm()


### PR DESCRIPTION
## Summary
- show Q-Pellets counter and adopted pig cards
- generate random pig names and stats
- update CSS for top row and pig cards
- test for new elements in Q-Pig farm view

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_6873f3f7a2a0832687d16b3518cc76fd