### PR TITLE
Fix TODO view file reading

### DIFF
--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -678,7 +678,7 @@ def view_comitted_todos():
         if path.name.startswith("_"):
             continue
         dotted = path.relative_to(base).with_suffix("").as_posix().replace("/", ".")
-        with open(path, "r") as f:
+        with open(path, "r", encoding="utf-8", errors="ignore") as f:
             lines = f.readlines()
         try:
             tree = ast.parse("".join(lines))


### PR DESCRIPTION
## Summary
- avoid UnicodeDecodeError in `view_comitted_todos`

## Testing
- `gway test --coverage` *(fails: system exit and assertion failures)*

------
https://chatgpt.com/codex/tasks/task_e_687da9176ccc8326b53dbc6b823c47da