### PR TITLE
Allow links without home in web.app.setup_app

### DIFF
--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -147,7 +147,7 @@ def setup_app(project,
     # Track project for later global static collection
     _enabled.add(project)
 
-    if home is None:
+    if home is None and not (_homes and links):
         setup_home_func = getattr(source, "setup_home", None)
         if callable(setup_home_func):
             try:
@@ -208,6 +208,8 @@ def setup_app(project,
     elif home:
         add_home(home, path, project)
         add_links(f"{path}/{home}", links)
+    elif links and _homes:
+        add_links(_homes[-1][1], links)
 
     if getattr(gw, "timed_enabled", False):
         @app.hook('before_request')
@@ -722,8 +724,9 @@ def add_links(route: str, links=None):
     global _links
     parsed = parse_links(links)
     if parsed:
-        _links[route] = parsed
-        gw.debug(f"Added links for {route}: {parsed}")
+        existing = _links.get(route, [])
+        _links[route] = existing + parsed
+        gw.debug(f"Added links for {route}: {_links[route]}")
 
 def parse_links(links) -> list[object]:
     if not links:

--- a/tests/test_links_without_home.py
+++ b/tests/test_links_without_home.py
@@ -3,14 +3,22 @@ import sys
 from gway import gw
 from paste.fixture import TestApp
 
-class SetupHomeLinksFuncTests(unittest.TestCase):
-    def test_defaults_from_project_functions(self):
+class LinksWithoutHomeTests(unittest.TestCase):
+    def setUp(self):
         gw.results.clear()
         gw.context.clear()
+
+    def tearDown(self):
+        gw.results.clear()
+        gw.context.clear()
+
+    def test_links_append_to_last_home(self):
         app = gw.web.app.setup_app("dummy", app=None)
+        # Add an extra link without specifying home
+        gw.web.app.setup_app("dummy", app=app, links="info")
         mod = sys.modules[gw.web.app.setup_app.__module__]
-        self.assertIn(("Dummy", "dummy/index"), mod._homes)
-        self.assertEqual(mod._links.get("dummy/index"), ["about", "more"])
+        self.assertEqual(mod._homes, [("Dummy", "dummy/index")])
+        self.assertEqual(mod._links.get("dummy/index"), ["about", "more", "info"]) 
         client = TestApp(app)
         resp = client.get("/dummy")
         self.assertEqual(resp.status, 200)


### PR DESCRIPTION
## Summary
- support adding links to last declared home when `home` argument is omitted
- avoid overwriting existing links
- add regression tests for links without home
- keep tests isolated from cached state

## Testing
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_687aedcd922c832689529cdb1a152d94