### PR TITLE
Update OCPP dashboard

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -9,6 +9,9 @@ The submodules are:
 - ``sink`` – a message logger for debugging.
 - ``rfid`` – helpers for RFID allow/deny checks.
 
+The landing page ``/ocpp/ocpp-dashboard`` shows a quick summary of these
+sub‑projects.
+
 Launch a simulator session pointing at your CSMS with:
 
 .. code-block:: bash

--- a/projects/ocpp/data.py
+++ b/projects/ocpp/data.py
@@ -184,6 +184,9 @@ def get_connection(charger_id: str):
 
 def get_summary():
     """Return summary rows per charger."""
+    # Ensure required tables exist even if no data has been recorded yet.
+    gw.sql.model(TRANSACTIONS, project="ocpp")
+    gw.sql.model(ERRORS, project="ocpp")
     conn = gw.sql.open_db(project="ocpp")
     rows = gw.sql.execute(
         """

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -11,7 +11,7 @@ web app setup:
     - web.message
     - web.chat
     - vbox --home uploads
-    - ocpp --home dashboard \
+    - ocpp --home ocpp-dashboard \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -10,7 +10,7 @@ web app setup:
     - web.message
     - awg --home awg-calculator
     - vbox --home uploads
-    - ocpp --auth required --home dashboard \
+    - ocpp --auth required --home ocpp-dashboard \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - web.chat.actions --home audit-chatlog --auth required
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client

--- a/tests/test_ocpp_data.py
+++ b/tests/test_ocpp_data.py
@@ -59,5 +59,10 @@ class OcppDataTests(unittest.TestCase):
         cols = [r[1] for r in gw.sql.execute("PRAGMA table_info(connections)", connection=conn)]
         self.assertIn("last_msg", cols)
 
+    def test_get_summary_without_tables(self):
+        """get_summary should work when no data has been recorded yet."""
+        rows = ocpp_data.get_summary()
+        self.assertEqual(rows, [])
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- rename `view_dashboard` to `view_ocpp_dashboard`
- show per-project cards on the OCPP landing page
- reference new landing route in docs and recipes
- gracefully create missing tables for `get_summary`
- test summary retrieval without existing database tables

## Testing
- `gway test --coverage` *(fails: Port 18888 not responding)*

------
https://chatgpt.com/codex/tasks/task_e_687d63ee4bf08326b19263d3983a3151