### PR TITLE
Fix CLI root test isolation

### DIFF
--- a/tests/test_init_root.py
+++ b/tests/test_init_root.py
@@ -4,12 +4,23 @@ import subprocess
 import os
 import sys
 from pathlib import Path
-from gway import gw
+from gway import Gateway
+import gway.gateway as gateway_module
+import gway as gway_pkg
 
 class InitRootTests(unittest.TestCase):
     def test_creates_expected_structure(self):
         with tempfile.TemporaryDirectory() as tmp:
-            result = gw.init_root(tmp)
+            local_gw = Gateway()
+            old_mod_gw = gateway_module.gw
+            old_pkg_gw = gway_pkg.gw
+            gateway_module.gw = local_gw
+            gway_pkg.gw = local_gw
+            try:
+                result = local_gw.init_root(tmp)
+            finally:
+                gateway_module.gw = old_mod_gw
+                gway_pkg.gw = old_pkg_gw
             root_path = Path(result)
             expected = [
                 'envs/clients',
@@ -26,7 +37,16 @@ class InitRootTests(unittest.TestCase):
 
     def test_cli_runs_project_from_anywhere(self):
         with tempfile.TemporaryDirectory() as root_tmp, tempfile.TemporaryDirectory() as cwd_tmp:
-            root_path = Path(gw.init_root(root_tmp))
+            local_gw = Gateway()
+            old_mod_gw = gateway_module.gw
+            old_pkg_gw = gway_pkg.gw
+            gateway_module.gw = local_gw
+            gway_pkg.gw = local_gw
+            try:
+                root_path = Path(local_gw.init_root(root_tmp))
+            finally:
+                gateway_module.gw = old_mod_gw
+                gway_pkg.gw = old_pkg_gw
             project_dir = root_path / 'projects'
             proj_file = project_dir / 'demo.py'
             proj_file.write_text('def say_hi(name="World"):\n    print(f"hello {name}")\n')


### PR DESCRIPTION
## Summary
- ensure tests replace the package-level gw instance
- maintain project state separation for CLI root test

## Testing
- `gway test --filter init_root`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68765a57d0f4832693987ba22a80130c