### PR TITLE
Allow repeated project setup without leftover state

### DIFF
--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -191,6 +191,7 @@ def setup_app(project,
         _homes.clear()
         _links.clear()
         _registered_routes.clear()
+        _enabled.clear()
         if home:
             add_home(home, path, project)
             add_links(f"{path}/{home}", links)

--- a/tests/test_setup_app_repeat.py
+++ b/tests/test_setup_app_repeat.py
@@ -1,0 +1,22 @@
+import unittest
+import sys
+from gway import gw
+from paste.fixture import TestApp
+
+class SetupAppRepeatTests(unittest.TestCase):
+    def test_repeated_project_setup_creates_clean_app(self):
+        app1 = gw.web.app.setup_app("dummy")
+        TestApp(app1).get("/dummy")
+        mod = sys.modules[gw.web.app.setup_app.__module__]
+        self.assertEqual(mod._homes, [("Dummy", "dummy/index")])
+        self.assertEqual(mod._enabled, {"dummy"})
+
+        app2 = gw.web.app.setup_app("dummy")
+        resp = TestApp(app2).get("/dummy")
+        self.assertEqual(resp.status, 200)
+        mod2 = sys.modules[gw.web.app.setup_app.__module__]
+        self.assertEqual(mod2._homes, [("Dummy", "dummy/index")])
+        self.assertEqual(mod2._enabled, {"dummy"})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- reset `_enabled` when creating a fresh Bottle app in `web.app.setup_app`
- ensure repeated calls don't accumulate state with a new test

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687aef8b173c8326961c5cca0b63b00f