### PR TITLE
Rename charger_status view to active_chargers

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -23,7 +23,7 @@ The simulator accepts ``--kwh-min`` and ``--kwh-max`` to control the
 approximate energy delivered per session. For example, ``--kwh-min 40
 --kwh-max 70`` will produce sessions around 40–70 kWh.
 
-Open ``/ocpp/csms/charger-status`` in your browser to view all
+Open ``/ocpp/csms/active-chargers`` in your browser to view all
 connected chargers. Each card refreshes every few seconds so data
 stays current. Click a charger to open its detail page where you can
 send commands like ``Stop`` or ``Soft Reset`` and watch the log update

--- a/projects/ocpp/ocpp.py
+++ b/projects/ocpp/ocpp.py
@@ -238,7 +238,7 @@ csms.bind_state(sys.modules[__name__])
 def view_dashboard(**_):
     """Landing page linking to sub-project dashboards."""
     links = [
-        ("CSMS Status", "/ocpp/csms/charger-status"),
+        ("CSMS Status", "/ocpp/csms/active-chargers"),
         ("Charger Summary", "/ocpp/data/summary"),
         ("Energy Time Series", "/ocpp/data/time-series"),
         ("CP Simulator", "/ocpp/evcs/cp-simulator"),
@@ -249,8 +249,8 @@ def view_dashboard(**_):
     return "\n".join(html)
 
 
-def view_charger_status(*args, **kwargs):
-    return csms.view_charger_status(*args, **kwargs)
+def view_active_chargers(*args, **kwargs):
+    return csms.view_active_chargers(*args, **kwargs)
 
 
 def view_charger_detail(*args, **kwargs):

--- a/projects/web/auth.py
+++ b/projects/web/auth.py
@@ -265,7 +265,7 @@ def config_basic(
         pw_b64 = base64.b64encode(password.encode("utf-8")).decode("ascii")
         gw.cdv.update(allow, username, b64=pw_b64, expiration=expiration)
 
-        demo_path = "ocpp/csms/charger-status"
+        demo_path = "ocpp/csms/active-chargers"
         resource_url = gw.web.build_url(demo_path)
         from urllib.parse import urlparse
         p = urlparse(resource_url)

--- a/recipes/etron/cloud.gwr
+++ b/recipes/etron/cloud.gwr
@@ -3,7 +3,7 @@
 
 web app setup:
     - ocpp.data --home charger-summary
-    - ocpp.csms --home charger-status
+    - ocpp.csms --home active-chargers
     - ocpp.csms --home cp-simulator
     - web.cookies
     - web.nav

--- a/recipes/etron/local.gwr
+++ b/recipes/etron/local.gwr
@@ -5,7 +5,7 @@ web app setup:
     - ocpp.data --home charger-summary
     - web.nav
     - vbox
-    - ocpp.csms --home charger-status
+    - ocpp.csms --home active-chargers
     - ocpp.evcs --home cp-simulator
     - monitor --home monitor-panel
     - monitor.nmcli 

--- a/recipes/static_site.gwr
+++ b/recipes/static_site.gwr
@@ -8,7 +8,7 @@ web app setup-app --mode manual:
     - web.message
     - awg --home awg-calculator
     - vbox --home uploads
-    - ocpp.csms --auth required --home charger-status
+    - ocpp.csms --auth required --home active-chargers
     - ocpp.evcs --auth required --home cp-simulator
     - ocpp.data --auth required --home charger-summary
     - web.chat.actions --home audit-chatlog --auth required

--- a/recipes/test/etron/cloud.gwr
+++ b/recipes/test/etron/cloud.gwr
@@ -3,7 +3,7 @@
 
 web app setup:
     - ocpp.data --home charger-summary
-    - ocpp.csms --home charger-status
+    - ocpp.csms --home active-chargers
     - ocpp.csms --home cp-simulator
     - web.cookies
     - web.nav

--- a/recipes/test/etron/local_proxy.gwr
+++ b/recipes/test/etron/local_proxy.gwr
@@ -5,7 +5,7 @@ web app setup:
     - ocpp.data --home charger-summary
     - web.nav
     - vbox
-    - ocpp.csms --home charger-status
+    - ocpp.csms --home active-chargers
     - ocpp.evcs --home cp-simulator
     - ocpp.data --home charger-summary
 

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -12,7 +12,7 @@ web app setup:
     - web.chat
     - vbox --home uploads
     - ocpp.data --home charger-summary
-    - ocpp.csms --auth required --home charger-status
+    - ocpp.csms --auth required --home active-chargers
     - ocpp.evcs --auth required --home cp-simulator
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -10,7 +10,7 @@ web app setup:
     - web.message
     - awg --home awg-calculator
     - vbox --home uploads
-    - ocpp.csms --auth required --home charger-status
+    - ocpp.csms --auth required --home active-chargers
     - ocpp.evcs --auth required --home cp-simulator
     - ocpp.data --auth required --home charger-summary
     - web.chat.actions --home audit-chatlog --auth required

--- a/tests/test_auth_charger.py
+++ b/tests/test_auth_charger.py
@@ -82,21 +82,21 @@ class AuthChargerStatusTests(unittest.TestCase):
         b64 = base64.b64encode(up.encode()).decode()
         return {"Authorization": f"Basic {b64}"}
 
-    def test_unauthenticated_blocked_on_charger_status(self):
-        url = self.base_url + "/ocpp/csms/charger-status"
+    def test_unauthenticated_blocked_on_active_chargers(self):
+        url = self.base_url + "/ocpp/csms/active-chargers"
         resp = requests.get(url)
         self.assertEqual(
             resp.status_code, 401,
-            f"Expected 401 for unauthenticated /ocpp/csms/charger-status, got {resp.status_code}"
+            f"Expected 401 for unauthenticated /ocpp/csms/active-chargers, got {resp.status_code}"
         )
 
-    def test_authenticated_allows_on_charger_status(self):
-        url = self.base_url + "/ocpp/csms/charger-status"
+    def test_authenticated_allows_on_active_chargers(self):
+        url = self.base_url + "/ocpp/csms/active-chargers"
         headers = self._auth_header(TEST_USER, TEST_PASS)
         resp = requests.get(url, headers=headers)
         self.assertEqual(
             resp.status_code, 200,
-            f"Expected 200 for authenticated /ocpp/csms/charger-status, got {resp.status_code}"
+            f"Expected 200 for authenticated /ocpp/csms/active-chargers, got {resp.status_code}"
         )
         self.assertIn("OCPP", resp.text)
 
@@ -121,7 +121,7 @@ class AuthChargerStatusTests(unittest.TestCase):
         screenshot_dir = Path("work/screenshots")
         screenshot_dir.mkdir(parents=True, exist_ok=True)
         screenshot_file = screenshot_dir / "charger_status.png"
-        url = f"http://{TEST_USER}:{TEST_PASS}@127.0.0.1:18888/ocpp/csms/charger-status"
+        url = f"http://{TEST_USER}:{TEST_PASS}@127.0.0.1:18888/ocpp/csms/active-chargers"
         try:
             gw.web.auto.capture_page_source(url, screenshot=str(screenshot_file))
         except Exception as e:

--- a/tests/test_charger_refresh.py
+++ b/tests/test_charger_refresh.py
@@ -100,12 +100,41 @@ class ChargerDashboardRefreshTests(unittest.TestCase):
                 )
             )
             await asyncio.sleep(3)
-            resp = await asyncio.to_thread(
-                requests.post,
-                "http://127.0.0.1:18888/render/ocpp/csms/charger-status/charger_list",
+            url = "http://127.0.0.1:18888/ocpp/csms/active-chargers"
+            view_resp = await asyncio.to_thread(
+                requests.get,
+                url,
                 headers=_auth_header(TEST_USER, TEST_PASS),
                 timeout=5,
             )
+            for _ in range(5):
+                if "SIMDASH" in view_resp.text:
+                    break
+                await asyncio.sleep(1)
+                view_resp = await asyncio.to_thread(
+                    requests.get,
+                    url,
+                    headers=_auth_header(TEST_USER, TEST_PASS),
+                    timeout=5,
+                )
+            self.assertIn("SIMDASH", view_resp.text)
+            list_url = "http://127.0.0.1:18888/render/ocpp/csms/active-chargers/charger_list"
+            resp = await asyncio.to_thread(
+                requests.post,
+                list_url,
+                headers=_auth_header(TEST_USER, TEST_PASS),
+                timeout=5,
+            )
+            for _ in range(5):
+                if "SIMDASH" in resp.text:
+                    break
+                await asyncio.sleep(1)
+                resp = await asyncio.to_thread(
+                    requests.post,
+                    list_url,
+                    headers=_auth_header(TEST_USER, TEST_PASS),
+                    timeout=5,
+                )
             self.assertIn("SIMDASH", resp.text)
             self.assertRegex(resp.text, r"kWh\.</td>\s*<td class=\"value\">[0-9.]+")
             await sim_task

--- a/tests/test_etron_ws.py
+++ b/tests/test_etron_ws.py
@@ -416,7 +416,7 @@ class EtronWebSocketTests(unittest.TestCase):
                 # Issue Stop from dashboard
                 await asyncio.to_thread(
                     requests.post,
-                    "http://127.0.0.1:18000/ocpp/csms/charger-status",
+                    "http://127.0.0.1:18000/ocpp/csms/active-chargers",
                     data={"charger_id": "stopper", "action": "remote_stop", "do": "send"},
                     timeout=5,
                 )


### PR DESCRIPTION
## Summary
- rename charger_status view to active_chargers
- display only active chargers
- update links and recipes for the new path
- refresh dashboard using render functions
- adjust tests for active_chargers view
- fix syntax error in render_charger_list
- make charger refresh test more robust

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6876d97aeed8832692d991cbd6314b6f