### PR TITLE
Remove optional auth in test recipe

### DIFF
--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -20,7 +20,7 @@ help-db build
 
 web:
  - static collect
- - auth config-basic --optional --temp-link
+ - auth config-basic --temp-link
 
 ocpp csms setup:
     --location simulator


### PR DESCRIPTION
## Summary
- require basic auth in test website recipe

## Testing
- `gway test` *(fails: failures=12, errors=3)*

------
https://chatgpt.com/codex/tasks/task_e_687da926ae3483269aecf9d334cacaef