### PR TITLE
Improve web.app docs for static assets

### DIFF
--- a/data/static/web/README.rst
+++ b/data/static/web/README.rst
@@ -47,3 +47,30 @@ For example, to embed the ``reader`` page:
 
 Only self-contained views display correctly when framed.
 
+Function Naming and Routing
+---------------------------
+
+Functions prefixed with ``view_`` render HTML pages. ``api_`` functions return
+JSON and ``render_`` functions return fragments for dynamic updates. Their names
+map directly to URL paths:
+
+* ``view_home`` -> ``/project/home``
+* ``view_get_stats`` -> ``/project/stats`` for GET requests only
+* ``api_update`` -> ``/api/project/update``
+* ``render_status_charger`` -> ``/render/project/status/charger``
+
+Multiple views may be combined in one request using ``+`` in the path, e.g.
+``/project/view1+view2``. Render functions can return HTML strings, JSON lists
+or dictionaries and are often used with ``render.js`` for auto-refresh blocks.
+
+Static Collection
+-----------------
+
+``setup_app`` bundles CSS and JavaScript from enabled projects into
+``/shared/global.css`` and ``/shared/global.js``. Call ``web static collect``
+before starting the server to create or update these bundles. To add files for a
+specific view, create ``<view>.css`` or ``<view>.js`` (without the ``view_``
+prefix) inside ``data/static/<project>``. These assets are picked up
+automatically during ``static collect`` so manual ``<link>`` or ``<script>``
+tags are unnecessary unless ``mode='manual'`` is requested.
+

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -1,4 +1,22 @@
 # file: projects/web/app.py
+"""Web application dispatcher for GWAY.
+
+`setup_app` registers a project and exposes any ``view_*`` functions under
+``/project`` for HTML responses, ``api_*`` under ``/api/project`` for JSON, and
+``render_*`` under ``/render/project/<view>/<hash>`` for fragment updates.
+
+Functions can be specialized by HTTP method (``view_get_*``/``view_post_*``) and
+multiple view names may be combined with ``+`` in the path to build a mashup.
+``render_*`` functions may return HTML or JSON and are ideal for dynamic
+refreshes via ``render.js``.
+
+CSS and JavaScript from enabled projects are bundled via
+``web.static.collect``. ``setup_app`` defaults to ``mode='collect'`` so pages
+load ``/shared/global.css`` and ``/shared/global.js`` automatically. Add
+``<view>.css`` or ``<view>.js`` (without the ``view_`` prefix) to
+``data/static/<project>`` for view-specific assets and avoid manual ``<link>`` or
+``<script>`` tags unless ``mode='manual'`` is requested.
+"""
 
 import os
 from urllib.parse import urlencode


### PR DESCRIPTION
## Summary
- document static asset bundling via `web.static.collect`
- explain how to add per-view CSS/JS by naming files after the view

## Testing
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6876bc1caf80832692bc326194339cdb