### PR TITLE
Fix footer link routing

### DIFF
--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -200,8 +200,8 @@ def setup_app(project,
         _enabled.add(project)
         if home:
             add_home(home, path, project)
-            add_links(f"{path}/{home}", links)
-            add_footer_links(f"{path}/{home}", footer)
+            add_links(f"{path}/{home}", links, project)
+            add_footer_links(f"{path}/{home}", footer, project)
 
         def index():
             response.status = 302
@@ -215,12 +215,12 @@ def setup_app(project,
     
     elif home:
         add_home(home, path, project)
-        add_links(f"{path}/{home}", links)
-        add_footer_links(f"{path}/{home}", footer)
+        add_links(f"{path}/{home}", links, project)
+        add_footer_links(f"{path}/{home}", footer, project)
     elif links and _homes:
-        add_links(_homes[-1][1], links)
+        add_links(_homes[-1][1], links, project)
     elif footer and _homes:
-        add_footer_links(_homes[-1][1], footer)
+        add_footer_links(_homes[-1][1], footer, project)
 
     if getattr(gw, "timed_enabled", False):
         @app.hook('before_request')
@@ -732,18 +732,28 @@ def add_home(home, path, project=None):
         _homes.append((title, route))
         gw.debug(f"Added home: ({title}, {route})")
 
-def add_links(route: str, links=None):
+def add_links(route: str, links=None, project: str | None = None):
     global _links
     parsed = parse_links(links)
     if parsed:
+        if project:
+            parsed = [
+                (project, item) if not isinstance(item, tuple) else item
+                for item in parsed
+            ]
         existing = _links.get(route, [])
         _links[route] = existing + parsed
         gw.debug(f"Added links for {route}: {_links[route]}")
 
-def add_footer_links(route: str, links=None):
+def add_footer_links(route: str, links=None, project: str | None = None):
     global _footer_links
     parsed = parse_links(links)
     if parsed:
+        if project:
+            parsed = [
+                (project, item) if not isinstance(item, tuple) else item
+                for item in parsed
+            ]
         existing = _footer_links.get(route, [])
         _footer_links[route] = existing + parsed
         gw.debug(f"Added footer links for {route}: {_footer_links[route]}")

--- a/tests/test_footer_links.py
+++ b/tests/test_footer_links.py
@@ -15,7 +15,7 @@ class FooterLinksTests(unittest.TestCase):
     def test_footer_links_render(self):
         app = gw.web.app.setup_app("dummy", footer="info")
         mod = sys.modules[gw.web.app.setup_app.__module__]
-        self.assertEqual(mod._footer_links.get("dummy/index"), ["info"])
+        self.assertEqual(mod._footer_links.get("dummy/index"), [("dummy", "info")])
         client = TestApp(app)
         resp = client.get("/dummy")
         self.assertEqual(resp.status, 200)

--- a/tests/test_links_without_home.py
+++ b/tests/test_links_without_home.py
@@ -18,7 +18,10 @@ class LinksWithoutHomeTests(unittest.TestCase):
         gw.web.app.setup_app("dummy", app=app, links="info")
         mod = sys.modules[gw.web.app.setup_app.__module__]
         self.assertEqual(mod._homes, [("Dummy", "dummy/index")])
-        self.assertEqual(mod._links.get("dummy/index"), ["about", "more", "info"]) 
+        self.assertEqual(
+            mod._links.get("dummy/index"),
+            [("dummy", "about"), ("dummy", "more"), ("dummy", "info")],
+        )
         client = TestApp(app)
         resp = client.get("/dummy")
         self.assertEqual(resp.status, 200)

--- a/tests/test_setup_home_links.py
+++ b/tests/test_setup_home_links.py
@@ -10,7 +10,9 @@ class SetupHomeLinksFuncTests(unittest.TestCase):
         app = gw.web.app.setup_app("dummy", app=None)
         mod = sys.modules[gw.web.app.setup_app.__module__]
         self.assertIn(("Dummy", "dummy/index"), mod._homes)
-        self.assertEqual(mod._links.get("dummy/index"), ["about", "more"])
+        self.assertEqual(
+            mod._links.get("dummy/index"), [("dummy", "about"), ("dummy", "more")]
+        )
         client = TestApp(app)
         resp = client.get("/dummy")
         self.assertEqual(resp.status, 200)


### PR DESCRIPTION
## Summary
- ensure footer links use the calling project when project prefix is omitted
- ensure navigation links inherit the calling project when no prefix is provided
- update cookie jar footer link paths in demo recipes
- adjust tests for new tuple-based link storage
- drop redundant project prefix in demo recipes

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: Port 18888 not responding after 15 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_687c4514285c832694d38c758a7cb8d1