### PR TITLE
Switch OCPP CSMS to DuckDB state

### DIFF
--- a/projects/sql/sql.py
+++ b/projects/sql/sql.py
@@ -256,7 +256,7 @@ def open_connection(
     # Build cache key (engine, datafile, thread)
     _start_writer_thread()
     base_key = (sql_engine, datafile or "default")
-    thread_key = threading.get_ident() if sql_engine == "sqlite" else "*"
+    thread_key = threading.get_ident() if sql_engine in ("sqlite", "duckdb") else "*"
     key = (base_key, thread_key)
 
     # Reuse cached connection if available


### PR DESCRIPTION
## Summary
- store OCPP CSMS state in `work/ocpp.db` using DuckDB
- add connection tracking helpers in `ocpp.data`
- remove module level state from `csms` and fetch from DB
- ensure sql project caches duckdb connections per-thread

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687a41dfa924832699ad2b3a6c9238c6