### PR TITLE
Implement flexible SQL model helper

### DIFF
--- a/data/static/sql/README.rst
+++ b/data/static/sql/README.rst
@@ -39,3 +39,20 @@ The ``recipes/midblog.gwr`` file shows how to combine this view with
 ``web.nav`` and ``web.site`` to create a minimal website.  For a slightly
 more complete example with basic authentication see ``recipes/micro_blog.gwr``.
 
+``gw.sql.model`` returns a proxy object with CRUD helpers for a specific
+table. Pass an existing table name or a definition such as a mapping or
+dataclass and the table will be created automatically::
+
+    from dataclasses import dataclass
+    from gway import gw
+
+    @dataclass
+    class Item:
+        id: int
+        name: str
+        qty: int
+
+    items = gw.sql.model(Item, dbfile='work/shop.sqlite')
+    new_id = items.create(name='apple', qty=5)
+    row = items.read(new_id)
+

--- a/tests/test_sql_model.py
+++ b/tests/test_sql_model.py
@@ -1,0 +1,47 @@
+import unittest
+import os
+from dataclasses import dataclass
+from collections import namedtuple
+from gway import gw
+
+class SqlModelTests(unittest.TestCase):
+    DB = "work/test_model.sqlite"
+
+    def setUp(self):
+        path = gw.resource(self.DB)
+        if os.path.exists(path):
+            os.remove(path)
+
+    def tearDown(self):
+        gw.sql.close_connection(self.DB)
+        path = gw.resource(self.DB)
+        if os.path.exists(path):
+            os.remove(path)
+
+    def test_dataclass_model(self):
+        @dataclass
+        class Note:
+            id: int
+            text: str
+
+        notes = gw.sql.model(Note, dbfile=self.DB)
+        nid = notes.create(text="hi")
+        row = notes.read(nid)
+        self.assertEqual(row[1], "hi")
+
+    def test_mapping_model(self):
+        spec = {"__name__": "things", "id": "INTEGER PRIMARY KEY AUTOINCREMENT", "foo": "TEXT"}
+        things = gw.sql.model(spec, dbfile=self.DB)
+        tid = things.create(foo="bar")
+        row = things.read(tid)
+        self.assertEqual(row[1], "bar")
+
+    def test_namedtuple_model(self):
+        Pet = namedtuple("Pet", "id name")
+        pets = gw.sql.model("pets (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)", dbfile=self.DB)
+        pid = pets.create(name="bob")
+        row = pets.read(pid)
+        self.assertEqual(row[1], "bob")
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `TableProxy` and `model()` helper to `sql` project
- document usage in SQL README
- test models created from dataclasses, mappings and SQL specs

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687a7317a79883268086408e67b98446