### PR TITLE
Enhance help docs with type info

### DIFF
--- a/data/static/styles/base.css
+++ b/data/static/styles/base.css
@@ -382,6 +382,20 @@ p.compass { margin-bottom: 0.5em; }
     padding: 1.05em 1.25em 0.7em 1.25em;
     transition: box-shadow 0.15s;
 }
+.help-entry table.param-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 0.8em;
+}
+.help-entry table.param-table th,
+.help-entry table.param-table td {
+    border: 1px solid #e2e6ee;
+    padding: 0.2em 0.4em;
+    text-align: left;
+}
+.help-entry table.param-table th {
+    background: var(--card-bg, #f0f0f0);
+}
 .help-entry:hover {
     box-shadow: 0 4px 14px 1px rgba(38,60,140,0.13);
 }

--- a/data/static/styles/radio-darker.css
+++ b/data/static/styles/radio-darker.css
@@ -237,6 +237,20 @@ footer::after {
     color: #fff81a;
     border-bottom: 1.8px solid #fff81a;
 }
+.help-entry table.param-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 0.6em;
+}
+.help-entry table.param-table th,
+.help-entry table.param-table td {
+    border: 1px solid #2b3e29;
+    padding: 2px 4px;
+    text-align: left;
+}
+.help-entry table.param-table th {
+    background: #0a140e;
+}
 
 aside img[src*="qr"] {
     border-radius: 7px;

--- a/projects/help_db.py
+++ b/projects/help_db.py
@@ -3,6 +3,7 @@
 
 import os
 from gway import gw
+import re
 
 
 def build(*, update: bool = False):
@@ -16,11 +17,23 @@ def build(*, update: bool = False):
 
     with gw.sql.open_db(datafile="data/help.sqlite") as cursor:
         cursor.execute("DROP TABLE IF EXISTS help")
+        cursor.execute("DROP TABLE IF EXISTS param_types")
+        cursor.execute("DROP TABLE IF EXISTS return_types")
+        cursor.execute("DROP TABLE IF EXISTS providers")
         cursor.execute(
             """
             CREATE VIRTUAL TABLE help USING fts5(
                 project, function, signature, docstring, source, todos, tokenize='porter')
             """
+        )
+        cursor.execute(
+            """CREATE TABLE param_types (project TEXT, function TEXT, name TEXT, type TEXT)"""
+        )
+        cursor.execute(
+            """CREATE TABLE return_types (project TEXT, function TEXT, type TEXT)"""
+        )
+        cursor.execute(
+            """CREATE TABLE providers (type TEXT, project TEXT, function TEXT)"""
         )
 
         for dotted_path in _walk_projects("projects"):
@@ -35,6 +48,7 @@ def build(*, update: bool = False):
                     raw_func = getattr(func, "__wrapped__", func)
                     doc = inspect.getdoc(raw_func) or ""
                     sig = str(inspect.signature(raw_func))
+                    param_types, return_type, provides = _parse_doc(doc)
                     try:
                         source = "".join(inspect.getsourcelines(raw_func)[0])
                     except OSError:
@@ -44,6 +58,24 @@ def build(*, update: bool = False):
                         "INSERT INTO help VALUES (?, ?, ?, ?, ?, ?)",
                         (dotted_path, fname, sig, doc, source, "\n".join(todos)),
                     )
+                    for p, t in param_types.items():
+                        cursor.execute(
+                            "INSERT INTO param_types VALUES (?, ?, ?, ?)",
+                            (dotted_path, fname, p, t),
+                        )
+                    if return_type:
+                        cursor.execute(
+                            "INSERT INTO return_types VALUES (?, ?, ?)",
+                            (dotted_path, fname, return_type),
+                        )
+                    provider_type = provides or (
+                        return_type if return_type and not _is_builtin_type(return_type) else None
+                    )
+                    if provider_type:
+                        cursor.execute(
+                            "INSERT INTO providers VALUES (?, ?, ?)",
+                            (provider_type, dotted_path, fname),
+                        )
             except Exception as e:
                 gw.warning(f"Skipping project {dotted_path}: {e}")
 
@@ -51,6 +83,7 @@ def build(*, update: bool = False):
             raw_func = getattr(func, "__wrapped__", func)
             doc = inspect.getdoc(raw_func) or ""
             sig = str(inspect.signature(raw_func))
+            param_types, return_type, provides = _parse_doc(doc)
             try:
                 source = "".join(inspect.getsourcelines(raw_func)[0])
             except OSError:
@@ -60,8 +93,27 @@ def build(*, update: bool = False):
                 "INSERT INTO help VALUES (?, ?, ?, ?, ?, ?)",
                 ("builtin", name, sig, doc, source, "\n".join(todos)),
             )
+            for p, t in param_types.items():
+                cursor.execute(
+                    "INSERT INTO param_types VALUES (?, ?, ?, ?)",
+                    ("builtin", name, p, t),
+                )
+            if return_type:
+                cursor.execute(
+                    "INSERT INTO return_types VALUES (?, ?, ?)",
+                    ("builtin", name, return_type),
+                )
+            provider_type = provides or (
+                return_type if return_type and not _is_builtin_type(return_type) else None
+            )
+            if provider_type:
+                cursor.execute(
+                    "INSERT INTO providers VALUES (?, ?, ?)",
+                    (provider_type, "builtin", name),
+                )
 
         cursor.execute("COMMIT")
+    gw.sql.close_connection(all=True)
     gw.info(f"Help database built at {db_path}")
     return db_path
 
@@ -94,3 +146,38 @@ def _extract_todos(source: str):
     if current:
         todos.append("\n".join(current))
     return todos
+
+
+_BUILTIN_TYPES = {
+    "int",
+    "float",
+    "str",
+    "bool",
+    "list",
+    "tuple",
+    "dict",
+    "set",
+    "None",
+}
+
+
+def _is_builtin_type(t: str) -> bool:
+    return t in _BUILTIN_TYPES
+
+
+def _parse_doc(doc: str):
+    """Return (param_types, return_type, provides) parsed from docstring."""
+    param_types = {}
+    return_type = None
+    provides = None
+    for line in doc.splitlines():
+        m = re.match(r"\s*:type\s+(\w+)\s*:\s*(.+)", line)
+        if m:
+            param_types[m.group(1)] = m.group(2).strip()
+        m = re.match(r"\s*:rtype:\s*(.+)", line)
+        if m:
+            return_type = m.group(1).strip()
+        m = re.match(r"\s*:provides:\s*(.+)", line)
+        if m:
+            provides = m.group(1).strip()
+    return param_types, return_type, provides

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -197,6 +197,7 @@ def setup_app(project,
         _footer_links.clear()
         _registered_routes.clear()
         _enabled.clear()
+        _enabled.add(project)
         if home:
             add_home(home, path, project)
             add_links(f"{path}/{home}", links)

--- a/projects/web/auto.py
+++ b/projects/web/auto.py
@@ -15,7 +15,16 @@ DEFAULT_BROWSER = "chrome"
 
 
 def get_driver(*, browser: str = DEFAULT_BROWSER, headless: bool = True):
-    """Return a Selenium WebDriver instance for the selected browser."""
+    """Return a Selenium WebDriver instance.
+
+    :param browser: Browser backend to use (``"chrome"`` or ``"firefox"``).
+    :type browser: str
+    :param headless: Launch the browser without a visible window.
+    :type headless: bool
+    :returns: Configured Selenium WebDriver.
+    :rtype: selenium.webdriver.Remote
+    :provides: selenium.webdriver.Remote
+    """
     browser = browser.lower()
     if browser == "chrome":
         options = ChromeOptions()
@@ -48,7 +57,21 @@ def browse(
     driver=None,
     close: bool = False,
 ):
-    """Yield a cached WebDriver instance, creating a new one if needed."""
+    """Context manager that yields a cached WebDriver.
+
+    :param url: Optional URL to open before yielding the driver.
+    :type url: str | None
+    :param browser: Browser backend to use.
+    :type browser: str
+    :param headless: Whether to run in headless mode.
+    :type headless: bool
+    :param driver: Existing driver object or sequence containing one.
+    :type driver: selenium.webdriver.Remote | iterable | None
+    :param close: If ``True`` the provided driver is closed and ``None`` yielded.
+    :type close: bool
+    :returns: Active WebDriver instance.
+    :rtype: selenium.webdriver.Remote
+    """
     global _active_driver, _active_config
 
     # Try to unwrap an existing driver from the given object (tuple/list etc)
@@ -120,7 +143,21 @@ def capture_page_source(
     wait: float = 2.0,
     screenshot: str | None = None,
 ) -> str:
-    """Return page source for ``url``. Optionally save a screenshot."""
+    """Return page source for ``url``.
+
+    :param url: Page URL to fetch.
+    :type url: str
+    :param browser_name: Browser backend to use.
+    :type browser_name: str
+    :param headless: Whether to run in headless mode.
+    :type headless: bool
+    :param wait: Seconds to wait after navigation.
+    :type wait: float
+    :param screenshot: Optional path for a screenshot of the page.
+    :type screenshot: str | None
+    :returns: HTML source of the page.
+    :rtype: str
+    """
     import time
 
     with browse(url=url, browser=browser_name, headless=headless) as drv:

--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -425,6 +425,25 @@ def _render_help_section(info, use_query_links=False, highlight=False, *args, **
         elif key in ("Signature", "Example CLI", "Example Code", "Sample CLI"):
             value = f"<pre><code class='python'>{html.escape(str(value))}</code></pre>"
 
+        elif key == "Parameters" and isinstance(value, list):
+            rows_html = []
+            for p in value:
+                builder = p.get("builder")
+                if builder and use_query_links:
+                    builder = f'<a href="?topic={builder}">{html.escape(builder)}</a>'
+                elif builder:
+                    builder = html.escape(builder)
+                else:
+                    builder = ""
+                rows_html.append(
+                    f"<tr><td>{html.escape(p['name'])}</td><td>{html.escape(p.get('type',''))}</td><td>{builder}</td></tr>"
+                )
+            value = (
+                "<table class='param-table'><tr><th>Name</th><th>Type</th><th>Builder</th></tr>"
+                + "".join(rows_html)
+                + "</table>"
+            )
+
         elif key in ("Docstring", "TODOs"):
             value = f"<div class='doc'>{html.escape(str(value))}</div>"
 

--- a/tests/test_help_params.py
+++ b/tests/test_help_params.py
@@ -1,0 +1,28 @@
+import unittest
+from gway import gw
+
+
+class HelpParamTests(unittest.TestCase):
+    def test_help_parameters_and_providers(self):
+        gw.help_db.build(update=True)
+        gw.sql.close_connection(all=True)
+        mod = __import__(gw.web.app.setup_app.__module__)
+        saved_enabled = getattr(mod, "_enabled", set()).copy()
+        saved_homes = getattr(mod, "_homes", []).copy()
+        info = gw.help("web.auto", "get-driver")
+        # Restore state altered by loading projects
+        if hasattr(mod, "_enabled"):
+            mod._enabled = saved_enabled
+        if hasattr(mod, "_homes"):
+            mod._homes = saved_homes
+        self.assertIn("Parameters", info)
+        params = {p["name"]: p for p in info["Parameters"]}
+        self.assertIn("browser", params)
+        self.assertEqual(params["browser"]["type"], "str")
+        self.assertEqual(info.get("Returns"), "selenium.webdriver.Remote")
+        self.assertEqual(info.get("Provides"), "selenium.webdriver.Remote")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- parse parameter/return types when building help database
- expose that information in `gw.help`
- render parameter tables in the web help view
- document new type hints in `web.auto` project
- style tables for help entries
- fix web app setup to keep enabled projects
- add regression test for help param types

## Testing
- `gway test --coverage` *(fails: Port 18888 not responding after 15 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_687bd6b3c18c832696e8411d4dc03d45