### PR TITLE
Fix missing OCPP summary view

### DIFF
--- a/projects/ocpp/data.py
+++ b/projects/ocpp/data.py
@@ -423,6 +423,10 @@ def view_charger_summary(**_):
     html.append("</table>")
     return "\n".join(html)
 
+def view_summary(**kwargs):
+    """Alias for :func:`view_charger_summary` to keep URLs stable."""
+    return view_charger_summary(**kwargs)
+
 def view_charger_details(
     *,
     charger_id: str = None,

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -12,6 +12,7 @@ web app setup:
     - vbox --home uploads
     - ocpp --auth required --home ocpp-dashboard \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
+    - ocpp.data --home charger-summary
     - web.chat.action --home audit-chatlog --auth required
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.auth


### PR DESCRIPTION
## Summary
- expose `view_summary` in `ocpp.data` as alias for the charger summary view
- register `ocpp.data` project in the website recipe so `/ocpp/data/*` routes work

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: Unauthorized errors in navigation tests)*

------
https://chatgpt.com/codex/tasks/task_e_687dac979bb88326ae5fafc39506fa6b