### PR TITLE
Add default-style support to web.nav

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ next non-indented command.
    # Configure multiple projects
    web app setup-app:
        - web.site --home reader
-       - web.nav --style random
+       - web.nav --style random --default-style dark-material.css
        - games.qpig --home qpig-farm
 
    # Start the server

--- a/data/static/web/nav/README.rst
+++ b/data/static/web/nav/README.rst
@@ -8,4 +8,5 @@ initial theme without exposing the style switcher. Use ``--style random``
 to pick a random theme on each request. A ``--side top`` option places the
 navigation bar at the top of the page with drop-down menus.
 The style switcher drop-down also includes a **Random** option to toggle
-this behavior per user.
+this behavior per user. ``--default-style`` (or ``--default_css``) changes
+the fallback theme used when no preference is stored.

--- a/tests/test_nav_active_style.py
+++ b/tests/test_nav_active_style.py
@@ -57,12 +57,18 @@ class ActiveStyleTests(unittest.TestCase):
 
         # Preserve original request object
         self.orig_request = nav.request
+        self.orig_forced = nav._forced_style
+        self.orig_default = getattr(nav, "_default_style", None)
+        nav._forced_style = None
+        nav._default_style = None
 
     def tearDown(self):
         self.list_patch.stop()
         nav.gw.web.app = self.orig_app
         nav.gw.web.cookies = self.orig_cookies
         nav.request = self.orig_request
+        nav._forced_style = self.orig_forced
+        nav._default_style = self.orig_default
 
     def test_query_param_overrides_cookie(self):
         nav.gw.web.cookies.store = {"css": "dark-material.css"}
@@ -106,6 +112,20 @@ class ActiveStyleTests(unittest.TestCase):
             result = nav.active_style()
             self.assertEqual(result, "/static/styles/dark-material.css")
             mock_choice.assert_called_once()
+
+    def test_default_style_fallback(self):
+        nav.setup_app(default_style="dark-material.css")
+        nav.gw.web.cookies.store = {}
+        nav.request = FakeRequest({})
+        result = nav.active_style()
+        self.assertEqual(result, "/static/styles/dark-material.css")
+
+    def test_default_css_alias(self):
+        nav.setup_app(default_css="dark-material.css")
+        nav.gw.web.cookies.store = {}
+        nav.request = FakeRequest({})
+        result = nav.active_style()
+        self.assertEqual(result, "/static/styles/dark-material.css")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `default_style` option to `web.nav.setup_app`
- use the default style when no cookie or query param is set
- document the option in nav docs and README example
- test new behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: Port 18888 not responding, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687d62ca2ddc83269e0b84be2b87119e