### PR TITLE
Improve SQL auto-migration and error messages

### DIFF
--- a/data/static/sql/README.rst
+++ b/data/static/sql/README.rst
@@ -44,9 +44,10 @@ more complete example with basic authentication see ``recipes/micro_blog.gwr``.
 
 ``gw.sql.model`` returns a proxy object with CRUD helpers for a specific
 table. Pass an existing table name or a definition such as a mapping or
-dataclass and the table will be created automatically. The helper also
-accepts a ``project`` name which is passed through to
-``gw.sql.open_db``::
+dataclass and the table will be created automatically. If the table
+already exists and your definition includes new columns they will be
+added automatically. The helper also accepts a ``project`` name which is
+passed through to ``gw.sql.open_db``::
 
     from dataclasses import dataclass
     from gway import gw

--- a/projects/ocpp/data.py
+++ b/projects/ocpp/data.py
@@ -163,6 +163,7 @@ def record_last_msg(charger_id: str, timestamp: int | None = None):
     )
 
 def get_connection(charger_id: str):
+    gw.sql.model(CONNECTIONS, project="ocpp")  # ensure table exists
     conn = gw.sql.open_db(project="ocpp")
     rows = gw.sql.execute(
         "SELECT connected, last_heartbeat, status, error_code, info, last_msg FROM connections WHERE charger_id=?",
@@ -304,6 +305,7 @@ def get_active_transactions():
 
 def get_active_chargers() -> list[str]:
     """Return list of charger IDs currently marked as connected."""
+    gw.sql.model(CONNECTIONS, project="ocpp")  # ensure table exists
     conn = gw.sql.open_db(project="ocpp")
     rows = gw.sql.execute(
         "SELECT charger_id FROM connections WHERE connected=1",
@@ -388,6 +390,7 @@ def get_meter_series(chargers: Sequence[str], *, start: int = None, end: int = N
 
 def list_chargers() -> list[str]:
     """Return list of distinct charger_ids."""
+    gw.sql.model(CONNECTIONS, project="ocpp")  # ensure table exists
     conn = gw.sql.open_db(project="ocpp")
     rows = gw.sql.execute(
         "SELECT charger_id FROM connections UNION SELECT DISTINCT charger_id FROM transactions ORDER BY charger_id",

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -198,8 +198,9 @@ class SqlTests(unittest.TestCase):
         gw.sql.execute(
             "CREATE TABLE errtest (z INT)", connection=self.conn
         )
-        with self.assertRaises(Exception):
+        with self.assertRaises(Exception) as cm:
             gw.sql.execute("INSRT INTO errtest VALUES (9)", connection=self.conn)
+        self.assertIn("INSRT INTO errtest", str(cm.exception))
         # Table should be empty
         rows = gw.sql.execute("SELECT count(*) FROM errtest", connection=self.conn)
         self.assertEqual(rows[0][0], 0)

--- a/tests/test_sql_model.py
+++ b/tests/test_sql_model.py
@@ -79,5 +79,15 @@ class SqlModelTests(unittest.TestCase):
         gw.sql.close_connection(DBFILE)
         del globals()["DBFILE"]
 
+    def test_add_missing_columns(self):
+        spec1 = {"__name__": "tbl", "id": "INTEGER PRIMARY KEY", "a": "TEXT"}
+        gw.sql.model(spec1, dbfile=self.DB)
+        spec2 = {"__name__": "tbl", "id": "INTEGER PRIMARY KEY", "a": "TEXT", "b": "INTEGER"}
+        gw.sql.model(spec2, dbfile=self.DB)
+        conn = gw.sql.open_db(self.DB)
+        cols = [r[1] for r in gw.sql.execute("PRAGMA table_info(tbl)", connection=conn)]
+        self.assertIn("b", cols)
+        gw.sql.close_connection(self.DB)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure SQL model is applied in OCPP data helpers
- show failing SQL in execution errors
- document auto-add behaviour in SQL README
- test missing column addition via sql.model
- validate error messages include SQL text

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687c7f1d53088326b7acd3f763114ce3