### PR TITLE
Fix dbfile detection for ocpp sql models

### DIFF
--- a/projects/ocpp/data.py
+++ b/projects/ocpp/data.py
@@ -54,7 +54,10 @@ CONNECTIONS = """connections(
 
 def open_db():
     """Return connection to the OCPP database, initializing tables."""
-    conn = gw.sql.open_connection(DBFILE, sql_engine=ENGINE)
+    if getattr(gw.sql, "_last_datafile", None) is None:
+        conn = gw.sql.open_connection(DBFILE, sql_engine=ENGINE)
+    else:
+        conn = gw.sql.open_connection()
     if not getattr(open_db, "_init", False):
         _init_db(conn)
         setattr(open_db, "_init", True)

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -254,6 +254,14 @@ class SqlTests(unittest.TestCase):
 
         os.remove(log_path)
 
+    def test_open_connection_persists_params(self):
+        """open_connection() without args reuses last params."""
+        gw.sql.close_connection(all=True)
+        c1 = gw.sql.open_connection("work/persist.sqlite")
+        c2 = gw.sql.open_connection()
+        self.assertIs(c1, c2)
+        gw.sql.close_connection("work/persist.sqlite")
+
     def test_parse_log_default_mask(self):
         """Default mask parses standard GWay log lines."""
         log_path = gw.resource("work/test_gw.log")


### PR DESCRIPTION
## Summary
- adjust `open_connection` to keep last-used params when called without them
- let OCPP data helpers rely on `open_connection` defaults
- test connection persistence

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687b064dbd1883269180966376cc2031