### PR TITLE
Implement ticking Q-Pigs

### DIFF
--- a/data/static/games/qpig/farm.css
+++ b/data/static/games/qpig/farm.css
@@ -20,7 +20,7 @@
     border: 1px solid #333;
     background: #d6f5d6;
     cursor: pointer;
-    color: #000;
+    color: #fff;
 }
 
 .qpig-garden #qpig-canvas {
@@ -69,7 +69,7 @@
     margin-bottom: 4px;
     display: flex;
     justify-content: space-between;
-    color: #fff;
+    color: #000;
 }
 
 .qpig-pigs { margin-top: 4px; }

--- a/tests/test_qpig_farm.py
+++ b/tests/test_qpig_farm.py
@@ -10,13 +10,14 @@ class QPigFarmTests(unittest.TestCase):
         self.qpig_mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(self.qpig_mod)
 
-    def test_view_contains_canvas_and_buttons(self):
+    def test_view_contains_basic_elements(self):
         html = self.qpig_mod.view_qpig_farm()
-        self.assertIn('qpig-canvas', html)
+        self.assertNotIn("<canvas id='qpig-canvas'", html)
         self.assertIn('qpig-save', html)
         self.assertIn('qpig-load', html)
         self.assertIn('Q-Pellets', html)
         self.assertIn('qpig-pig-card', html)
+        self.assertIn('Q-Pigs:', html)
 
     def test_tab_names_updated(self):
         html = self.qpig_mod.view_qpig_farm()


### PR DESCRIPTION
## Summary
- set Q-Pig Farm initial limit to 2
- show current/max pigs and remove canvas element
- color tweaks for counters and buttons
- keep sessionStorage state and add pellet ticking
- adjust tests for new markup

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6873f9daa74c83269a33c9a3299494ee