### PR TITLE
Add VS Code action to install requirements

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,6 +32,14 @@
             "module": "gway",
             "args": ["release", "build", "--all"],
             "console": "integratedTerminal"
+        },
+        {
+            "name": "Install Requirements",
+            "type": "python",
+            "request": "launch",
+            "module": "pip",
+            "args": ["install", "-U", "-r", "requirements.txt"],
+            "console": "integratedTerminal"
         }
     ]
 }

--- a/tasks.json
+++ b/tasks.json
@@ -20,6 +20,17 @@
         "reveal": "always",
         "panel": "shared"
       }
+    },
+    {
+      "label": "Install Requirements",
+      "type": "shell",
+      "command": "python -m pip install -U -r requirements.txt",
+      "problemMatcher": [],
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "panel": "shared"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add an 'Install Requirements' launch config to `.vscode/launch.json`
- provide a matching task in `tasks.json` for running `pip install -U -r requirements.txt`

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68754cde48488326b55f71b64d411085