### PR TITLE
Update Q-Pig button text colors

### DIFF
--- a/data/static/games/qpig/qpig_farm.css
+++ b/data/static/games/qpig/qpig_farm.css
@@ -27,7 +27,11 @@
     border: 1px solid #333;
     background: #d6f5d6;
     cursor: pointer;
-    color: #fff;
+    color: #000;
+}
+
+.qpig-garden button:disabled {
+    color: grey;
 }
 
 .qpig-garden #qpig-canvas {


### PR DESCRIPTION
## Summary
- ensure Q-Pig Farm buttons show black text
- grey out text when the button is disabled

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6874663773b88326875784043478604d