### PR TITLE
Add RFID management web UI

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -96,3 +96,11 @@ Two additional views provide more insight into stored data:
 with simple filtering and pagination. ``view_time_series`` returns a
 chart of energy usage over time for selected chargers and dates.
 
+
+RFID Management
+---------------
+
+RFID access entries are stored in ``work/ocpp/rfids.cdv``. Open
+``/ocpp/manage-rfids`` in your browser to edit these records. The page lists
+all tags with their balance and ``allowed`` flag so you can quickly update,
+credit or delete entries and add new ones.

--- a/data/static/ocpp/rfid/manage.css
+++ b/data/static/ocpp/rfid/manage.css
@@ -1,0 +1,24 @@
+/* file: data/static/ocpp/rfid/manage.css */
+
+.rfid-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 0.94em;
+}
+.rfid-table th,
+.rfid-table td {
+    border: 1px solid #bbb;
+    padding: 4px 6px;
+}
+.rfid-table td {
+    vertical-align: top;
+}
+.rfid-table input[type="text"],
+.rfid-table input[type="number"],
+.rfid-table select {
+    width: 100%;
+    box-sizing: border-box;
+}
+.rfid-row button {
+    margin-right: 4px;
+}


### PR DESCRIPTION
## Summary
- implement single page interface to manage RFID entries
- add minimal styling for RFID table
- document new `/ocpp/manage-rfids` page

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687af08d673083268407af6f35544fdc