### PR TITLE
Add project parameter for SQL models

### DIFF
--- a/data/static/sql/README.rst
+++ b/data/static/sql/README.rst
@@ -4,7 +4,10 @@ SQL CRUD Helpers
 The ``sql.crud`` project offers basic APIs for creating, reading,
 updating and deleting records in any SQLite table. All functions use
 ``gw.sql.open_db`` internally, so you can simply pass a
-``--dbfile`` parameter (defaulting to ``work/data.sqlite``).
+``--dbfile`` parameter (defaulting to ``work/data.sqlite``). If you
+pass a ``project`` name to :func:`gw.sql.open_db`, you can reuse that
+configuration by supplying the same ``project`` argument to the CRUD
+helpers.
 
 Schema changes are staged in memory until ``gw.sql.migrate`` is called.
 
@@ -41,7 +44,9 @@ more complete example with basic authentication see ``recipes/micro_blog.gwr``.
 
 ``gw.sql.model`` returns a proxy object with CRUD helpers for a specific
 table. Pass an existing table name or a definition such as a mapping or
-dataclass and the table will be created automatically::
+dataclass and the table will be created automatically. The helper also
+accepts a ``project`` name which is passed through to
+``gw.sql.open_db``::
 
     from dataclasses import dataclass
     from gway import gw
@@ -52,13 +57,13 @@ dataclass and the table will be created automatically::
         name: str
         qty: int
 
-    items = gw.sql.model(Item, dbfile='work/shop.sqlite')
+    items = gw.sql.model(Item, dbfile='work/shop.sqlite', project='shop')
     new_id = items.create(name='apple', qty=5)
     row = items.read(new_id)
 
 You can also target other engines such as DuckDB::
 
-    items = gw.sql.model(Item, dbfile='work/shop.duckdb', sql_engine='duckdb')
+    items = gw.sql.model(Item, dbfile='work/shop.duckdb', sql_engine='duckdb', project='shop')
 
 When using ``gw.sql.model`` in your own modules, define your table
 specifications as uppercase constants and call ``gw.sql.model`` inside the

--- a/projects/ocpp/data.py
+++ b/projects/ocpp/data.py
@@ -126,7 +126,7 @@ def record_transaction_start(
     meter_start: Optional[float] = None,
     charger_timestamp: Optional[int] = None,
 ):
-    gw.sql.model(TRANSACTIONS).create(
+    gw.sql.model(TRANSACTIONS, project="ocpp").create(
         charger_id=charger_id,
         transaction_id=transaction_id,
         start_time=int(start_time),
@@ -161,7 +161,7 @@ def record_transaction_stop(
     record_last_msg(charger_id, stop_time)
 
 def record_meter_value(charger_id: str, transaction_id: int, timestamp: int, measurand: str, value: float, unit: str = "", context: str = ""):
-    gw.sql.model(METER_VALUES).create(
+    gw.sql.model(METER_VALUES, project="ocpp").create(
         charger_id=charger_id,
         transaction_id=transaction_id,
         timestamp=int(timestamp),
@@ -174,7 +174,7 @@ def record_meter_value(charger_id: str, transaction_id: int, timestamp: int, mea
 
 def record_error(charger_id: str, status: str, error_code: str = "", info: str = ""):
     ts = int(time.time())
-    gw.sql.model(ERRORS).create(
+    gw.sql.model(ERRORS, project="ocpp").create(
         charger_id=charger_id,
         status=status,
         error_code=error_code,
@@ -185,19 +185,19 @@ def record_error(charger_id: str, status: str, error_code: str = "", info: str =
 
 def set_connection_status(charger_id: str, connected: bool):
     """Mark charger connection as active or inactive."""
-    gw.sql.model(CONNECTIONS).delete(charger_id, id_col="charger_id")
-    gw.sql.model(CONNECTIONS).create(
+    gw.sql.model(CONNECTIONS, project="ocpp").delete(charger_id, id_col="charger_id")
+    gw.sql.model(CONNECTIONS, project="ocpp").create(
         charger_id=charger_id, connected=1 if connected else 0
     )
 
 def record_heartbeat(charger_id: str, timestamp: str):
-    gw.sql.model(CONNECTIONS).update(
+    gw.sql.model(CONNECTIONS, project="ocpp").update(
         charger_id, id_col="charger_id", last_heartbeat=timestamp
     )
     record_last_msg(charger_id)
 
 def update_status(charger_id: str, status: str = None, error_code: str = None, info: str = None):
-    gw.sql.model(CONNECTIONS).update(
+    gw.sql.model(CONNECTIONS, project="ocpp").update(
         charger_id,
         id_col="charger_id",
         status=status,
@@ -206,7 +206,7 @@ def update_status(charger_id: str, status: str = None, error_code: str = None, i
     )
 
 def clear_status(charger_id: str):
-    gw.sql.model(CONNECTIONS).update(
+    gw.sql.model(CONNECTIONS, project="ocpp").update(
         charger_id,
         id_col="charger_id",
         status=None,


### PR DESCRIPTION
## Summary
- support specifying project for TableProxy so CRUD helpers share configuration
- allow passing project through sql.crud helpers
- initialize ocpp database models with project="ocpp"
- document the new option in SQL README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: Port 18888 not responding after 15 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_687bd6fb44b483269e1a5f2166f4a4b8