### PR TITLE
Fix website search command crash

### DIFF
--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -232,6 +232,23 @@ def view_help(topic="", *args, **kwargs):
                         + res_html + "</div>"
                     )
                 return "<div class='cli-result'>" + "<hr>".join(html_parts) + "</div>"
+            except SystemExit as ex:
+                if gw.debug_enabled:
+                    tb = traceback.format_exc()
+                    log_tail = ""
+                    try:
+                        log_path = gw.resource("logs", "gway.log")
+                        with open(log_path) as lf:
+                            log_tail = "".join(lf.readlines()[-20:])
+                    except Exception:
+                        log_tail = "(unable to read log)"
+                    return (
+                        "<h2>Command Error</h2>"
+                        f"<pre>{html.escape(str(ex))}</pre>"
+                        f"<pre>{html.escape(tb)}</pre>"
+                        f"<pre>{html.escape(log_tail)}</pre>"
+                    )
+                return f"<pre>{html.escape(str(ex))}</pre>"
             except Exception as ex:
                 if gw.debug_enabled:
                     tb = traceback.format_exc()

--- a/tests/test_view_help_command.py
+++ b/tests/test_view_help_command.py
@@ -1,0 +1,19 @@
+import unittest
+from gway import gw
+from paste.fixture import TestApp
+from unittest.mock import patch
+
+class ViewHelpCommandTests(unittest.TestCase):
+    def setUp(self):
+        self.app = gw.web.app.setup_app("web.site")
+        self.client = TestApp(self.app)
+
+    def test_invalid_command_returns_error(self):
+        with patch.object(gw.web.server, "is_local", return_value=True):
+            resp = self.client.get("/web/site/help", {"topic": ">unknown"})
+            self.assertEqual(resp.status, 200)
+            body = resp.body.decode()
+            self.assertIn("<pre>", body)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- catch `SystemExit` from console errors in `view_help`
- test invalid command via the web search bar

## Testing
- `gway test --filter help_command`

------
https://chatgpt.com/codex/tasks/task_e_687bc9fb5054832694f31c71201326b6