### PR TITLE
Fix duplicate qpig script include

### DIFF
--- a/projects/games/qpig.py
+++ b/projects/games/qpig.py
@@ -6,7 +6,6 @@ def view_qpig_farm(*_, **__):
     gw.debug("view_qpig_farm called")
     html = [
         '<link rel="stylesheet" href="/static/games/qpig/qpig_farm.css">',
-        '<script src="/static/games/qpig/qpig_farm.js"></script>',
         '<h1>Quantum Piggy Farm</h1>',
         '<div class="qpig-garden tab-garden">',
         '<div class="qpig-tabs">',


### PR DESCRIPTION
## Summary
- remove redundant `qpig_farm.js` script tag from the QPig view

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6876f4c5d4d0832685150af5f3c3842f