### PR TITLE
Update OCPP dashboard

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -9,6 +9,9 @@ The submodules are:
 - ``sink`` – a message logger for debugging.
 - ``rfid`` – helpers for RFID allow/deny checks.
 
+The landing page ``/ocpp/ocpp-dashboard`` shows a quick summary of these
+sub‑projects.
+
 Launch a simulator session pointing at your CSMS with:
 
 .. code-block:: bash

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -11,7 +11,7 @@ web app setup:
     - web.message
     - web.chat
     - vbox --home uploads
-    - ocpp --home dashboard \
+    - ocpp --home ocpp-dashboard \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -10,7 +10,7 @@ web app setup:
     - web.message
     - awg --home awg-calculator
     - vbox --home uploads
-    - ocpp --auth required --home dashboard \
+    - ocpp --auth required --home ocpp-dashboard \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - web.chat.actions --home audit-chatlog --auth required
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client


### PR DESCRIPTION
## Summary
- rename `view_dashboard` to `view_ocpp_dashboard`
- show per-project cards on the OCPP landing page
- reference new landing route in docs and recipes

## Testing
- `gway test --coverage` *(fails: Port 18888 not responding)*

------
https://chatgpt.com/codex/tasks/task_e_687d63ee4bf08326b19263d3983a3151