### PR TITLE
Fix OCPP dashboard time series link

### DIFF
--- a/projects/ocpp/ocpp.py
+++ b/projects/ocpp/ocpp.py
@@ -79,7 +79,7 @@ def view_ocpp_dashboard(**_):
          f"Active chargers: {active}"),
         ("Charger Summary", "/ocpp/data/summary",
          f"Chargers: {chargers}<br>Sessions: {sessions}"),
-        ("Energy Time Series", "/ocpp/data/time-series",
+        ("Energy Time Series", "/ocpp/time-series",
          f"Total Energy: {energy} kWh"),
         ("CP Simulator", "/ocpp/evcs/cp-simulator",
          f"Simulator: {sim_running}"),


### PR DESCRIPTION
## Summary
- correct Energy Time Series link on the OCPP dashboard

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test` *(fails: test suite reported multiple failures)*

------
https://chatgpt.com/codex/tasks/task_e_687dacadea1c8326941672274bcb0872