### PR TITLE
Add notify flag to release.build

### DIFF
--- a/projects/release.py
+++ b/projects/release.py
@@ -36,6 +36,7 @@ def build(
     help_db: bool = False,
     projects: bool = False,
     git: bool = False,
+    notify: bool = False,
     all: bool = False,
     force: bool = False
 ) -> None:
@@ -48,6 +49,7 @@ def build(
         twine (bool): Upload to PyPI if True.
         force (bool): Skip version-exists check on PyPI if True.
         git (bool): Require a clean git repo and commit/push after release if True.
+        notify (bool): Show a desktop notification when done.
         vscode (bool): Build the vscode extension.
     """
     from pathlib import Path
@@ -65,6 +67,7 @@ def build(
         twine = True
         git = True
         projects = True
+        notify = True
 
     gw.info(f"Running tests before project build.")
     test_result = gw.test()
@@ -270,6 +273,9 @@ def build(
         subprocess.run(["git", "commit", "-m", commit_msg], check=True)
         subprocess.run(["git", "push"], check=True)
         gw.info(f"Committed and pushed: {commit_msg}")
+
+    if notify:
+        gw.notify(f"Release v{version} build complete")
 
 
 def build_help_db():

--- a/tests/test_release_notify.py
+++ b/tests/test_release_notify.py
@@ -1,0 +1,48 @@
+import unittest
+import tempfile
+import os
+from pathlib import Path
+from unittest.mock import patch
+import subprocess
+from gway import gw
+
+class ReleaseBuildNotifyTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmp.name)
+        self.old = Path.cwd()
+        os.chdir(self.base)
+        Path("VERSION").write_text("0.0.1\n")
+        Path("requirements.txt").write_text("requests\n")
+        Path("README.rst").write_text("readme\n")
+
+    def tearDown(self):
+        os.chdir(self.old)
+        self.tmp.cleanup()
+
+    def test_notify_option_calls_notify(self):
+        cp = subprocess.CompletedProcess([], 0, "", "")
+        with patch.object(gw, "test", return_value=True), \
+             patch.object(gw, "resolve", return_value=""), \
+             patch.object(gw.hub, "commit", return_value="abc"), \
+             patch.object(gw.release, "update_changelog"), \
+             patch("subprocess.run", return_value=cp), \
+             patch.object(gw, "notify") as mock_notify:
+            gw.release.build(notify=True)
+            mock_notify.assert_called_once()
+
+    def test_all_enables_notify(self):
+        cp = subprocess.CompletedProcess([], 0, "", "")
+        with patch.object(gw, "test", return_value=True), \
+             patch.object(gw, "resolve", return_value=""), \
+             patch.object(gw.hub, "commit", return_value="abc"), \
+             patch.object(gw.release, "update_changelog"), \
+             patch.object(gw.release, "update_readme_links"), \
+             patch("subprocess.run", return_value=cp), \
+             patch("requests.get"), \
+             patch.object(gw, "notify") as mock_notify:
+            gw.release.build(all=True)
+            mock_notify.assert_called_once()
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `notify` option to `release.build`
- notify on completion when enabled
- ensure `--all` sets `notify`
- test notification behavior

## Testing
- `gway test --coverage` *(fails: Git repository is not clean and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_687c801069408326a75dc5378aa3a987