### PR TITLE
Persist CP simulator state across processes

### DIFF
--- a/projects/ocpp/ocpp.py
+++ b/projects/ocpp/ocpp.py
@@ -71,7 +71,7 @@ def view_ocpp_dashboard(**_):
     chargers = len(summary)
     sessions = sum(r.get("sessions", 0) for r in summary)
     energy = round(sum(r.get("energy", 0.0) for r in summary), 3)
-    sim_state = getattr(gw.ocpp.evcs, "_simulator_state", {})
+    sim_state = gw.ocpp.evcs.get_simulator_state(refresh_file=True)
     sim_running = "Running" if sim_state.get("running") else "Stopped"
 
     links = [


### PR DESCRIPTION
## Summary
- persist simulator status in `work/ocpp/simulator_state.json`
- load/save state in `ocpp.evcs`
- expose `get_simulator_state()`
- update OCPP dashboard to read simulator state from disk

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: unauthorized access errors)*

------
https://chatgpt.com/codex/tasks/task_e_687dae52ec3c8326815df1bc02e90745