### PR TITLE
Fix OCPP dashboard style for dark theme

### DIFF
--- a/projects/ocpp/ocpp.py
+++ b/projects/ocpp/ocpp.py
@@ -89,8 +89,8 @@ def view_ocpp_dashboard(**_):
     html.append(
         "<style>"
         ".ocpp-cards{display:flex;flex-wrap:wrap;gap:1em;margin:1em 0;}"
-        ".ocpp-card{display:block;padding:1em;border:1px solid #ccc;border-radius:8px;"
-        "background:#f9f9f9;box-shadow:0 2px 4px rgba(0,0,0,0.1);width:16em;"
+        ".ocpp-card{display:block;padding:1em;border:1px solid var(--muted,#ccc);border-radius:8px;"
+        "background:var(--card-bg,#f9f9f9);box-shadow:0 2px 4px rgba(0,0,0,0.1);width:16em;"
         "text-decoration:none;color:inherit;}"
         ".ocpp-card h2{margin-top:0;font-size:1.2em;}"
         ".ocpp-card p{margin:.4em 0;}"


### PR DESCRIPTION
## Summary
- ensure OCPP dashboard cards adapt to theme colors

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: SystemExit in release build; various assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_687d7f8a1b0c8326b2085d33ab021262