### PR TITLE
Move help database builder to new project

### DIFF
--- a/gway/builtins/help_utils.py
+++ b/gway/builtins/help_utils.py
@@ -40,7 +40,7 @@ def help(*args, full: bool = False, list_flags: bool = False):
 
     db_path = gw.resource("data", "help.sqlite")
     if not os.path.isfile(db_path):
-        gw.web.site.build_help_db()
+        gw.help_db.build()
 
     joined_args = " ".join(args).strip().replace("-", "_")
     norm_args = [a.replace("-", "_").replace("/", ".") for a in args]

--- a/projects/help_db.py
+++ b/projects/help_db.py
@@ -1,0 +1,96 @@
+# file: projects/help_db.py
+"""Helper utilities for building the `gw.help` database."""
+
+import os
+from gway import gw
+
+
+def build(*, update: bool = False):
+    """Build or update the help database used by :func:`gw.help`."""
+    import inspect
+
+    db_path = gw.resource("data", "help.sqlite")
+    if not update and os.path.isfile(db_path):
+        gw.info("Help database already exists; skipping build.")
+        return db_path
+
+    with gw.sql.open_connection(datafile="data/help.sqlite") as cursor:
+        cursor.execute("DROP TABLE IF EXISTS help")
+        cursor.execute(
+            """
+            CREATE VIRTUAL TABLE help USING fts5(
+                project, function, signature, docstring, source, todos, tokenize='porter')
+            """
+        )
+
+        for dotted_path in _walk_projects("projects"):
+            try:
+                project_obj = gw.load_project(dotted_path)
+                for fname in dir(project_obj):
+                    if fname.startswith("_"):
+                        continue
+                    func = getattr(project_obj, fname, None)
+                    if not callable(func):
+                        continue
+                    raw_func = getattr(func, "__wrapped__", func)
+                    doc = inspect.getdoc(raw_func) or ""
+                    sig = str(inspect.signature(raw_func))
+                    try:
+                        source = "".join(inspect.getsourcelines(raw_func)[0])
+                    except OSError:
+                        source = ""
+                    todos = _extract_todos(source)
+                    cursor.execute(
+                        "INSERT INTO help VALUES (?, ?, ?, ?, ?, ?)",
+                        (dotted_path, fname, sig, doc, source, "\n".join(todos)),
+                    )
+            except Exception as e:
+                gw.warning(f"Skipping project {dotted_path}: {e}")
+
+        for name, func in gw._builtins.items():
+            raw_func = getattr(func, "__wrapped__", func)
+            doc = inspect.getdoc(raw_func) or ""
+            sig = str(inspect.signature(raw_func))
+            try:
+                source = "".join(inspect.getsourcelines(raw_func)[0])
+            except OSError:
+                source = ""
+            todos = _extract_todos(source)
+            cursor.execute(
+                "INSERT INTO help VALUES (?, ?, ?, ?, ?, ?)",
+                ("builtin", name, sig, doc, source, "\n".join(todos)),
+            )
+
+        cursor.execute("COMMIT")
+    gw.info(f"Help database built at {db_path}")
+    return db_path
+
+
+def _walk_projects(base: str = "projects"):
+    for dirpath, _, filenames in os.walk(base):
+        for fname in filenames:
+            if not fname.endswith(".py") or fname.startswith("_"):
+                continue
+            rel_path = os.path.relpath(os.path.join(dirpath, fname), base)
+            dotted = rel_path.replace(os.sep, ".").removesuffix(".py")
+            yield dotted
+
+
+def _extract_todos(source: str):
+    todos = []
+    lines = source.splitlines()
+    current = []
+    for line in lines:
+        stripped = line.strip()
+        if "# TODO" in stripped:
+            if current:
+                todos.append("\n".join(current))
+            current = [stripped]
+        elif current and (stripped.startswith("#") or not stripped):
+            current.append(stripped)
+        elif current:
+            todos.append("\n".join(current))
+            current = []
+    if current:
+        todos.append("\n".join(current))
+    return todos

--- a/projects/release.py
+++ b/projects/release.py
@@ -273,8 +273,8 @@ def build(
 
 
 def build_help_db():
-    """Compatibility wrapper that delegates to :mod:`web.site`."""
-    return gw.web.site.build_help_db(update=True)
+    """Compatibility wrapper that delegates to :mod:`help_db`."""
+    return gw.help_db.build(update=True)
 
 
 

--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -610,92 +610,10 @@ def view_project_readmes():
 
 
 def build_help_db(*, update: bool = False):
-    """Build or update the help database used by :func:`gw.help`."""
-    import inspect
-    db_path = gw.resource("data", "help.sqlite")
-    if not update and os.path.isfile(db_path):
-        gw.info("Help database already exists; skipping build.")
-        return db_path
-
-    with gw.sql.open_connection(datafile="data/help.sqlite") as cursor:
-        cursor.execute("DROP TABLE IF EXISTS help")
-        cursor.execute(
-            """
-            CREATE VIRTUAL TABLE help USING fts5(
-                project, function, signature, docstring, source, todos, tokenize='porter')
-            """
-        )
-
-        for dotted_path in _walk_projects("projects"):
-            try:
-                project_obj = gw.load_project(dotted_path)
-                for fname in dir(project_obj):
-                    if fname.startswith("_"):
-                        continue
-                    func = getattr(project_obj, fname, None)
-                    if not callable(func):
-                        continue
-                    raw_func = getattr(func, "__wrapped__", func)
-                    doc = inspect.getdoc(raw_func) or ""
-                    sig = str(inspect.signature(raw_func))
-                    try:
-                        source = "".join(inspect.getsourcelines(raw_func)[0])
-                    except OSError:
-                        source = ""
-                    todos = _extract_todos(source)
-                    cursor.execute(
-                        "INSERT INTO help VALUES (?, ?, ?, ?, ?, ?)",
-                        (dotted_path, fname, sig, doc, source, "\n".join(todos)),
-                    )
-            except Exception as e:
-                gw.warning(f"Skipping project {dotted_path}: {e}")
-
-        for name, func in gw._builtins.items():
-            raw_func = getattr(func, "__wrapped__", func)
-            doc = inspect.getdoc(raw_func) or ""
-            sig = str(inspect.signature(raw_func))
-            try:
-                source = "".join(inspect.getsourcelines(raw_func)[0])
-            except OSError:
-                source = ""
-            todos = _extract_todos(source)
-            cursor.execute(
-                "INSERT INTO help VALUES (?, ?, ?, ?, ?, ?)",
-                ("builtin", name, sig, doc, source, "\n".join(todos)),
-            )
-
-        cursor.execute("COMMIT")
-    gw.info(f"Help database built at {db_path}")
-    return db_path
-
-
-def _walk_projects(base: str = "projects"):
-    for dirpath, _, filenames in os.walk(base):
-        for fname in filenames:
-            if not fname.endswith(".py") or fname.startswith("_"):
-                continue
-            rel_path = os.path.relpath(os.path.join(dirpath, fname), base)
-            dotted = rel_path.replace(os.sep, ".").removesuffix(".py")
-            yield dotted
-
-
-def _extract_todos(source: str):
-    todos = []
-    lines = source.splitlines()
-    current = []
-    for line in lines:
-        stripped = line.strip()
-        if "# TODO" in stripped:
-            if current:
-                todos.append("\n".join(current))
-            current = [stripped]
-        elif current and (stripped.startswith("#") or not stripped):
-            current.append(stripped)
-        elif current:
-            todos.append("\n".join(current))
-            current = []
-    if current:
-        todos.append("\n".join(current))
-    return todos
+    """Compatibility wrapper for :func:`gw.help_db.build`."""
+    gw.warning(
+        "web.site.build_help_db is deprecated; use help-db.build instead"
+    )
+    return gw.help_db.build(update=update)
 
 

--- a/recipes/crud_site.gwr
+++ b/recipes/crud_site.gwr
@@ -9,7 +9,7 @@ web app setup:
     --project web.nav --home style-switcher
     --project web.site --home reader
     --project sql.crud --home posts?table=posts&dbfile=work/blog.sqlite
-web site build-help-db
+help-db build
 web:
  - static collect
  - server start-app --port 8888

--- a/recipes/etron/cloud.gwr
+++ b/recipes/etron/cloud.gwr
@@ -9,7 +9,7 @@ web app setup:
     - web.nav
     - vbox
     - ocpp.data --home charger-summary
-web site build-help-db
+help-db build
 
 # Toggle this version to apply the allow list
 ocpp csms setup-app:

--- a/recipes/etron/local.gwr
+++ b/recipes/etron/local.gwr
@@ -11,7 +11,7 @@ web app setup:
     - monitor.nmcli 
     - monitor.rpi --home pi-remote
     - ocpp.data --home charger-summary
-web site build-help-db
+help-db build
 
 # Toggle this version to apply the allowlist
 # ocpp csms setup-app --allow data/etron/rfids.cdv --location porsche_centre

--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -6,7 +6,7 @@ web app setup:
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.nav --home style-switcher
     - web.cookies --home cookie-jar
-web site build-help-db
+help-db build
 
 web:
  - static collect

--- a/recipes/media_blog.gwr
+++ b/recipes/media_blog.gwr
@@ -12,7 +12,7 @@ web app setup-app:
     - web.nav --home style-switcher
     - web.site --home reader
     - sql.crud --home posts?table=posts&dbfile=work/blog.sqlite
-web site build-help-db
+help-db build
 web:
  - static collect
  - server start-app --port 8888

--- a/recipes/micro_blog.gwr
+++ b/recipes/micro_blog.gwr
@@ -13,7 +13,7 @@ web app setup-app:
     - web.site --home reader
     - web.auth --home login
     - sql.crud --home table?table=posts&dbfile=work/blog.sqlite
-web site build-help-db
+help-db build
 web:
  - static collect
  - auth config-basic --optional --temp-link

--- a/recipes/midblog.gwr
+++ b/recipes/midblog.gwr
@@ -12,7 +12,7 @@ web app setup-app:
     - web.nav --home style-switcher
     - web.site --home reader
     - sql.crud --home posts?table=posts&dbfile=work/blog.sqlite
-web site build-help-db
+help-db build
 web:
  - static collect
  - server start-app --port 8888

--- a/recipes/skeleton.gwr
+++ b/recipes/skeleton.gwr
@@ -4,7 +4,7 @@ web app setup:
     - web.site --home reader
     - web.nav --style random
     - cdv --home data-editor
-web site build-help-db
+help-db build
 web:
  - static collect
 - server start-app

--- a/recipes/static_site.gwr
+++ b/recipes/static_site.gwr
@@ -15,7 +15,7 @@ web app setup-app --mode manual:
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth
 
-web site build-help-db
+help-db build
 
 web:
  - auth config-basic --optional --temp-link

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -17,7 +17,7 @@ web app setup:
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth
 
-web site build-help-db
+help-db build
 
 web:
  - static collect

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -17,7 +17,7 @@ web app setup:
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth
 
-web site build-help-db
+help-db build
 
 web:
  - static collect


### PR DESCRIPTION
## Summary
- move `build_help_db` from `web.site` to new project `help_db.build`
- update builtins and release helpers for the new path
- rewrite recipes to call `help-db build`
- keep a compatibility wrapper in `web.site`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68767763c26483269d3d4bbb29176fcb