### PR TITLE
Improve SQLite connect error reporting

### DIFF
--- a/projects/sql/sql.py
+++ b/projects/sql/sql.py
@@ -292,7 +292,13 @@ def open_db(
     if sql_engine == "sqlite":
         path = gw.resource(datafile or "work/data.sqlite")
         # Note: check_same_thread=False for sharing connections in the writer thread
-        conn = sqlite3.connect(path, check_same_thread=False)
+        try:
+            conn = sqlite3.connect(path, check_same_thread=False)
+        except sqlite3.OperationalError as e:
+            gw.abort(
+                f"Unable to open SQLite database at {path}. "
+                f"Check the path and file permissions. ({e})"
+            )
         if row_factory:
             if row_factory is True:
                 conn.row_factory = sqlite3.Row

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -204,6 +204,18 @@ class SqlTests(unittest.TestCase):
         rows = gw.sql.execute("SELECT count(*) FROM errtest", connection=self.conn)
         self.assertEqual(rows[0][0], 0)
 
+    def test_open_db_invalid_path_message(self):
+        """open_db aborts with helpful message on invalid path."""
+        bad_dir = "work/bad_db"
+        full = gw.resource(bad_dir, dir=True)
+        from unittest.mock import patch
+        with patch.object(gw, "abort", side_effect=SystemExit(13)) as abort_fn:
+            with self.assertRaises(SystemExit):
+                gw.sql.open_db(bad_dir)
+        abort_msg = abort_fn.call_args[0][0]
+        self.assertIn(str(full), abort_msg)
+        self.assertIn("permission", abort_msg.lower())
+
     def test_close_all_connections(self):
         """close_connection(all=True) closes all and stops writer."""
         c1 = gw.sql.open_db(TEMP_DB)


### PR DESCRIPTION
## Summary
- wrap sqlite3.connect in a try/except and abort on failure
- test that open_db aborts with a helpful message when path is invalid

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: Port 18888 not responding)*

------
https://chatgpt.com/codex/tasks/task_e_687be0d1afa0832680bbfef25e6d5c82