### PR TITLE
Add footer links option to setup_app

### DIFF
--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -5,7 +5,7 @@ web app setup:
     - web.site --home reader
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.nav --home style-switcher
-    - web.cookies --home cookie-jar
+    - web.cookies --footer cookie-jar
 help-db build
 
 web:

--- a/recipes/static_site.gwr
+++ b/recipes/static_site.gwr
@@ -2,9 +2,9 @@
 # Demo website using per-view static assets instead of bundled CSS/JS
 
 web app setup-app --mode manual:
-    - web.site --home reader --links feedback
+    - web.site --home reader --footer feedback
     - web.nav --home style-switcher
-    - web.cookies --home cookie-jar
+    - web.cookies --footer cookie-jar
     - web.message
     - awg --home awg-calculator
     - vbox --home uploads

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -4,10 +4,10 @@
 # Lines without a starting command repeat the previous with new params
 
 web app setup:
-    - web.site --home reader --links feedback
+    - web.site --home reader --footer feedback
     - awg --home awg-calculator
     - web.nav --home style-switcher
-    - web.cookies --home cookie-jar
+    - web.cookies --footer cookie-jar
     - web.message
     - web.chat
     - vbox --home uploads

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -4,9 +4,9 @@
 # Lines without a starting command repeat the previous with new params
 
 web app setup:
-    - web.site --home reader --links feedback 
+    - web.site --home reader --footer feedback
     - web.nav --home style-switcher
-    - web.cookies --home cookie-jar
+    - web.cookies --footer cookie-jar
     - web.message
     - awg --home awg-calculator
     - vbox --home uploads

--- a/tests/test_footer_links.py
+++ b/tests/test_footer_links.py
@@ -1,0 +1,27 @@
+import unittest
+import sys
+from gway import gw
+from paste.fixture import TestApp
+
+class FooterLinksTests(unittest.TestCase):
+    def setUp(self):
+        gw.results.clear()
+        gw.context.clear()
+
+    def tearDown(self):
+        gw.results.clear()
+        gw.context.clear()
+
+    def test_footer_links_render(self):
+        app = gw.web.app.setup_app("dummy", footer="info")
+        mod = sys.modules[gw.web.app.setup_app.__module__]
+        self.assertEqual(mod._footer_links.get("dummy/index"), ["info"])
+        client = TestApp(app)
+        resp = client.get("/dummy")
+        self.assertEqual(resp.status, 200)
+        body = resp.body.decode()
+        self.assertIn('<p class="footer-links">', body)
+        self.assertIn('/dummy/info', body)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `web.app.setup_app` to register footer links
- render footer links in `render_template`
- test footer links
- move cookie jar and feedback links to footer in demo recipes

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687af1ee7a208326816b5c6ae53d81c4