### PR TITLE
Update OCPP README database info

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -70,9 +70,10 @@ OCPP Data Storage
 -----------------
 
 ``ocpp.data`` provides helper functions to persist transactions, meter
-values and error reports in ``work/ocpp.sqlite`` using ``gw.sql``.  The
-``csms`` module calls these helpers so charging sessions are recorded
-automatically.
+values and error reports in ``work/ocpp.db`` using ``gw.sql``. By
+default these helpers rely on the DuckDB engine so the ``duckdb``
+package must be available. The ``csms`` module calls these helpers so
+charging sessions are recorded automatically.
 
 For comparison with real EVCS logs, every completed transaction is also
 written as a ``.dat`` file under ``work/ocpp/records/<charger_id>/``.


### PR DESCRIPTION
## Summary
- document DuckDB dependency for OCPP
- switch path references to `work/ocpp.db`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: Port 18888 not responding)*

------
https://chatgpt.com/codex/tasks/task_e_687be0c4eca48326996d71944c1c02b2