### PR TITLE
Add chat action alias

### DIFF
--- a/projects/web/chat/action.py
+++ b/projects/web/chat/action.py
@@ -1,0 +1,37 @@
+"""Alias for ChatGPT Actions.
+
+This module exposes the same functionality as ``web.chat.actions``
+under the shorter project name ``web.chat.action`` so the API endpoint
+is registered as ``/api/web/chat/action``.
+"""
+
+from gway import gw
+
+
+def _actions():
+    """Return the real actions module lazily to avoid import loops."""
+    return gw.web.chat.actions
+
+
+def api_post_action(*args, **kwargs):
+    return _actions().api_post_action(*args, **kwargs)
+
+
+def api_get_manifest(*args, **kwargs):
+    return _actions().api_get_manifest(*args, **kwargs)
+
+
+def api_get_openapi_json(*args, **kwargs):
+    return _actions().api_get_openapi_json(*args, **kwargs)
+
+
+def api_post_trust(*args, **kwargs):
+    return _actions().api_post_trust(*args, **kwargs)
+
+
+def view_trust_status(*args, **kwargs):
+    return _actions().view_trust_status(*args, **kwargs)
+
+
+def view_audit_chatlog(*args, **kwargs):
+    return _actions().view_audit_chatlog(*args, **kwargs)

--- a/recipes/static_site.gwr
+++ b/recipes/static_site.gwr
@@ -11,7 +11,7 @@ web app setup-app --mode manual:
     - ocpp.csms --auth required --home active-chargers
     - ocpp.evcs --auth required --home cp-simulator
     - ocpp.data --auth required --home charger-summary
-    - web.chat.actions --home audit-chatlog --auth required
+    - web.chat.action --home audit-chatlog --auth required
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth
 

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -12,7 +12,7 @@ web app setup:
     - vbox --home uploads
     - ocpp --auth required --home ocpp-dashboard \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
-    - web.chat.actions --home audit-chatlog --auth required
+    - web.chat.action --home audit-chatlog --auth required
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth
 


### PR DESCRIPTION
## Summary
- expose `web.chat.action` as a thin wrapper around the existing ChatGPT actions
- register the alias in website recipes so the endpoint is `/api/web/chat/action`

## Testing
- `gway test` *(fails: Must provide PyPI token; missing resources)*

------
https://chatgpt.com/codex/tasks/task_e_687c80ae59fc8326b9d93688847aef9e