### PR TITLE
Fix OCPP EVCS routing

### DIFF
--- a/projects/ocpp/ocpp.py
+++ b/projects/ocpp/ocpp.py
@@ -145,6 +145,17 @@ def view_cp_simulator(*args, **kwargs):
     return gw.ocpp.evcs.view_cp_simulator(*args, **kwargs)
 
 
+def view_evcs(view: str | None = None, *args, **kwargs):
+    """Delegate ``/ocpp/evcs/<view>`` routes to :mod:`ocpp.evcs` views."""
+    target = (view or "cp-simulator").replace("-", "_")
+    func = getattr(gw.ocpp.evcs, f"view_{target}", None)
+    if not callable(func):
+        return gw.web.error.redirect(
+            f"View not found: {target} in ocpp.evcs"
+        )
+    return func(*args, **kwargs)
+
+
 def view_manage_rfids(*args, **kwargs):
     """Delegate to :func:`gw.ocpp.rfid.view_manage_rfids`."""
     return gw.ocpp.rfid.view_manage_rfids(*args, **kwargs)


### PR DESCRIPTION
## Summary
- add `view_evcs` to route `/ocpp/evcs/...` to the EVCS module

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: unauthorized tests etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687dac8b13b08326928e4c4019408dc1