### PR TITLE
Disable reload for FastAPI

### DIFF
--- a/projects/web/server.py
+++ b/projects/web/server.py
@@ -159,7 +159,7 @@ def start_app(*,
                 port=port_to_use,
                 log_level="debug" if debug else "info",
                 workers=workers or 1,
-                reload=debug,
+                reload=False,
             )
             return
 


### PR DESCRIPTION
## Summary
- prevent FastAPI from spawning a reload worker in `start_app`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6879b7b6d3d88326b4a92184f34b008f