### PR TITLE
Fix footer link routing

### DIFF
--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -201,7 +201,7 @@ def setup_app(project,
         if home:
             add_home(home, path, project)
             add_links(f"{path}/{home}", links)
-            add_footer_links(f"{path}/{home}", footer)
+            add_footer_links(f"{path}/{home}", footer, project)
 
         def index():
             response.status = 302
@@ -216,11 +216,11 @@ def setup_app(project,
     elif home:
         add_home(home, path, project)
         add_links(f"{path}/{home}", links)
-        add_footer_links(f"{path}/{home}", footer)
+        add_footer_links(f"{path}/{home}", footer, project)
     elif links and _homes:
         add_links(_homes[-1][1], links)
     elif footer and _homes:
-        add_footer_links(_homes[-1][1], footer)
+        add_footer_links(_homes[-1][1], footer, project)
 
     if getattr(gw, "timed_enabled", False):
         @app.hook('before_request')
@@ -740,10 +740,15 @@ def add_links(route: str, links=None):
         _links[route] = existing + parsed
         gw.debug(f"Added links for {route}: {_links[route]}")
 
-def add_footer_links(route: str, links=None):
+def add_footer_links(route: str, links=None, project: str | None = None):
     global _footer_links
     parsed = parse_links(links)
     if parsed:
+        if project:
+            parsed = [
+                (project, item) if not isinstance(item, tuple) else item
+                for item in parsed
+            ]
         existing = _footer_links.get(route, [])
         _footer_links[route] = existing + parsed
         gw.debug(f"Added footer links for {route}: {_footer_links[route]}")

--- a/tests/test_footer_links.py
+++ b/tests/test_footer_links.py
@@ -15,7 +15,7 @@ class FooterLinksTests(unittest.TestCase):
     def test_footer_links_render(self):
         app = gw.web.app.setup_app("dummy", footer="info")
         mod = sys.modules[gw.web.app.setup_app.__module__]
-        self.assertEqual(mod._footer_links.get("dummy/index"), ["info"])
+        self.assertEqual(mod._footer_links.get("dummy/index"), [("dummy", "info")])
         client = TestApp(app)
         resp = client.get("/dummy")
         self.assertEqual(resp.status, 200)


### PR DESCRIPTION
## Summary
- ensure footer links use the calling project when project prefix is omitted
- adjust footer link test expectations

## Testing
- `gway test --coverage` *(fails: Port 18888 not responding after 15 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_687c4514285c832694d38c758a7cb8d1