### PR TITLE
Add Future Updates web view

### DIFF
--- a/tests/test_view_future_updates.py
+++ b/tests/test_view_future_updates.py
@@ -1,0 +1,25 @@
+import unittest
+from gway import gw
+from paste.fixture import TestApp
+from unittest.mock import patch
+
+class ViewFutureUpdatesTests(unittest.TestCase):
+    def setUp(self):
+        self.app = gw.web.app.setup_app("web.site")
+        self.client = TestApp(self.app)
+
+    def test_newer_version_notice(self):
+        with patch("requests.get") as mock_get:
+            mock_get.return_value.json.return_value = {"info": {"version": "9.9.9"}}
+            mock_get.return_value.raise_for_status = lambda: None
+            changelog = "Changelog\n=========\n\nUnreleased\n----------\n- pending\n\n0.1\n"
+            with patch("pathlib.Path.read_text", return_value=changelog):
+                resp = self.client.get("/web/site/future-updates")
+        self.assertEqual(resp.status, 200)
+        body = resp.body.decode()
+        self.assertIn("newer version of GWAY pending", body)
+        self.assertIn("9.9.9", body)
+        self.assertIn("pending", body)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `view_future_updates` in `web.site`
- parse CHANGELOG and compare installed version with PyPI release
- provide basic tests for the new view

## Testing
- `gway test --coverage` *(fails: test_auth_charger.AuthChargerStatusTests.test_unauthenticated_blocked_on_active_chargers, test_builtins.GatewayBuiltinsTests.test_test_install_option, test_index_home_title.IndexHomeTitleTests.test_home_title_uses_project_name, test_links_without_home.LinksWithoutHomeTests.test_links_append_to_last_home, test_nav_top.NavTopTests.test_render_top_nav, test_setup_app_repeat.SetupAppRepeatTests.test_repeated_project_setup_creates_clean_app, test_setup_home_links.SetupHomeLinksFuncTests.test_defaults_from_project_functions, test_release_notify.ReleaseBuildNotifyTests.test_all_enables_notify)*

------
https://chatgpt.com/codex/tasks/task_e_687d8354253083269db533cec17518b3