### PR TITLE
Refactor SQL open_db setup

### DIFF
--- a/data/static/sql/README.rst
+++ b/data/static/sql/README.rst
@@ -3,7 +3,7 @@ SQL CRUD Helpers
 
 The ``sql.crud`` project offers basic APIs for creating, reading,
 updating and deleting records in any SQLite table. All functions use
-``gw.sql.open_connection`` internally, so you can simply pass a
+``gw.sql.open_db`` internally, so you can simply pass a
 ``--dbfile`` parameter (defaulting to ``work/data.sqlite``).
 
 Schema changes are staged in memory until ``gw.sql.migrate`` is called.

--- a/gway/builtins/help_utils.py
+++ b/gway/builtins/help_utils.py
@@ -45,7 +45,7 @@ def help(*args, full: bool = False, list_flags: bool = False):
     joined_args = " ".join(args).strip().replace("-", "_")
     norm_args = [a.replace("-", "_").replace("/", ".") for a in args]
 
-    with gw.sql.open_connection(db_path, row_factory=True) as cur:
+    with gw.sql.open_db(db_path, row_factory=True) as cur:
         if not args:
             cur.execute("SELECT DISTINCT project FROM help")
             return {"Available Projects": sorted([row["project"] for row in cur.fetchall()])}

--- a/projects/awg.py
+++ b/projects/awg.py
@@ -81,7 +81,7 @@ def find_awg(
 
     def _calc(*, force_awg=None, limit_awg=None):
         local_conduit = conduit
-        with gw.sql.open_connection(autoload=True) as cursor:
+        with gw.sql.open_db(autoload=True) as cursor:
             sql = (
                 "SELECT awg_size, line_num, k_ohm_km, amps_60c, amps_75c, amps_90c "
                 "FROM awg_cable_size "
@@ -215,7 +215,7 @@ def find_awg(
 
 def find_conduit(awg, cables, *, conduit="emt"):
     """Calculate the kind of conduit required for a set of cables."""
-    with gw.sql.open_connection(autoload=True) as cursor:
+    with gw.sql.open_db(autoload=True) as cursor:
 
         assert conduit in ("emt", "imc", "rmc", "fmc"), "Allowed: emt, imc, rmc, fmc."
         assert 1 <= cables <= 30, "Valid for 1-30 cables per conduit."

--- a/projects/help_db.py
+++ b/projects/help_db.py
@@ -14,7 +14,7 @@ def build(*, update: bool = False):
         gw.info("Help database already exists; skipping build.")
         return db_path
 
-    with gw.sql.open_connection(datafile="data/help.sqlite") as cursor:
+    with gw.sql.open_db(datafile="data/help.sqlite") as cursor:
         cursor.execute("DROP TABLE IF EXISTS help")
         cursor.execute(
             """

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -997,7 +997,7 @@ def purge(*, database: bool = False, logs: bool = False):
     gw.info("[OCPP] In-memory state purged.")
 
     if database:
-        conn = gw.ocpp.data.open_db()
+        conn = gw.sql.open_db(project="ocpp")
         gw.sql.execute("DELETE FROM transactions", connection=conn)
         gw.sql.execute("DELETE FROM meter_values", connection=conn)
         gw.sql.execute("DELETE FROM errors", connection=conn)

--- a/projects/web/chat/actions.py
+++ b/projects/web/chat/actions.py
@@ -12,7 +12,7 @@ _db_conn = None
 def _open_db():
     global _db_conn
     if _db_conn is None:
-        _db_conn = gw.sql.open_connection("work/chatlog.sqlite")
+        _db_conn = gw.sql.open_db("work/chatlog.sqlite")
         _init_db(_db_conn)
     return _db_conn
 

--- a/recipes/crud_site.gwr
+++ b/recipes/crud_site.gwr
@@ -2,8 +2,8 @@
 # Minimal website using sql.crud to manage a table
 
 # Ensure the posts table exists
-sql open-connection --datafile work/blog.sqlite
-sql execute "CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, body TEXT)" --connection [sql.open_connection]
+sql open-db --datafile work/blog.sqlite
+sql execute "CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, body TEXT)" --connection [sql.open_db]
 
 web app setup:
     --project web.nav --home style-switcher

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -27,7 +27,7 @@ class SqlTests(unittest.TestCase):
 
     def setUp(self):
         # Each test gets a fresh database connection
-        self.conn = gw.sql.open_connection(TEMP_DB)
+        self.conn = gw.sql.open_db(TEMP_DB)
 
     def tearDown(self):
         # Close thread's own connection
@@ -64,7 +64,7 @@ class SqlTests(unittest.TestCase):
         results = []
 
         def read_db():
-            c = gw.sql.open_connection(TEMP_DB)
+            c = gw.sql.open_db(TEMP_DB)
             out = gw.sql.execute("SELECT sum(x) FROM readers", connection=c)
             results.append(out[0][0])
             gw.sql.close_connection(TEMP_DB)
@@ -82,7 +82,7 @@ class SqlTests(unittest.TestCase):
         )
 
         def write_db(val):
-            c = gw.sql.open_connection(TEMP_DB)
+            c = gw.sql.open_db(TEMP_DB)
             gw.sql.execute(
                 "INSERT INTO writers (y) VALUES (?)",
                 connection=c, args=(val,)
@@ -179,7 +179,7 @@ class SqlTests(unittest.TestCase):
     def test_row_factory(self):
         """Can get dict-like rows using row_factory option."""
         gw.sql.close_connection(all=True)  # Ensure fresh conn
-        conn = gw.sql.open_connection(TEMP_DB, row_factory=True)
+        conn = gw.sql.open_db(TEMP_DB, row_factory=True)
         gw.sql.execute(
             "CREATE TABLE rf (k INT, v TEXT)",
             connection=conn
@@ -206,11 +206,11 @@ class SqlTests(unittest.TestCase):
 
     def test_close_all_connections(self):
         """close_connection(all=True) closes all and stops writer."""
-        c1 = gw.sql.open_connection(TEMP_DB)
-        c2 = gw.sql.open_connection(TEMP_DB)
+        c1 = gw.sql.open_db(TEMP_DB)
+        c2 = gw.sql.open_db(TEMP_DB)
         gw.sql.close_connection(all=True)
         # New connection after all closed should work
-        c3 = gw.sql.open_connection(TEMP_DB)
+        c3 = gw.sql.open_db(TEMP_DB)
         gw.sql.execute("CREATE TABLE foo (id INT)", connection=c3)
         gw.sql.close_connection(TEMP_DB)
 
@@ -254,11 +254,11 @@ class SqlTests(unittest.TestCase):
 
         os.remove(log_path)
 
-    def test_open_connection_persists_params(self):
-        """open_connection() without args reuses last params."""
+    def test_open_db_persists_params(self):
+        """open_db() without args reuses last params."""
         gw.sql.close_connection(all=True)
-        c1 = gw.sql.open_connection("work/persist.sqlite")
-        c2 = gw.sql.open_connection()
+        c1 = gw.sql.open_db("work/persist.sqlite")
+        c2 = gw.sql.open_db()
         self.assertIs(c1, c2)
         gw.sql.close_connection("work/persist.sqlite")
 

--- a/tests/test_sql_crud.py
+++ b/tests/test_sql_crud.py
@@ -12,7 +12,7 @@ class SqlCrudTests(unittest.TestCase):
         path = gw.resource(self.DB)
         if os.path.exists(path):
             os.remove(path)
-        with gw.sql.open_connection(self.DB) as cur:
+        with gw.sql.open_db(self.DB) as cur:
             cur.execute('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, qty INT)')
 
     def tearDown(self):
@@ -39,7 +39,7 @@ class SqlCrudTests(unittest.TestCase):
         gw.sql.setup_table('extras', 'name', 'TEXT', dbfile=self.DB)
         gw.sql.setup_table('extras', 'qty', 'INT', dbfile=self.DB)
         gw.sql.migrate(dbfile=self.DB)
-        with gw.sql.open_connection(self.DB) as cur:
+        with gw.sql.open_db(self.DB) as cur:
             cur.execute('PRAGMA table_info(extras)')
             cols = {r[1] for r in cur.fetchall()}
         self.assertEqual({'id', 'name', 'qty'}, cols)


### PR DESCRIPTION
## Summary
- remove ocpp.data open_db helper and rely on gw.sql.open_db
- add project-based open_db in sql module with backwards-compatible alias
- update helpers, docs, and recipes to use open_db
- adjust tests for new open_db API

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: TimeoutError for web server related tests)*

------
https://chatgpt.com/codex/tasks/task_e_687bc3debe6c83269b06493a2235c3a6