### PR TITLE
Add world clock web view

### DIFF
--- a/data/static/clock/world-clock.css
+++ b/data/static/clock/world-clock.css
@@ -1,0 +1,20 @@
+.world-clock {
+    font-family: monospace;
+    font-size: 8vw;
+    text-align: center;
+    margin: 2rem 0;
+}
+
+.clock-wrap {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 40vh;
+}
+
+.tz-select {
+    display: block;
+    margin: 1em auto;
+    font-size: 1.2em;
+    padding: 0.3em 0.6em;
+}

--- a/data/static/clock/world-clock.js
+++ b/data/static/clock/world-clock.js
@@ -1,0 +1,31 @@
+function initClock(defaultTz) {
+  const clockEl = document.getElementById('clock');
+  const selectEl = document.getElementById('tz-select');
+  if (defaultTz) selectEl.value = defaultTz;
+
+  function formatISO(date, zone) {
+    const parts = new Intl.DateTimeFormat('en-CA', {
+      timeZone: zone,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+      hourCycle: 'h23'
+    }).formatToParts(date).reduce((o,p)=>{o[p.type]=p.value;return o;},{});
+    const offset = new Intl.DateTimeFormat('en-US', {timeZone: zone, timeZoneName: 'longOffset'})
+      .formatToParts(date)
+      .find(p => p.type === 'timeZoneName').value.replace('GMT','');
+    return `${parts.year}-${parts.month}-${parts.day}T${parts.hour}:${parts.minute}:${parts.second}${offset}`;
+  }
+
+  function update() {
+    const zone = selectEl.value;
+    clockEl.textContent = formatISO(new Date(), zone);
+  }
+
+  selectEl.addEventListener('change', update);
+  update();
+  setInterval(update, 1000);
+}

--- a/projects/clock.py
+++ b/projects/clock.py
@@ -4,6 +4,8 @@ import re
 import time
 import requests
 import datetime
+from zoneinfo import available_timezones, ZoneInfo
+from gway import gw
 
 #       If there is missing functionality we need for other projects, add it.
 
@@ -132,3 +134,40 @@ def to_download(filesize):
             raise
 
     download_time_report(filesize)
+
+
+# ---------------------------------------------------------------------------
+# Web Interface: World Clock
+# ---------------------------------------------------------------------------
+
+
+@gw.web.static.include()
+def view_world_clock(*, tz: str = "UTC", **_):
+    """Return a page with a live world clock."""
+    zones = sorted(available_timezones())
+    if tz not in zones:
+        tz = "UTC"
+    options = [
+        f"<option value='{z}'{' selected' if z == tz else ''}>{z}</option>"
+        for z in zones
+    ]
+    html = [
+        "<h1>World Clock</h1>",
+        "<div class='clock-wrap'><div id='clock' class='world-clock'></div></div>",
+        "<label class='tz-label'>Timezone: <select id='tz-select' class='tz-select'>",
+        *options,
+        "</select></label>",
+        "<script src='/static/clock/world-clock.js'></script>",
+        f"<script>initClock('{tz}');</script>",
+    ]
+    return "\n".join(html)
+
+
+def setup_home():
+    """World clock is the default view when serving this project."""
+    return "world-clock"
+
+
+def setup_links():
+    """Navigation links for this project."""
+    return ["world-clock"]


### PR DESCRIPTION
## Summary
- add `world_clock` web view in clock project
- include timezone selector and live clock JS/CSS

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: TimeoutError: Port 18888 not responding)*

------
https://chatgpt.com/codex/tasks/task_e_687c769c722883268223a6f6cb8d9487