### PR TITLE
Add standalone OCPP simulator recipe

### DIFF
--- a/recipes/ocpp_simulator.gwr
+++ b/recipes/ocpp_simulator.gwr
@@ -1,0 +1,13 @@
+# file: recipes/ocpp_simulator.gwr
+# Run only the OCPP simulator view
+
+web app setup:
+    - ocpp.evcs --home cp-simulator
+
+help-db build
+
+web:
+ - static collect
+ - server start-app --port 8080 --ws-port 9001
+
+until --done


### PR DESCRIPTION
## Summary
- add a minimal recipe to run the OCPP simulator view

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68794b49feb083269ba8478a7cdea68c