### PR TITLE
Refactor QPig farm to run entirely in JS

### DIFF
--- a/data/static/games/qpig/qpig_farm.js
+++ b/data/static/games/qpig/qpig_farm.js
@@ -1,17 +1,51 @@
 // file: data/static/games/qpig/qpig_farm.js
+// All Quantum Piggy Farm logic lives here. The server only supplies the HTML
+// skeleton used by this script.
 
 const QPIG_KEY = 'qpig_state';
-if (!sessionStorage.getItem(QPIG_KEY) && window.qpigInitState) {
-    sessionStorage.setItem(QPIG_KEY, window.qpigInitState);
+const LAB_KEY = 'qpig_lab';
+
+// ------------------------- Helpers -------------------------
+const ADJECTIVES = ['Fluffy', 'Happy', 'Cheery', 'Bouncy', 'Chubby', 'Sunny'];
+const NOUNS = ['Nibbler', 'Snout', 'Whisker', 'Hopper', 'Wiggler', 'Sniffer'];
+
+function randomName() {
+    return ADJECTIVES[Math.floor(Math.random() * ADJECTIVES.length)] +
+        ' ' + NOUNS[Math.floor(Math.random() * NOUNS.length)];
+}
+
+function newPig() {
+    function rnd() { return +(1 + Math.random() * 3).toFixed(2); }
+    return {
+        name: randomName(),
+        alertness: rnd(),
+        curiosity: rnd(),
+        fitness: rnd(),
+        handling: rnd(),
+        face: 1 + Math.floor(Math.random() * 70),
+        activity: 'Resting'
+    };
+}
+
+function defaultState() {
+    return {
+        garden: {
+            max_qpigs: 2,
+            qpellets: 0,
+            pigs: [newPig()]
+        },
+        vcreds: 100
+    };
 }
 
 function loadState() {
-    const data = sessionStorage.getItem(QPIG_KEY) || window.qpigInitState || '';
-    try {
-        return JSON.parse(atob(data));
-    } catch (e) {
-        return {};
+    const raw = sessionStorage.getItem(QPIG_KEY) || '';
+    if (!raw) {
+        const st = defaultState();
+        saveState(st);
+        return st;
     }
+    try { return JSON.parse(atob(raw)); } catch (e) { return defaultState(); }
 }
 
 function saveState(st) {
@@ -31,14 +65,62 @@ function updateCounters(st) {
     if (vcLab) vcLab.textContent = `V-Creds: ${st.vcreds}`;
 }
 
+function renderPigs(st) {
+    const wrap = document.querySelector('.qpig-pigs');
+    const tmpl = document.getElementById('pig-template');
+    if (!wrap || !tmpl) return;
+    wrap.innerHTML = '';
+    st.garden.pigs.forEach(p => {
+        const card = tmpl.cloneNode(true);
+        card.id = '';
+        card.style.display = '';
+        card.querySelector('.qpig-pig-name').textContent = p.name;
+        card.querySelector('.qpig-pig-activity').textContent = p.activity;
+        card.querySelector('.qpig-pig-stats').textContent =
+            `Alertness: ${p.alertness} Curiosity: ${p.curiosity} ` +
+            `Fitness: ${p.fitness} Handling: ${p.handling}`;
+        card.querySelector('.qpig-photo').src =
+            `https://i.pravatar.cc/30?img=${p.face}`;
+        wrap.appendChild(card);
+    });
+}
+
+// --------------------- State machine -----------------------
+function fitnessChance(a) { return Math.random() * 100 < (a.fitness || 0); }
+function curiosityChance(a) { return Math.random() * 100 < (a.curiosity || 0); }
+function handlingChance(a) { return Math.random() * 100 < (a.handling || 0); }
+function alertnessChance(a) { return Math.random() * 100 < (a.alertness || 0); }
+
+const STATE_MACHINE = {
+    'Resting': { 'Resting placidly': 'fitnessChance' },
+    'Resting placidly': { 'Exploring pen': 'curiosityChance' },
+    'Exploring pen': { 'Running laps': 'fitnessChance' },
+    'Running laps': { 'Resting': 'handlingChance' }
+};
+
+function nextActivity(act, attrs) {
+    const transitions = STATE_MACHINE[act] || {};
+    for (const [nxt, cond] of Object.entries(transitions)) {
+        if (typeof cond === 'string') {
+            const fn = globalThis[cond];
+            if (typeof fn === 'function') {
+                if (fn(attrs)) return nxt;
+            } else if (cond.endsWith('%')) {
+                const attr = cond.slice(0, -1).toLowerCase();
+                if (Math.random() * 100 < (attrs[attr] || 0)) return nxt;
+            }
+        }
+    }
+    return act;
+}
+
 function producePellet(st, idx) {
     const p = st.garden.pigs[idx];
-    if (!p || p.pooping) {
-        return;
-    }
+    if (!p || p.pooping) return;
     p.pooping = true;
     p.prevActivity = p.activity;
     p.activity = 'Pooping.';
+    renderPigs(st);
     setTimeout(() => {
         const cur = loadState();
         const pig = (cur.garden.pigs || [])[idx];
@@ -50,89 +132,65 @@ function producePellet(st, idx) {
         delete pig.prevActivity;
         delete pig.pooping;
         saveState(cur);
+        renderPigs(cur);
         updateCounters(cur);
     }, 2000);
 }
 
-async function tick() {
+function tick() {
     const st = loadState();
-    for (let i = 0; i < (st.garden.pigs || []).length; i++) {
-        const p = st.garden.pigs[i];
+    st.garden.pigs.forEach((p, i) => {
         if (Math.random() * 100 < (p.curiosity || 0)) {
-            try {
-                const url = `/api/games/qpig/next-activity?act=${encodeURIComponent(p.activity || '')}&alertness=${p.alertness}&curiosity=${p.curiosity}&fitness=${p.fitness}&handling=${p.handling}`;
-                const res = await fetch(url);
-                const data = await res.json();
-                if (data.activity) {
-                    p.activity = data.activity;
-                }
-            } catch (e) {}
+            p.activity = nextActivity(p.activity, p);
         }
         if (Math.random() * 100 < (p.fitness || 0)) {
             producePellet(st, i);
         }
-    }
+    });
     saveState(st);
+    renderPigs(st);
     updateCounters(st);
 }
-updateCounters(loadState());
-setInterval(() => { tick(); }, 1000);
-const save = document.getElementById('qpig-save');
-if (save) {
-    save.addEventListener('click', () => {
-        const data = sessionStorage.getItem(QPIG_KEY) || '';
-        const blob = new Blob([data], { type: 'application/octet-stream' });
-        const a = document.createElement('a');
-        a.href = URL.createObjectURL(blob);
-        a.download = 'qpig-save.qpg';
-        a.click();
-        setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+
+// ----------------------- Market ----------------------------
+const MARKET_STALLS = [
+    ['Veggie Wagon', [
+        { cost: 5, icon: '🥕', name: 'Carrot Bundle' },
+        { cost: 8, icon: '🥬', name: 'Lettuce Head' },
+        { cost: 10, icon: '🌿', name: 'Cilantro Bunch' }
+    ]],
+    ['Piggery Provisions', [
+        { cost: 15, icon: '🧴', name: 'Water Bottle' },
+        { cost: 20, icon: '🛏️', name: 'Straw Bedding' }
+    ]]
+];
+
+function renderMarketStalls() {
+    const cont = document.getElementById('market-stalls');
+    if (!cont) return;
+    cont.innerHTML = '';
+    MARKET_STALLS.forEach(([stall, items]) => {
+        const div = document.createElement('div');
+        div.className = 'market-stall';
+        div.innerHTML = `<strong>${stall}</strong>`;
+        const table = document.createElement('table');
+        items.forEach(item => {
+            const row = document.createElement('tr');
+            row.innerHTML = `<td><button data-cost="${item.cost}">${item.cost} VC</button></td>` +
+                             `<td>${item.icon}</td><td>${item.name}</td>`;
+            table.appendChild(row);
+        });
+        div.appendChild(table);
+        cont.appendChild(div);
     });
 }
-const load = document.getElementById('qpig-load');
-if (load) {
-    load.addEventListener('click', () => {
-        const inp = document.createElement('input');
-        inp.type = 'file';
-        inp.accept = '.qpg';
-        inp.onchange = e => {
-            const f = e.target.files[0];
-            if (!f) return;
-            const r = new FileReader();
-            r.onload = ev => {
-                sessionStorage.setItem(QPIG_KEY, ev.target.result.trim());
-                location.reload();
-            };
-            r.readAsText(f);
-        };
-        inp.click();
-    });
-}
-const tabs = document.querySelectorAll('.qpig-tab');
-const panels = document.querySelectorAll('.qpig-panel');
-const garden = document.querySelector('.qpig-garden');
-tabs.forEach(t => t.addEventListener('click', () => {
-    tabs.forEach(x => x.classList.remove('active'));
-    panels.forEach(p => p.classList.remove('active'));
-    t.classList.add('active');
-    const panel = document.getElementById('qpig-panel-' + t.dataset.tab);
-    if (panel) panel.classList.add('active');
-    if (garden) {
-        garden.className = garden.className.replace(/\btab-\w+\b/, '').trim();
-        garden.classList.add('tab-' + t.dataset.tab);
-    }
-}));
 
-// Quantum Lab operations
-const LAB_KEY = 'qpig_lab';
-
+// --------------------- Quantum Lab -------------------------
 function loadLabState() {
-    try { return JSON.parse(sessionStorage.getItem(LAB_KEY) || '{}'); } catch (e) { return {}; }
+    try { return JSON.parse(sessionStorage.getItem(LAB_KEY) || '{}'); } catch { return {}; }
 }
 
-function saveLabState(st) {
-    sessionStorage.setItem(LAB_KEY, JSON.stringify(st));
-}
+function saveLabState(st) { sessionStorage.setItem(LAB_KEY, JSON.stringify(st)); }
 
 function startLabOp(op, secs) {
     const finish = Date.now() + secs * 1000;
@@ -143,8 +201,6 @@ function startLabOp(op, secs) {
 function handleLabOpComplete(op) {
     if (op === 'collect') {
         collectPellets();
-    } else {
-        console.log('lab operation complete:', op);
     }
 }
 
@@ -193,12 +249,70 @@ function updateLabProgress() {
     btns.forEach(b => b.disabled = true);
 }
 
-document.querySelectorAll('#qpig-lab-ops button').forEach(b => {
-    b.addEventListener('click', () => {
-        const secs = parseInt(b.dataset.time || '0', 10);
-        if (secs > 0) startLabOp(b.dataset.op, secs);
-    });
-});
+// ----------------------- Setup -----------------------------
+document.addEventListener('DOMContentLoaded', () => {
+    renderMarketStalls();
+    const st = loadState();
+    renderPigs(st);
+    updateCounters(st);
+    setInterval(tick, 1000);
 
-updateLabProgress();
-setInterval(updateLabProgress, 500);
+    document.querySelectorAll('.qpig-tab').forEach(t => {
+        const panels = document.querySelectorAll('.qpig-panel');
+        const garden = document.querySelector('.qpig-garden');
+        t.addEventListener('click', () => {
+            document.querySelectorAll('.qpig-tab').forEach(x => x.classList.remove('active'));
+            panels.forEach(p => p.classList.remove('active'));
+            t.classList.add('active');
+            const panel = document.getElementById('qpig-panel-' + t.dataset.tab);
+            if (panel) panel.classList.add('active');
+            if (garden) {
+                garden.className = garden.className.replace(/\btab-\w+\b/, '').trim();
+                garden.classList.add('tab-' + t.dataset.tab);
+            }
+        });
+    });
+
+    document.querySelectorAll('#qpig-lab-ops button').forEach(b => {
+        b.addEventListener('click', () => {
+            const secs = parseInt(b.dataset.time || '0', 10);
+            if (secs > 0) startLabOp(b.dataset.op, secs);
+        });
+    });
+
+    const saveBtn = document.getElementById('qpig-save');
+    if (saveBtn) {
+        saveBtn.addEventListener('click', () => {
+            const data = sessionStorage.getItem(QPIG_KEY) || '';
+            const blob = new Blob([data], { type: 'application/octet-stream' });
+            const a = document.createElement('a');
+            a.href = URL.createObjectURL(blob);
+            a.download = 'qpig-save.qpg';
+            a.click();
+            setTimeout(() => URL.revokeObjectURL(a.href), 1000);
+        });
+    }
+
+    const loadBtn = document.getElementById('qpig-load');
+    if (loadBtn) {
+        loadBtn.addEventListener('click', () => {
+            const inp = document.createElement('input');
+            inp.type = 'file';
+            inp.accept = '.qpg';
+            inp.onchange = e => {
+                const f = e.target.files[0];
+                if (!f) return;
+                const r = new FileReader();
+                r.onload = ev => {
+                    sessionStorage.setItem(QPIG_KEY, ev.target.result.trim());
+                    location.reload();
+                };
+                r.readAsText(f);
+            };
+            inp.click();
+        });
+    }
+
+    updateLabProgress();
+    setInterval(updateLabProgress, 500);
+});

--- a/projects/games/qpig.py
+++ b/projects/games/qpig.py
@@ -1,256 +1,10 @@
-# file: projects/games/qpig.py
-"""Prototype incremental game about quantum guinea pigs."""
-
+"""Quantum Piggy Farm view skeleton served by GWAY."""
 from gway import gw
-import json
-import base64
-import random
-import yaml
-from bottle import request
-
-DEFAULT_MAX_QPIGS = 2
-
-DEFAULT_PIGS = 1
-DEFAULT_MICROCERTS = 500  # 0.5 Cert
-DEFAULT_ENC_SMALL = 1
-DEFAULT_ENC_LARGE = 0
-DEFAULT_AVAILABLE = 3
-DEFAULT_VEGGIES = {}
-DEFAULT_FOOD = []
-DEFAULT_VCREDS = 100  # starting amount of V-Creds
-
-ENCLOSURE_MAX = 8
-
-CERTAINTY_MAX = 1000  # stored in microcerts
-FILL_TIME = 10 * 60  # base seconds from 0 to 1
-ENC_TIME_SMALL = 5 * 60
-ENC_TIME_LARGE = 8 * 60
-
-SMALL_COST = 650
-LARGE_COST = 920
-UPKEEP_SMALL_HR = 2.0
-UPKEEP_LARGE_HR = 3.0
-
-ADOPTION_ADD = 2
-ADOPTION_INTERVAL = 3 * 3600
-ADOPTION_THRESHOLD = 7
-
-# QP generation: 50% chance every 30s plus +/-25% from Certainty
-QP_INTERVAL = 30.0  # seconds between pellet attempts
-QP_BASE_CHANCE = 0.5
-QP_CERT_BONUS = 0.25
-
-VEGGIE_TYPES = ["carrot", "lettuce", "cilantro", "cucumber"]
-VEGGIE_BASE_PRICE = 12
-VEGGIE_PRICE_SPREAD = 8
-
-# chance to generate an extra pellet while nibbling
-VEGGIE_BONUS = {
-    "carrot": 0.25,
-    "lettuce": 0.15,
-    "cilantro": 0.3,
-    "cucumber": 0.2,
-}
-
-# how long each veggie is eaten and how long the boost lingers, in seconds
-VEGGIE_EFFECTS = {
-    "carrot": (60, 30),
-    "lettuce": (90, 45),
-    "cilantro": (120, 60),
-    "cucumber": (75, 40),
-}
 
 
-OFFER_EXPIRY = 300  # seconds
-
-# Example market stall inventory
-_MARKET_STALLS = [
-    (
-        "Veggie Wagon",
-        [
-            {"cost": 5, "icon": "🥕", "name": "Carrot Bundle"},
-            {"cost": 8, "icon": "🥬", "name": "Lettuce Head"},
-            {"cost": 10, "icon": "🌿", "name": "Cilantro Bunch"},
-        ],
-    ),
-    (
-        "Piggery Provisions",
-        [
-            {"cost": 15, "icon": "🧴", "name": "Water Bottle"},
-            {"cost": 20, "icon": "🛏️", "name": "Straw Bedding"},
-        ],
-    ),
-]
-
-
-_ADJECTIVES = ["Fluffy", "Happy", "Cheery", "Bouncy", "Chubby", "Sunny"]
-_NOUNS = ["Nibbler", "Snout", "Whisker", "Hopper", "Wiggler", "Sniffer"]
-
-
-def _random_name() -> str:
-    """Generate a cute two-word name."""
-    return f"{random.choice(_ADJECTIVES)} {random.choice(_NOUNS)}"
-
-
-def _new_pig() -> dict:
-    """Create a new pig with random stats."""
-    return {
-        "name": _random_name(),
-        "alertness": round(random.uniform(1, 4), 2),
-        "curiosity": round(random.uniform(1, 4), 2),
-        "fitness": round(random.uniform(1, 4), 2),
-        "handling": round(random.uniform(1, 4), 2),
-        "face": random.randint(1, 70),
-        "activity": "Resting",
-    }
-
-
-def _load_state() -> dict:
-    """Load simplified state from request or defaults."""
-    data = request.forms.get("state") or request.query.get("state") or ""
-    state = {}
-    if data:
-        try:
-            raw = base64.b64decode(data.encode()).decode()
-            state = json.loads(raw)
-        except Exception:
-            gw.debug("invalid state input")
-    garden = state.get("garden", {}) if isinstance(state, dict) else {}
-    max_qpigs = int(garden.get("max_qpigs", DEFAULT_MAX_QPIGS))
-    qpellets = int(garden.get("qpellets", 0))
-    pigs = garden.get("pigs") if isinstance(garden, dict) else None
-    vcreds = int(state.get("vcreds", DEFAULT_VCREDS)) if isinstance(state, dict) else DEFAULT_VCREDS
-    if not isinstance(pigs, list) or not pigs:
-        pigs = [_new_pig() for _ in range(DEFAULT_PIGS)]
-    else:
-        for pig in pigs:
-            if isinstance(pig, dict):
-                pig.setdefault("activity", "Resting")
-    return {"garden": {"max_qpigs": max_qpigs, "qpellets": qpellets, "pigs": pigs},
-            "vcreds": vcreds}
-
-
-def _dump_state(state: dict) -> str:
-    raw = json.dumps(state)
-    return base64.b64encode(raw.encode()).decode()
-
-
-
-def _process_state(state: dict, action: str | None = None) -> dict:
-    """Minimal state processor (placeholder for future logic)."""
-    gw.debug(f"_process_state called with action={action}")
-    return state
-
-
-# -------------------------------------------------------------
-# Activity state machine helpers
-# -------------------------------------------------------------
-
-def fitness_chance(attrs: dict) -> bool:
-    """Return True if a fitness-based roll succeeds."""
-    return random.random() * 100 < float(attrs.get("fitness", 0))
-
-
-def curiosity_chance(attrs: dict) -> bool:
-    """Return True if a curiosity-based roll succeeds."""
-    return random.random() * 100 < float(attrs.get("curiosity", 0))
-
-
-def handling_chance(attrs: dict) -> bool:
-    """Return True if a handling-based roll succeeds."""
-    return random.random() * 100 < float(attrs.get("handling", 0))
-
-
-def alertness_chance(attrs: dict) -> bool:
-    """Return True if an alertness-based roll succeeds."""
-    return random.random() * 100 < float(attrs.get("alertness", 0))
-
-
-_DEFAULT_STATE_MACHINE: dict[str, dict[str, str]] = {
-    "Resting": {"Resting placidly": "fitness_chance"},
-    "Resting placidly": {"Exploring pen": "curiosity_chance"},
-    "Exploring pen": {"Running laps": "fitness_chance"},
-    "Running laps": {"Resting": "handling_chance"},
-}
-
-
-def _load_state_machine() -> dict[str, dict[str, str]]:
-    """Load transitions from YAML file or return defaults."""
-    try:
-        path = gw.resource("work", "games", "qpig", "transitions.yml")
-        if path.is_file():
-            with open(path, "r", encoding="utf-8") as fh:
-                data = yaml.safe_load(fh) or {}
-                if isinstance(data, dict):
-                    return data
-    except Exception as exc:  # pragma: no cover - file IO
-        gw.debug(f"failed to load transitions: {exc}")
-    return _DEFAULT_STATE_MACHINE
-
-
-
-# Simple finite state machine for pig activities
-_STATE_MACHINE: dict[str, dict[str, str]] = _load_state_machine()
-
-
-def api_next_activity(*, act: str = "Resting", alertness: float = 0.0,
-                      curiosity: float = 0.0, fitness: float = 0.0,
-                      handling: float = 0.0, **_):
-    """Determine the next activity using the FSM based on pig stats."""
-    attrs = {
-        "alertness": float(alertness or 0),
-        "curiosity": float(curiosity or 0),
-        "fitness": float(fitness or 0),
-        "handling": float(handling or 0),
-    }
-
-    transitions = _STATE_MACHINE.get(act, {})
-    for nxt, cond in transitions.items():
-        if isinstance(cond, str):
-            func = globals().get(cond)
-            if callable(func):
-                if func(attrs):
-                    return {"activity": nxt}
-            elif cond.endswith('%'):
-                attr = cond[:-1].lower()
-                chance = attrs.get(attr, 0)
-                if random.random() * 100 < chance:
-                    return {"activity": nxt}
-
-    return {"activity": act}
-
-
-def render_market_stalls():
-    """Render available stalls and their wares."""
-    rows = []
-    for stall, items in _MARKET_STALLS:
-        rows.append(f'<div class="market-stall"><strong>{stall}</strong>')
-        rows.append('<table>')
-        for item in items:
-            cost = item.get("cost", 0)
-            icon = item.get("icon", "")
-            name = item.get("name", "")
-            rows.append(
-                f'<tr><td><button data-cost="{cost}">{cost} VC</button>'
-                f'</td><td>{icon}</td><td>{name}</td></tr>'
-            )
-        rows.append('</table></div>')
-    return "\n".join(rows)
-
-
-
-
-def view_qpig_farm(*, action: str = None, **_):
-    """Main Quantum Piggy farm view."""
+def view_qpig_farm(*_, **__):
+    """Return the basic HTML frame for the Quantum Piggy Farm game."""
     gw.debug("view_qpig_farm called")
-    state = _load_state()
-    state_b64 = _dump_state(state)
-    garden = state["garden"]
-    max_qpigs = garden["max_qpigs"]
-    qpellets = garden.get("qpellets", 0)
-    pigs = garden.get("pigs", [])
-    vcreds = state.get("vcreds", DEFAULT_VCREDS)
-
     html = [
         '<link rel="stylesheet" href="/static/games/qpig/qpig_farm.css">',
         '<script src="/static/games/qpig/qpig_farm.js"></script>',
@@ -264,50 +18,48 @@ def view_qpig_farm(*, action: str = None, **_):
         '<button class="qpig-tab" data-tab="settings">Game Settings</button>',
         '</div>',
         '<div id="qpig-panel-garden" class="qpig-panel active">',
-        f'<div class="qpig-top"><span id="qpig-count">Q-Pigs: {len(pigs)}/{max_qpigs}</span><span id="qpig-pellets">Q-Pellets: {qpellets}</span></div>',
+        '<div class="qpig-top"><span id="qpig-count"></span>'
+        '<span id="qpig-pellets"></span></div>',
         '<div class="qpig-pigs">',
-    ]
-    for pig in pigs:
-        html.extend([
-            '<div class="qpig-pig-card">',
-            '<div class="qpig-pig-info">',
-            f'<div><span class="qpig-pig-name">{pig["name"]}</span> — '
-            f'<em>{pig.get("activity", "Resting")}</em></div>',
-            f'<div class="qpig-pig-stats">Alertness: {pig["alertness"]} '
-            f'Curiosity: {pig["curiosity"]} Fitness: {pig["fitness"]} '
-            f'Handling: {pig["handling"]}</div>',
-            '</div>',
-            f'<img class="qpig-photo" src="https://i.pravatar.cc/30?img={pig.get("face",1)}" width="30" height="30">',
-            '</div>',
-        ])
-    html.extend([
-        '</div>',  # close qpig-pigs
-        '</div>',  # close qpig-panel-garden
-        f'<div id="qpig-panel-market" class="qpig-panel">'
-        f'<div class="qpig-top"><span id="qpig-vcreds">Available V-Creds: {vcreds}</span></div>'
-        f'<div id="market-stalls" gw-render="market_stalls">{render_market_stalls()}</div></div>',
-        '<div id="qpig-panel-lab" class="qpig-panel">'
-        f'<div class="qpig-top">'
-        f'<span id="qpig-lab-pellets">Q-Pellets: {qpellets}</span>'
-        f'<span id="qpig-lab-vcreds">V-Creds: {vcreds}</span>'
-        '</div>'
-        '<table id="qpig-lab-ops" class="lab-ops">'
-        '<tr><th>Operation</th><th>Time</th><th></th></tr>'
-        '<tr><td>Measure Spin</td><td>5s</td><td><button data-op="measure" data-time="5">Start</button></td></tr>'
-        '<tr><td>Entangle Pair</td><td>10s</td><td><button data-op="entangle" data-time="10">Start</button></td></tr>'
-        '<tr><td>Collect Quantum Pellets</td><td>3s</td><td><button data-op="collect" data-time="3">Start</button></td></tr>'
-        '</table>'
-        '<progress id="lab-progress" value="0" max="100" style="display:none;width:100%"></progress>'
+        '<div id="pig-template" class="qpig-pig-card" style="display:none;">',
+        '<div class="qpig-pig-info">',
+        '<div><span class="qpig-pig-name">Name</span> — '
+        '<em class="qpig-pig-activity">Resting</em></div>',
+        '<div class="qpig-pig-stats"></div>',
         '</div>',
-        '<div id="qpig-panel-travel" class="qpig-panel"><div class="qpig-top"></div>Travel Abroad coming soon</div>',
-        '<div id="qpig-panel-settings" class="qpig-panel"><div class="qpig-top"></div>',
+        '<img class="qpig-photo" src="" width="30" height="30">',
+        '</div>',
+        '</div>',
+        '</div>',
+        '<div id="qpig-panel-market" class="qpig-panel">',
+        '<div class="qpig-top"><span id="qpig-vcreds"></span></div>',
+        '<div id="market-stalls"></div></div>',
+        '<div id="qpig-panel-lab" class="qpig-panel">',
+        '<div class="qpig-top">',
+        '<span id="qpig-lab-pellets"></span>'
+        '<span id="qpig-lab-vcreds"></span>',
+        '</div>',
+        '<table id="qpig-lab-ops" class="lab-ops">',
+        '<tr><th>Operation</th><th>Time</th><th></th></tr>',
+        '<tr><td>Measure Spin</td><td>5s</td>'
+        '<td><button data-op="measure" data-time="5">Start</button></td></tr>',
+        '<tr><td>Entangle Pair</td><td>10s</td>'
+        '<td><button data-op="entangle" data-time="10">Start</button></td></tr>',
+        '<tr><td>Collect Quantum Pellets</td><td>3s</td>'
+        '<td><button data-op="collect" data-time="3">Start</button></td></tr>',
+        '</table>',
+        '<progress id="lab-progress" value="0" max="100" '
+        'style="display:none;width:100%"></progress>',
+        '</div>',
+        '<div id="qpig-panel-travel" class="qpig-panel">'
+        '<div class="qpig-top"></div>Travel Abroad coming soon</div>',
+        '<div id="qpig-panel-settings" class="qpig-panel">'
+        '<div class="qpig-top"></div></div>',
         '<div class="qpig-buttons">',
         "<button type='button' id='qpig-save' title='Save'>💾 Save</button>",
         "<button type='button' id='qpig-load' title='Load'>📂 Load</button>",
         '</div>',
         '</div>',
-        '</div>',  # close qpig-garden
-    ])
-
-    html.append(f'<script>window.qpigInitState="{state_b64}";</script>')
+        '</div>',
+    ]
     return "\n".join(html)

--- a/tests/test_qpig_farm.py
+++ b/tests/test_qpig_farm.py
@@ -15,19 +15,13 @@ class QPigFarmTests(unittest.TestCase):
         self.assertNotIn("<canvas id='qpig-canvas'", html)
         self.assertIn('qpig-save', html)
         self.assertIn('qpig-load', html)
-        self.assertIn('Q-Pellets', html)
-        self.assertIn('Available V-Creds', html)
+        self.assertIn('id="qpig-count"', html)
+        self.assertIn('id="qpig-pellets"', html)
+        self.assertIn('id="qpig-vcreds"', html)
         self.assertIn('qpig-pig-card', html)
-        self.assertIn('Q-Pigs:', html)
-        self.assertIn('Resting', html)
-        self.assertIn('gw-render="market_stalls"', html)
-        self.assertIn('qpig-lab-pellets', html)
-        self.assertIn('qpig-lab-vcreds', html)
-
-    def test_render_market_stalls_basic(self):
-        html = self.qpig_mod.render_market_stalls()
-        self.assertIn('Veggie Wagon', html)
-        self.assertIn('VC', html)
+        self.assertIn('market-stalls', html)
+        self.assertIn('id="qpig-lab-pellets"', html)
+        self.assertIn('id="qpig-lab-vcreds"', html)
 
     def test_tab_names_updated(self):
         html = self.qpig_mod.view_qpig_farm()


### PR DESCRIPTION
## Summary
- migrate QPig game logic from Python to JavaScript
- provide minimal Python view skeleton for the game
- update JavaScript with game state management and rendering
- adjust tests for new HTML layout

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6876e373f91c83269309f9ea982127dc