### PR TITLE
Add pre-charge delay to OCPP simulator

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -23,7 +23,10 @@ The simulator can also be controlled via the web UI at
 The simulator accepts ``--kwh-min`` and ``--kwh-max`` to control the
 approximate energy delivered per session. For example, ``--kwh-min 40
 --kwh-max 70`` will produce sessions around 40–70 kWh. Use ``--interval``
-to specify how often MeterValues are sent (default 5s).
+to specify how often MeterValues are sent (default 5s). The
+``--pre-charge-delay`` option keeps the charger idle for the given
+number of seconds after connecting while it sends Heartbeats and idle
+MeterValues.
 
 Open ``/ocpp/csms/active-chargers`` in your browser to view all
 connected chargers. Each card refreshes every few seconds so data

--- a/data/static/ocpp/evcs/README.rst
+++ b/data/static/ocpp/evcs/README.rst
@@ -4,4 +4,5 @@ EVCS Simulator
 Mock charge point that connects to the CSMS dashboard.
 Launch it with ``gway ocpp.evcs simulate`` and open
 ``/ocpp/evcs/cp-simulator`` (``gw.ocpp.evcs.view_simulator``)
-to start or stop sessions and view status.
+to start or stop sessions and view status. Use ``--pre-charge-delay`` to
+postpone the start of charging while still exchanging Heartbeats.


### PR DESCRIPTION
## Summary
- extend `gw.ocpp.evcs.simulate` and `simulate_cp` with `pre_charge_delay`
- send heartbeats and idle MeterValues during the delay
- expose delay parameter in the simulator view
- document the new option in OCPP docs
- test that the delay is respected

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687a708f01ec8326b3b8d64d331cf8cb