### PR TITLE
Add Collect Quantum Pellets operation

### DIFF
--- a/data/static/games/qpig/qpig_farm.css
+++ b/data/static/games/qpig/qpig_farm.css
@@ -112,3 +112,17 @@
     border-radius: 4px;
     margin-left: 8px;
 }
+
+.lab-ops {
+    margin-top: 4px;
+    width: 100%;
+    border-collapse: collapse;
+}
+.lab-ops th, .lab-ops td {
+    border: 1px solid #333;
+    padding: 4px;
+}
+#lab-progress {
+    width: 100%;
+    margin-top: 4px;
+}

--- a/data/static/games/qpig/qpig_farm.js
+++ b/data/static/games/qpig/qpig_farm.js
@@ -98,3 +98,83 @@ tabs.forEach(t => t.addEventListener('click', () => {
         garden.classList.add('tab-' + t.dataset.tab);
     }
 }));
+
+// Quantum Lab operations
+const LAB_KEY = 'qpig_lab';
+
+function loadLabState() {
+    try { return JSON.parse(sessionStorage.getItem(LAB_KEY) || '{}'); } catch (e) { return {}; }
+}
+
+function saveLabState(st) {
+    sessionStorage.setItem(LAB_KEY, JSON.stringify(st));
+}
+
+function startLabOp(op, secs) {
+    const finish = Date.now() + secs * 1000;
+    saveLabState({ op, finish, duration: secs * 1000 });
+    updateLabProgress();
+}
+
+function handleLabOpComplete(op) {
+    if (op === 'collect') {
+        collectPellets();
+    } else {
+        console.log('lab operation complete:', op);
+    }
+}
+
+function collectPellets() {
+    const state = loadState();
+    let pellets = state.garden.qpellets || 0;
+    if (pellets <= 0) return;
+    const rewards = Array.from({ length: pellets }, () => 1 + Math.floor(Math.random() * 4));
+    let drained = 0;
+    const drain = setInterval(() => {
+        const st = loadState();
+        if (st.garden.qpellets > 0) {
+            st.garden.qpellets -= 1;
+            saveState(st);
+            updateCounters(st);
+        }
+        drained += 1;
+        if (drained >= pellets) {
+            clearInterval(drain);
+            const fin = loadState();
+            fin.vcreds = (fin.vcreds || 0) + rewards.reduce((a, b) => a + b, 0);
+            saveState(fin);
+            updateCounters(fin);
+        }
+    }, 100);
+}
+
+function updateLabProgress() {
+    const st = loadLabState();
+    const bar = document.getElementById('lab-progress');
+    const btns = document.querySelectorAll('#qpig-lab-ops button');
+    if (!bar) return;
+    if (!st.finish || Date.now() >= st.finish) {
+        bar.style.display = 'none';
+        btns.forEach(b => b.disabled = false);
+        if (st.finish && Date.now() >= st.finish) {
+            handleLabOpComplete(st.op);
+        }
+        saveLabState({});
+        return;
+    }
+    const remaining = st.finish - Date.now();
+    bar.style.display = 'block';
+    bar.max = st.duration;
+    bar.value = st.duration - remaining;
+    btns.forEach(b => b.disabled = true);
+}
+
+document.querySelectorAll('#qpig-lab-ops button').forEach(b => {
+    b.addEventListener('click', () => {
+        const secs = parseInt(b.dataset.time || '0', 10);
+        if (secs > 0) startLabOp(b.dataset.op, secs);
+    });
+});
+
+updateLabProgress();
+setInterval(updateLabProgress, 500);

--- a/projects/games/qpig.py
+++ b/projects/games/qpig.py
@@ -253,12 +253,13 @@ def view_qpig_farm(*, action: str = None, **_):
 
     html = [
         '<link rel="stylesheet" href="/static/games/qpig/qpig_farm.css">',
+        '<script src="/static/games/qpig/qpig_farm.js"></script>',
         '<h1>Quantum Piggy Farm</h1>',
         '<div class="qpig-garden tab-garden">',
         '<div class="qpig-tabs">',
         '<button class="qpig-tab active" data-tab="garden">Garden Shed</button>',
         '<button class="qpig-tab" data-tab="market">Market Street</button>',
-        '<button class="qpig-tab" data-tab="lab">Laboratory</button>',
+        '<button class="qpig-tab" data-tab="lab">Quantum Lab</button>',
         '<button class="qpig-tab" data-tab="travel">Travel Abroad</button>',
         '<button class="qpig-tab" data-tab="settings">Game Settings</button>',
         '</div>',
@@ -289,7 +290,15 @@ def view_qpig_farm(*, action: str = None, **_):
         f'<div class="qpig-top">'
         f'<span id="qpig-lab-pellets">Q-Pellets: {qpellets}</span>'
         f'<span id="qpig-lab-vcreds">V-Creds: {vcreds}</span>'
-        '</div>Laboratory coming soon</div>',
+        '</div>'
+        '<table id="qpig-lab-ops" class="lab-ops">'
+        '<tr><th>Operation</th><th>Time</th><th></th></tr>'
+        '<tr><td>Measure Spin</td><td>5s</td><td><button data-op="measure" data-time="5">Start</button></td></tr>'
+        '<tr><td>Entangle Pair</td><td>10s</td><td><button data-op="entangle" data-time="10">Start</button></td></tr>'
+        '<tr><td>Collect Quantum Pellets</td><td>3s</td><td><button data-op="collect" data-time="3">Start</button></td></tr>'
+        '</table>'
+        '<progress id="lab-progress" value="0" max="100" style="display:none;width:100%"></progress>'
+        '</div>',
         '<div id="qpig-panel-travel" class="qpig-panel"><div class="qpig-top"></div>Travel Abroad coming soon</div>',
         '<div id="qpig-panel-settings" class="qpig-panel"><div class="qpig-top"></div>',
         '<div class="qpig-buttons">',

--- a/tests/test_qpig_farm.py
+++ b/tests/test_qpig_farm.py
@@ -33,9 +33,15 @@ class QPigFarmTests(unittest.TestCase):
         html = self.qpig_mod.view_qpig_farm()
         self.assertIn('Garden Shed', html)
         self.assertIn('Market Street', html)
-        self.assertIn('Laboratory', html)
+        self.assertIn('Quantum Lab', html)
         self.assertIn('Travel Abroad', html)
         self.assertIn('Game Settings', html)
+
+    def test_lab_operations_table_present(self):
+        html = self.qpig_mod.view_qpig_farm()
+        self.assertIn('qpig-lab-ops', html)
+        self.assertIn('Measure Spin', html)
+        self.assertIn('Collect Quantum Pellets', html)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add a Collect Quantum Pellets option in the Quantum Lab
- implement client-side operation handling with pellet drain and VC reward
- persist and complete operations even across reloads
- update tests for new operation

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_687459baf0648326b5bce15ab5281c86