### PR TITLE
Support top navigation bar in web.nav

### DIFF
--- a/data/static/styles/base.css
+++ b/data/static/styles/base.css
@@ -47,6 +47,51 @@ html, body {
     flex-direction: row-reverse;
 }
 
+.layout.nav-top {
+    flex-direction: column;
+}
+
+.layout.nav-top nav {
+    display: flex;
+    align-items: center;
+    padding: 0.5rem 1rem;
+    background: var(--bg-alt, #f0f0f0);
+    border-bottom: 1px solid #ccc;
+}
+
+.layout.nav-top nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+}
+
+.layout.nav-top nav li {
+    position: relative;
+    margin-right: 1em;
+}
+
+.layout.nav-top nav li ul.sub-links {
+    display: none;
+    position: absolute;
+    left: 0;
+    top: 100%;
+    background: var(--bg-alt, #f0f0f0);
+    border: 1px solid #ccc;
+    padding: 0.3em 0.5em;
+    list-style: none;
+    min-width: 10em;
+    z-index: 1000;
+}
+
+.layout.nav-top nav li:hover ul.sub-links {
+    display: block;
+}
+
+.layout.nav-top nav form.nav {
+    margin-left: auto;
+}
+
 /* Nav on the right tweaks */
 .layout.nav-right aside {
     border-right: none;

--- a/data/static/web/nav/README.rst
+++ b/data/static/web/nav/README.rst
@@ -5,6 +5,7 @@ JavaScript helpers for responsive navigation menus.
 
 ``web.nav`` accepts a ``--style`` parameter during setup to select the
 initial theme without exposing the style switcher. Use ``--style random``
-to pick a random theme on each request.
+to pick a random theme on each request. A ``--side top`` option places the
+navigation bar at the top of the page with drop-down menus.
 The style switcher drop-down also includes a **Random** option to toggle
 this behavior per user.

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -636,9 +636,11 @@ def render_template(*, title="GWAY", content="", css_files=None, js_files=None, 
         </head>
         <body>
             <div class="page-wrap">
-                <div class="layout{{' nav-right' if nav_side == 'right' else ''}}">
+                <div class="layout{{' nav-right' if nav_side == 'right' else (' nav-top' if nav_side == 'top' else '')}}">
                     % if nav_side == 'right':
                     <main>{{!message_html}}{{!content}}</main>{{!nav}}
+                    % elif nav_side == 'top':
+                    {{!nav}}<main>{{!message_html}}{{!content}}</main>
                     % else:
                     {{!nav}}<main>{{!message_html}}{{!content}}</main>
                     % end

--- a/projects/web/nav.py
+++ b/projects/web/nav.py
@@ -200,6 +200,8 @@ def render(*, homes=None, links=None):
             )
         compass = f'<div class="compass"{data_attr}>{compass}</div>'
 
+    if _side == "top":
+        return f"<nav class='top-bar'><ul class='top-links'>{links_html}</ul>{search_box}</nav>"
     return f"<aside>{search_box}<ul>{links_html}</ul><br>{compass}{toggle}</aside>"
 
 
@@ -526,13 +528,14 @@ def setup_app(*, app=None, style=None, side="left", **_):
     """Optional hook to set a default style and nav side when the project is added.
 
     Pass ``style='random'`` to select a random theme on each request.
-    Use ``side='right'`` to place the navigation on the right side.
+    Use ``side='right'`` to place the navigation on the right side or ``side='top'``
+    for a horizontal bar with drop-down menus.
     """
     global _forced_style, _side
     if style:
         _forced_style = style
         gw.info(f"web.nav forced style: {style}")
-    if side in {"left", "right"}:
+    if side in {"left", "right", "top"}:
         _side = side
         gw.info(f"web.nav side set to {side}")
     else:
@@ -541,5 +544,5 @@ def setup_app(*, app=None, style=None, side="left", **_):
 
 
 def side() -> str:
-    """Return the configured navigation side ('left' or 'right')."""
+    """Return the configured navigation side ('left', 'right' or 'top')."""
     return _side

--- a/tests/test_nav_top.py
+++ b/tests/test_nav_top.py
@@ -1,0 +1,30 @@
+import unittest
+from unittest.mock import patch
+from gway import gw
+
+class FakeRequest:
+    def __init__(self):
+        self.fullpath = '/web/site/index'
+        self.query = {}
+        self.query_string = ''
+        self.environ = {}
+    def get_header(self, name):
+        return None
+
+class NavTopTests(unittest.TestCase):
+    def test_render_top_nav(self):
+        old_side = gw.web.nav.side()
+        try:
+            gw.web.nav.setup_app(side='top')
+            with patch('web_nav.request', FakeRequest()):
+                html = gw.web.nav.render(homes=[('Home', 'web/site')],
+                                          links={'web/site': ['about']})
+            self.assertIn('<nav', html)
+            self.assertIn('sub-links', html)
+            self.assertIn('top-bar', html)
+        finally:
+            gw.web.nav.setup_app(side=old_side)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add `--side top` option to `web.nav.setup_app`
- support rendering a top bar with drop-down menus
- style the top navigation in the base CSS
- document the new option
- test rendering the top navigation

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6876c1f641bc8326849476f7ca4a0471