### PR TITLE
Expand style switcher preview

### DIFF
--- a/data/static/web/nav/README.rst
+++ b/data/static/web/nav/README.rst
@@ -10,3 +10,7 @@ navigation bar at the top of the page with drop-down menus.
 The style switcher drop-down also includes a **Random** option to toggle
 this behavior per user. ``--default-style`` (or ``--default_css``) changes
 the fallback theme used when no preference is stored.
+
+The style switcher page previews the selected theme and now showcases
+several common inputs such as text fields, checkboxes, radio buttons and
+a select drop-down to demonstrate how each style affects form elements.

--- a/projects/web/nav.py
+++ b/projects/web/nav.py
@@ -448,6 +448,13 @@ def view_style_switcher(*, css=None, project=None):
             <h2>Theme Preview: {selected_style[:-4].replace('_', ' ').title()}</h2>
             <p>This is a preview of the <b>{selected_style}</b> theme.</p>
             <button>Sample button</button>
+            <input type="text" placeholder="Text input" style="display:block;margin:0.5em 0;">
+            <label style="display:block;margin:0.25em 0;"><input type="checkbox"> Checkbox</label>
+            <label style="display:block;margin:0.25em 0;"><input type="radio" name="r"> Radio</label>
+            <select style="display:block;margin:0.5em 0;">
+                <option>Option A</option>
+                <option>Option B</option>
+            </select>
             <pre>code block</pre>
         </div>
         """


### PR DESCRIPTION
## Summary
- add input examples to style switcher preview
- note new preview elements in nav README

## Testing
- `gway test --coverage` *(fails: test_all_enables_notify, test_unauthenticated_blocked_on_active_chargers, test_test_install_option, test_home_title_uses_project_name, test_links_append_to_last_home, test_render_top_nav, test_repeated_project_setup_creates_clean_app, test_defaults_from_project_functions)*

------
https://chatgpt.com/codex/tasks/task_e_687d7eee3ca4832685cd32ffd5c4c2df