### PR TITLE
Handle duckdb writes without thread queue

### DIFF
--- a/tests/test_duckdb_concurrency.py
+++ b/tests/test_duckdb_concurrency.py
@@ -1,0 +1,53 @@
+import unittest
+import os
+import threading
+from gway import gw
+
+TEMP_DB = "work/test_duck_concurrent.duckdb"
+
+class DuckDBConcurrencyTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        path = gw.resource(TEMP_DB)
+        if os.path.exists(path):
+            os.remove(path)
+
+    @classmethod
+    def tearDownClass(cls):
+        path = gw.resource(TEMP_DB)
+        if os.path.exists(path):
+            os.remove(path)
+        gw.sql.close_connection(all=True)
+
+    def setUp(self):
+        self.conn = gw.sql.open_db(TEMP_DB, sql_engine="duckdb", project="ducktest")
+
+    def tearDown(self):
+        gw.sql.close_connection(TEMP_DB, sql_engine="duckdb", project="ducktest")
+
+    def test_concurrent_writes(self):
+        gw.sql.execute(
+            "CREATE TABLE items (id INTEGER, val INTEGER)",
+            connection=self.conn,
+        )
+
+        def write_db(val):
+            c = gw.sql.open_db(TEMP_DB, sql_engine="duckdb", project="ducktest")
+            gw.sql.execute(
+                "INSERT INTO items VALUES (?, ?)",
+                connection=c,
+                args=(val, val),
+            )
+            gw.sql.close_connection(TEMP_DB, sql_engine="duckdb", project="ducktest")
+
+        threads = [threading.Thread(target=write_db, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        rows = gw.sql.execute("SELECT count(*) FROM items", connection=self.conn)
+        self.assertEqual(rows[0][0], 10)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- detect DuckDB engine when opening DB and skip writer thread
- track engine on connections
- execute DuckDB writes synchronously rather than through the writer queue
- add regression test for concurrent writes on DuckDB

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: Port 18888 not responding after 15 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_687bd7256cc88326ae3a487d1fd74c70