### PR TITLE
Add test auto-install option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+- add --install option to test command
+
 0.4.51 [build edbd5b]
 ---------------------
 

--- a/TESTING.rst
+++ b/TESTING.rst
@@ -9,6 +9,10 @@ Install the runtime dependencies first. The simplest approach is:
    pip install -e .
    gway test --coverage
 
+The ``gway test`` command accepts ``--install`` to perform these
+installation steps automatically. When dependencies like ``requests``
+are missing, ``--install`` is run implicitly.
+
 This ensures that modules such as ``requests`` and ``websockets`` are
 available to the test suite.
 

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -79,5 +79,14 @@ class GatewayBuiltinsTests(unittest.TestCase):
         with self.assertRaises(SystemExit):
             gw.abort("Abort test")
 
+    def test_test_install_option(self):
+        """Ensure the test builtin accepts the install flag."""
+        import tempfile
+        import pathlib
+        with tempfile.TemporaryDirectory() as tmp:
+            pathlib.Path(tmp, "__init__.py").touch()
+            result = builtins.test(root=tmp, install=False)
+            self.assertTrue(result)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `--install` option to builtin test command
- install dependencies automatically when missing
- document flag in TESTING guide
- add regression test for new option
- update changelog

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: test suite has failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_687c7a31341c8326b550c550d3737c11