### PR TITLE
Update website recipe with unified OCPP dashboard link

### DIFF
--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -11,9 +11,8 @@ web app setup:
     - web.message
     - web.chat
     - vbox --home uploads
-    - ocpp.data --home charger-summary
-    - ocpp.csms --auth required --home active-chargers
-    - ocpp.evcs --auth required --home cp-simulator
+    - ocpp --home dashboard \
+        --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth
 

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -10,9 +10,8 @@ web app setup:
     - web.message
     - awg --home awg-calculator
     - vbox --home uploads
-    - ocpp.csms --auth required --home active-chargers
-    - ocpp.evcs --auth required --home cp-simulator
-    - ocpp.data --auth required --home charger-summary
+    - ocpp --auth required --home dashboard \
+        --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - web.chat.actions --home audit-chatlog --auth required
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth


### PR DESCRIPTION
## Summary
- update website recipe to link to OCPP dashboard instead of individual links
- sync test variant of website recipe

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: Port 18888 not responding after 15 seconds)*

------
https://chatgpt.com/codex/tasks/task_e_687d4338554483269ebc4591fc83bb8f