### PR TITLE
Improve Q-Pig Farm styling

### DIFF
--- a/data/static/games/qpig/qpig_farm.css
+++ b/data/static/games/qpig/qpig_farm.css
@@ -2,13 +2,19 @@
 
 .qpig-garden {
     font-family: monospace;
-    background: #7ec87e;
-    border: 2px solid #2b7a2b;
     padding: 8px;
     margin: 0 auto;
     display: inline-block;
     width: 600px;
+    border: 2px solid #2b7a2b;
+    background: #b2f0b2;
 }
+
+.qpig-garden.tab-garden { background: #b2f0b2; border-color: #2b7a2b; }
+.qpig-garden.tab-market { background: #ffe0b2; border-color: #cc6600; }
+.qpig-garden.tab-lab { background: #e0b2ff; border-color: purple; }
+.qpig-garden.tab-travel { background: #b2d0ff; border-color: blue; }
+.qpig-garden.tab-settings { background: #eee; border-color: grey; }
 
 .qpig-garden .qpig-buttons {
     display: flex;
@@ -50,13 +56,15 @@
     color: #fff;
     cursor: pointer;
     font-weight: bold;
+    box-sizing: border-box;
 }
+.qpig-tab.active { filter: brightness(1.2); }
 
-.qpig-tab[data-tab='garden'] { background: green; }
+.qpig-tab[data-tab='garden'] { background: #2b7a2b; }
 .qpig-tab[data-tab='market'] { background: #cc6600; }
 .qpig-tab[data-tab='lab'] { background: purple; }
 .qpig-tab[data-tab='travel'] { background: blue; }
-.qpig-tab[data-tab='settings'] { background: grey; }
+.qpig-tab[data-tab='settings'] { background: #666; }
 
 .qpig-panel { display: none; padding: 4px; }
 .qpig-panel.active { display: block; }
@@ -87,6 +95,12 @@
     padding: 4px;
     margin-bottom: 4px;
     box-sizing: border-box;
+}
+
+.qpig-pig-info {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
 }
 
 .qpig-pig-name { font-weight: bold; }

--- a/projects/games/qpig.py
+++ b/projects/games/qpig.py
@@ -211,9 +211,9 @@ def view_qpig_farm(*, action: str = None, **_):
     pigs = garden.get("pigs", [])
 
     html = [
-        '<link rel="stylesheet" href="/static/games/qpig/farm.css">',
+        '<link rel="stylesheet" href="/static/games/qpig/qpig_farm.css">',
         '<h1>Quantum Piggy Farm</h1>',
-        '<div class="qpig-garden">',
+        '<div class="qpig-garden tab-garden">',
         '<div class="qpig-tabs">',
         '<button class="qpig-tab active" data-tab="garden">Garden Shed</button>',
         '<button class="qpig-tab" data-tab="market">Market Street</button>',
@@ -228,12 +228,15 @@ def view_qpig_farm(*, action: str = None, **_):
     for pig in pigs:
         html.extend([
             '<div class="qpig-pig-card">',
+            '<div class="qpig-pig-info">',
             f'<div><span class="qpig-pig-name">{pig["name"]}</span> — '
             f'<em>{pig.get("activity", "Resting")}</em></div>',
             f'<div class="qpig-pig-stats">Alertness: {pig["alertness"]} '
             f'Curiosity: {pig["curiosity"]} Fitness: {pig["fitness"]} '
-            f'Handling: {pig["handling"]}</div></div>',
-            f'<img class="qpig-photo" src="https://i.pravatar.cc/30?img={pig.get("face",1)}" width="30" height="30"></div>',
+            f'Handling: {pig["handling"]}</div>',
+            '</div>',
+            f'<img class="qpig-photo" src="https://i.pravatar.cc/30?img={pig.get("face",1)}" width="30" height="30">',
+            '</div>',
         ])
     html.extend([
         '</div>',  # close qpig-pigs
@@ -297,12 +300,17 @@ const load=document.getElementById('qpig-load');
 if(load){{load.addEventListener('click',()=>{{const inp=document.createElement('input');inp.type='file';inp.accept='.qpg';inp.onchange=e=>{{const f=e.target.files[0];if(!f)return;const r=new FileReader();r.onload=ev=>{{sessionStorage.setItem(KEY, ev.target.result.trim());location.reload();}};r.readAsText(f);}};inp.click();}});}}
 const tabs=document.querySelectorAll('.qpig-tab');
 const panels=document.querySelectorAll('.qpig-panel');
+const garden=document.querySelector('.qpig-garden');
 tabs.forEach(t=>t.addEventListener('click',()=>{{
   tabs.forEach(x=>x.classList.remove('active'));
   panels.forEach(p=>p.classList.remove('active'));
   t.classList.add('active');
   const panel=document.getElementById('qpig-panel-'+t.dataset.tab);
   if(panel) panel.classList.add('active');
+  if(garden){{
+    garden.className = garden.className.replace(/\btab-\w+\b/, '').trim();
+    garden.classList.add('tab-'+t.dataset.tab);
+  }}
 }}));
 </script>
 """.format(state_b64=state_b64)


### PR DESCRIPTION
## Summary
- update qpig farm styles so the active tab controls garden color
- keep pig photo inside card and display stats on a second row
- tweak JS to toggle color classes with active tab
- fix stylesheet link path

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6874427e829c8326b6fe6b99de5de07b