### PR TITLE
Fix manage RFID view routing

### DIFF
--- a/projects/ocpp/ocpp.py
+++ b/projects/ocpp/ocpp.py
@@ -143,3 +143,8 @@ def view_time_series(*args, **kwargs):
 
 def view_cp_simulator(*args, **kwargs):
     return gw.ocpp.evcs.view_cp_simulator(*args, **kwargs)
+
+
+def view_manage_rfids(*args, **kwargs):
+    """Delegate to :func:`gw.ocpp.rfid.view_manage_rfids`."""
+    return gw.ocpp.rfid.view_manage_rfids(*args, **kwargs)


### PR DESCRIPTION
## Summary
- expose the manage RFID page through the root `ocpp` project

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: failures=7, errors=1)*

------
https://chatgpt.com/codex/tasks/task_e_687d7978f2488326848a3bd6c0913b46