### PR TITLE
Remove CSMS allow/deny lists

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -22,7 +22,8 @@ The simulator can also be controlled via the web UI at
 
 The simulator accepts ``--kwh-min`` and ``--kwh-max`` to control the
 approximate energy delivered per session. For example, ``--kwh-min 40
---kwh-max 70`` will produce sessions around 40–70 kWh.
+--kwh-max 70`` will produce sessions around 40–70 kWh. Use ``--interval``
+to specify how often MeterValues are sent (default 5s).
 
 Open ``/ocpp/csms/active-chargers`` in your browser to view all
 connected chargers. Each card refreshes every few seconds so data

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -25,10 +25,8 @@ _msg_log: Dict[str, list] = {}
     
 def setup_app(*,
     app=None,
-    allowlist=None,
-    denylist=None,
     location=None,
-    authorize="ocpp.rfid.approve",
+    authorize=None,
     email=None,
     auth="disabled",
 ):
@@ -88,8 +86,6 @@ def setup_app(*,
                         payload=payload,
                         charger_id=charger_id,
                         action=action,
-                        allowlist=allowlist,
-                        denylist=denylist,
                     )
                 )
             except Exception as e:

--- a/recipes/etron/cloud.gwr
+++ b/recipes/etron/cloud.gwr
@@ -11,15 +11,9 @@ web app setup:
     - ocpp.data --home charger-summary
 help-db build
 
-# Toggle this version to apply the allow list
+# Basic setup with all transactions allowed
 ocpp csms setup-app:
-    --allow data/etron/rfids.cdv \
-    --authorize ocpp.rfid.approve \
     --location etron_cloud
-
-# Without --allow, all transactions will be allowed by default
-# ocpp csms setup:
-#     --location porsche_centre --deny data/etron/rfids.cdv
 
 web:
  - static collect

--- a/recipes/etron/local.gwr
+++ b/recipes/etron/local.gwr
@@ -13,9 +13,7 @@ web app setup:
     - ocpp.data --home charger-summary
 help-db build
 
-# Toggle this version to apply the allowlist
-# ocpp csms setup-app --allow data/etron/rfids.cdv \
-#     --authorize ocpp.rfid.approve --location porsche_centre
+# Example customized setup with all transactions allowed
 ocpp csms setup-app:
     --location porsche_centre
 

--- a/recipes/static_site.gwr
+++ b/recipes/static_site.gwr
@@ -21,8 +21,7 @@ web:
  - auth config-basic --optional --temp-link
 
 ocpp csms setup-app:
-    --location simulator \
-    --authorize ocpp.rfid.approve
+    --location simulator
 
 web:
  - server start-app --port 8888 --ws-port 9999

--- a/recipes/test/etron/cloud.gwr
+++ b/recipes/test/etron/cloud.gwr
@@ -10,15 +10,9 @@ web app setup:
     - vbox
     - ocpp.data --home charger-summary
    
-# Toggle this version to apply the allow list  
+# Basic setup with all transactions allowed
 ocpp csms setup-app:
-    --allow data/etron/rfids.cdv \
-    --authorize ocpp.rfid.approve \
     --location etron_cloud
-
-# Without --allow, all transactions will be allowed by default
-# ocpp csms setup:
-#     --location porsche_centre --deny data/etron/rfids.cdv
 
 web:
  - static collect

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -24,8 +24,7 @@ web:
  - auth config-basic --optional --temp-link
 
 ocpp csms setup-app:
-    --location simulator \
-    --authorize ocpp.rfid.approve
+    --location simulator
 
 web:
  - server start-app --port 8888 --ws-port 9999

--- a/tests/test_etron_ws.py
+++ b/tests/test_etron_ws.py
@@ -141,7 +141,7 @@ class EtronWebSocketTests(unittest.TestCase):
         asyncio.run(run_ws_check())
 
     def test_authorize_valid_rfid(self):
-        """RFID in allowlist with balance >=1 should be Accepted"""
+        """Known RFID should be accepted."""
         self._set_balance(KNOWN_GOOD_TAG, 100)
         uri = "ws://127.0.0.1:19000/tester1?token=foo"
         async def run_authorize_check():


### PR DESCRIPTION
## Summary
- stop accepting allowlist/denylist in the CSMS setup
- simplify CSMS authorization so it only calls an optional function
- default to allowing all transactions
- update recipes to match new CSMS options
- adjust a test docstring
- EVCS simulator now accepts an `--interval` for meter updates (default 5s)

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68797a19995c8326b61037133d7022d0