### PR TITLE
Implement Q-Pig activities & settings tab

### DIFF
--- a/data/static/games/qpig/farm.css
+++ b/data/static/games/qpig/farm.css
@@ -7,6 +7,7 @@
     padding: 8px;
     margin: 0 auto;
     display: inline-block;
+    width: 300px;
 }
 
 .qpig-garden .qpig-buttons {
@@ -55,6 +56,7 @@
 .qpig-tab[data-tab='market'] { background: #cc6600; }
 .qpig-tab[data-tab='lab'] { background: purple; }
 .qpig-tab[data-tab='travel'] { background: blue; }
+.qpig-tab[data-tab='settings'] { background: grey; }
 
 .qpig-panel { display: none; padding: 4px; }
 .qpig-panel.active { display: block; }
@@ -63,6 +65,7 @@
 #qpig-panel-market { background: #ffe0b2; }
 #qpig-panel-lab { background: #e0b2ff; }
 #qpig-panel-travel { background: #b2d0ff; }
+#qpig-panel-settings { background: #ccc; }
 
 .qpig-top {
     font-weight: bold;

--- a/projects/games/qpig.py
+++ b/projects/games/qpig.py
@@ -80,6 +80,7 @@ def _new_pig() -> dict:
         "fitness": round(random.uniform(1, 4), 2),
         "handling": round(random.uniform(1, 4), 2),
         "face": random.randint(1, 70),
+        "activity": "Resting",
     }
 
 
@@ -99,6 +100,10 @@ def _load_state() -> dict:
     pigs = garden.get("pigs") if isinstance(garden, dict) else None
     if not isinstance(pigs, list) or not pigs:
         pigs = [_new_pig() for _ in range(DEFAULT_PIGS)]
+    else:
+        for pig in pigs:
+            if isinstance(pig, dict):
+                pig.setdefault("activity", "Resting")
     return {"garden": {"max_qpigs": max_qpigs, "qpellets": qpellets, "pigs": pigs}}
 
 
@@ -135,6 +140,7 @@ def view_qpig_farm(*, action: str = None, **_):
         '<button class="qpig-tab" data-tab="market">Market Street</button>',
         '<button class="qpig-tab" data-tab="lab">Laboratory</button>',
         '<button class="qpig-tab" data-tab="travel">Travel Abroad</button>',
+        '<button class="qpig-tab" data-tab="settings">Game Settings</button>',
         '</div>',
         '<div id="qpig-panel-garden" class="qpig-panel active">',
         f'<div class="qpig-top"><span id="qpig-count">Q-Pigs: {len(pigs)}/{max_qpigs}</span><span id="qpig-pellets">Q-Pellets: {qpellets}</span></div>',
@@ -143,7 +149,8 @@ def view_qpig_farm(*, action: str = None, **_):
     for pig in pigs:
         html.extend([
             '<div class="qpig-pig-card">',
-            f'<div><div class="qpig-pig-name">{pig["name"]}</div>',
+            f'<div><div class="qpig-pig-name">{pig["name"]} — '
+            f'<em>{pig.get("activity", "Resting")}</em></div>',
             f'<div class="qpig-pig-stats">Alertness: {pig["alertness"]} '
             f'Curiosity: {pig["curiosity"]} Fitness: {pig["fitness"]} '
             f'Handling: {pig["handling"]}</div></div>',
@@ -151,14 +158,16 @@ def view_qpig_farm(*, action: str = None, **_):
         ])
     html.extend([
         '</div>',  # close qpig-pigs
-        '<div class="qpig-buttons">',
-        "<button type='button' id='qpig-save' title='Save'>💾</button>",
-        "<button type='button' id='qpig-load' title='Load'>📂</button>",
-        '</div>',
         '</div>',  # close qpig-panel-garden
         '<div id="qpig-panel-market" class="qpig-panel"><div class="qpig-top"></div>Market Street coming soon</div>',
         '<div id="qpig-panel-lab" class="qpig-panel"><div class="qpig-top"></div>Laboratory coming soon</div>',
         '<div id="qpig-panel-travel" class="qpig-panel"><div class="qpig-top"></div>Travel Abroad coming soon</div>',
+        '<div id="qpig-panel-settings" class="qpig-panel"><div class="qpig-top"></div>',
+        '<div class="qpig-buttons">',
+        "<button type='button' id='qpig-save' title='Save'>💾 Save</button>",
+        "<button type='button' id='qpig-load' title='Load'>📂 Load</button>",
+        '</div>',
+        '</div>',
         '</div>',  # close qpig-garden
     ])
 

--- a/tests/test_qpig_farm.py
+++ b/tests/test_qpig_farm.py
@@ -18,6 +18,7 @@ class QPigFarmTests(unittest.TestCase):
         self.assertIn('Q-Pellets', html)
         self.assertIn('qpig-pig-card', html)
         self.assertIn('Q-Pigs:', html)
+        self.assertIn('Resting', html)
 
     def test_tab_names_updated(self):
         html = self.qpig_mod.view_qpig_farm()
@@ -25,6 +26,7 @@ class QPigFarmTests(unittest.TestCase):
         self.assertIn('Market Street', html)
         self.assertIn('Laboratory', html)
         self.assertIn('Travel Abroad', html)
+        self.assertIn('Game Settings', html)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add `activity` field for pigs and show current activity
- provide `Game Settings` tab and relocate save/load buttons
- widen Q-Pig garden and add new styles
- update Q-Pig tests for new text

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_6873ffe0ea8c832681bd12fb6d6001f9