### PR TITLE
Add pending TODO view with feedback link

### DIFF
--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -558,17 +558,17 @@ def view_feedback(*, name=None, email=None, topic=None, message=None, create_iss
     issue_option = (
         "<label class=\"checkbox-right\">"
         "Optional: Create an Issue Report for GWAY or this website."
-        "<input type=\"checkbox\" name=\"create_issue\" value=\"1\" />"
+        "<input type=\"checkbox\" name=\"create_issue\" value=\"1\" {('checked' if create_issue else '')}/>"
         "</label>"
     ) if token else "<p>(GitHub issue creation unavailable)</p>"
     return f"""
         <h1>Send Feedback</h1>
         <p>Your name and message may be publicly displayed and processed. Your email will be kept private.</p>
         <form method="post">
-            <input type="text" name="name" placeholder="Your Name" required class="main" />
-            <input type="email" name="email" placeholder="Email" required class="main" />
-            <input type="text" name="topic" placeholder="Topic" required class="main" />
-            <textarea name="message" placeholder="Message" required rows="6" class="main"></textarea>
+            <input type="text" name="name" placeholder="Your Name" required class="main" value="{html.escape(name or '')}" />
+            <input type="email" name="email" placeholder="Email" required class="main" value="{html.escape(email or '')}" />
+            <input type="text" name="topic" placeholder="Topic" required class="main" value="{html.escape(topic or '')}" />
+            <textarea name="message" placeholder="Message" required rows="6" class="main">{html.escape(message or '')}</textarea>
             {issue_option}
             <button type="submit" class="submit btn-block">Submit</button>
         </form>
@@ -697,7 +697,7 @@ def view_project_readmes():
     return "<h1>Project READMEs</h1>" + body
 
 
-def view_comitted_todos():
+def view_pending_todos():
     """Render an HTML table of TODOs grouped by project."""
     import ast
     import inspect
@@ -758,14 +758,23 @@ def view_comitted_todos():
     if not todos:
         return "<h1>No TODOs found.</h1>"
 
-    html_parts = ["<h1>Committed TODOs</h1>"]
+    html_parts = ["<h1>Pending TODOs</h1>"]
     for proj in sorted(todos):
         html_parts.append(f"<h2>{html.escape(proj)}</h2>")
-        html_parts.append("<table class='todo-table'><tr><th>Function</th><th>TODO</th></tr>")
+        html_parts.append(
+            "<table class='todo-table'><tr><th>Function</th><th>TODO</th><th></th></tr>"
+        )
         for func, todo in todos[proj]:
             link = gw.web.app.build_url("web", "site", "help", topic=f"{proj}/{func}")
+            fb_url = gw.web.app.build_url(
+                "feedback",
+                topic=f"TODO request for {proj}.{func}",
+                message=f"Please add a TODO for {proj}.{func}"
+            )
             html_parts.append(
-                f"<tr><td><a href='{link}'>{html.escape(func)}</a></td><td><pre>{html.escape(todo)}</pre></td></tr>"
+                f"<tr><td><a href='{link}'>{html.escape(func)}</a></td>"
+                f"<td><pre>{html.escape(todo)}</pre></td>"
+                f"<td><a class='btn-small' href='{fb_url}'>Request TODO</a></td></tr>"
             )
         html_parts.append("</table>")
     return "".join(html_parts)

--- a/recipes/crud_site.gwr
+++ b/recipes/crud_site.gwr
@@ -7,7 +7,7 @@ sql execute "CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREM
 
 web app setup:
     --project web.nav --home style-switcher
-    --project web.site --home reader --footer comitted-todos
+    --project web.site --home reader --footer pending-todos
     --project sql.crud --home posts?table=posts&dbfile=work/blog.sqlite
 help-db build
 web:

--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -2,7 +2,7 @@
 # Games-only demo with cookies, navbar and style switcher
 
 web app setup:
-    - web.site --home reader --footer comitted-todos
+    - web.site --home reader --footer pending-todos
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.nav --home style-switcher
     - web.cookies --footer web.cookies:cookie-jar

--- a/recipes/media_blog.gwr
+++ b/recipes/media_blog.gwr
@@ -10,7 +10,7 @@ sql migrate --dbfile work/blog.sqlite
 
 web app setup-app:
     - web.nav --home style-switcher
-    - web.site --home reader --footer comitted-todos
+    - web.site --home reader --footer pending-todos
     - sql.crud --home posts?table=posts&dbfile=work/blog.sqlite
 help-db build
 web:

--- a/recipes/micro_blog.gwr
+++ b/recipes/micro_blog.gwr
@@ -10,7 +10,7 @@ sql migrate --dbfile work/blog.sqlite
 
 web app setup-app:
     - web.nav --home style-switcher
-    - web.site --home reader --footer comitted-todos
+    - web.site --home reader --footer pending-todos
     - web.auth --home login
     - sql.crud --home table?table=posts&dbfile=work/blog.sqlite
 help-db build

--- a/recipes/midblog.gwr
+++ b/recipes/midblog.gwr
@@ -10,7 +10,7 @@ sql migrate --dbfile work/blog.sqlite
 
 web app setup-app:
     - web.nav --home style-switcher
-    - web.site --home reader --footer comitted-todos
+    - web.site --home reader --footer pending-todos
     - sql.crud --home posts?table=posts&dbfile=work/blog.sqlite
 help-db build
 web:

--- a/recipes/skeleton.gwr
+++ b/recipes/skeleton.gwr
@@ -1,7 +1,7 @@
 # file: recipes/skeleton.gwr
 
 web app setup:
-    - web.site --home reader --footer comitted-todos
+    - web.site --home reader --footer pending-todos
     - cdv --home data-editor
     - etron --home extract-records
 help-db build

--- a/recipes/static_site.gwr
+++ b/recipes/static_site.gwr
@@ -2,7 +2,7 @@
 # Demo website using per-view static assets instead of bundled CSS/JS
 
 web app setup-app --mode manual:
-    - web.site --home reader --footer feedback,comitted-todos
+    - web.site --home reader --footer feedback,pending-todos
     - web.nav --home style-switcher
     - web.cookies --footer web.cookies:cookie-jar
     - web.message

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -4,7 +4,7 @@
 # Lines without a starting command repeat the previous with new params
 
 web app setup:
-    - web.site --home reader --footer feedback,comitted-todos
+    - web.site --home reader --footer feedback,pending-todos
     - awg --home awg-calculator
     - web.nav --home style-switcher
     - web.cookies --footer web.cookies:cookie-jar

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -4,7 +4,7 @@
 # Lines without a starting command repeat the previous with new params
 
 web app setup:
-    - web.site --home reader --footer feedback,comitted-todos
+    - web.site --home reader --footer feedback,pending-todos
     - web.nav --home style-switcher
     - web.cookies --footer web.cookies:cookie-jar
     - web.message

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -18,6 +18,14 @@ class FeedbackViewTests(unittest.TestCase):
             self.assertIn("publicly displayed", html)
             self.assertIn("Create an Issue Report", html)
 
+    def test_feedback_form_prefills_fields(self):
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "x"}):
+            html = site.view_feedback(name="Ann", email="a@b", topic="T", message="Msg")
+            self.assertIn('value="Ann"', html)
+            self.assertIn('value="a@b"', html)
+            self.assertIn('value="T"', html)
+            self.assertIn('>Msg</textarea>', html)
+
     def test_feedback_form_missing_token_with_mail(self):
         env = {
             "MAIL_SENDER": "a",

--- a/tests/test_view_pending_todos.py
+++ b/tests/test_view_pending_todos.py
@@ -1,13 +1,15 @@
 import unittest
 from gway import gw
 
-class ViewComittedTodosTests(unittest.TestCase):
+class ViewPendingTodosTests(unittest.TestCase):
     def test_view_renders_todo_table(self):
         gw.help_db.build(update=True)
-        html = gw.web.site.view_comitted_todos()
+        html = gw.web.site.view_pending_todos()
         self.assertIn('<table', html)
         self.assertIn('ocpp.rfid', html)
         self.assertIn('?topic=ocpp.rfid%2Fauthorize_balance', html)
+        self.assertIn('Request TODO', html)
+        self.assertIn('TODO+request+for+ocpp.rfid.authorize_balance', html)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- rename `view_comitted_todos` to `view_pending_todos`
- add per-row feedback links and update header
- allow feedback form to pre-fill fields from query params
- update recipes to use new pending-todos route
- adjust tests for renamed view and prefilled feedback form

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --filter view_pending_todos`
- `gway test --filter feedback`

Full test suite fails due to environment-specific web tests.

------
https://chatgpt.com/codex/tasks/task_e_687dac6f7b2c83268fc4c0d08470b106