### PR TITLE
Fix details link in charger dashboard

### DIFF
--- a/data/static/render.js
+++ b/data/static/render.js
@@ -227,6 +227,7 @@
     let leftClick = getAttr(el, 'click') || getAttr(el, 'left-click');
     if (leftClick && /^re/i.test(leftClick) && !el.dataset.gwLeftClickSetup) {
       el.addEventListener('click', evt => {
+        if (evt.target.closest('a,button,input,textarea,select,label')) return;
         evt.preventDefault();
         refreshFunc(el);
       });
@@ -235,6 +236,7 @@
     let rightClick = getAttr(el, 'right-click');
     if (rightClick && /^re/i.test(rightClick) && !el.dataset.gwRightClickSetup) {
       el.addEventListener('contextmenu', evt => {
+        if (evt.target.closest('a,button,input,textarea,select,label')) return;
         evt.preventDefault();
         refreshFunc(el);
       });
@@ -243,6 +245,7 @@
     let dblClick = getAttr(el, 'double-click');
     if (dblClick && /^re/i.test(dblClick) && !el.dataset.gwDoubleClickSetup) {
       el.addEventListener('dblclick', evt => {
+        if (evt.target.closest('a,button,input,textarea,select,label')) return;
         evt.preventDefault();
         refreshFunc(el);
       });


### PR DESCRIPTION
## Summary
- allow normal link clicks inside auto-refresh containers

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687adc07f6e4832692e5083a36506492