### PR TITLE
Add Gateway Cookbook view

### DIFF
--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -835,6 +835,6 @@ def render_footer_links() -> str:
                 href = f"{proj_root}/{name}".strip('/')
                 label = name.replace('-', ' ').replace('_', ' ').title()
             items.append(f'<a href="/{href}">{label}</a>')
-    if not items:
-        return ""
-    return '<p class="footer-links">' + ' | '.join(items) + '</p>'
+    cookbook = gw.web.app.build_url("web", "site", "gateway-cookbook")
+    items.append(f'<a href="{cookbook}">Gateway Cookbook</a>')
+    return '<p class="footer-links">' + ' | '.join(items) + '</p>' if items else ""

--- a/recipes/crud_site.gwr
+++ b/recipes/crud_site.gwr
@@ -7,7 +7,7 @@ sql execute "CREATE TABLE IF NOT EXISTS posts (id INTEGER PRIMARY KEY AUTOINCREM
 
 web app setup:
     --project web.nav --home style-switcher
-    --project web.site --home reader --footer pending-todos
+    --project web.site --home reader --footer gateway-cookbook,pending-todos
     --project sql.crud --home posts?table=posts&dbfile=work/blog.sqlite
 help-db build
 web:

--- a/recipes/gamebox.gwr
+++ b/recipes/gamebox.gwr
@@ -2,7 +2,7 @@
 # Games-only demo with cookies, navbar and style switcher
 
 web app setup:
-    - web.site --home reader --footer pending-todos
+    - web.site --home reader --footer gateway-cookbook,pending-todos
     - games --home games --links game-of-life,divination-wars,qpig-farm,massive-snake,fantastic-client
     - web.nav --home style-switcher
     - web.cookies --footer web.cookies:cookie-jar

--- a/recipes/media_blog.gwr
+++ b/recipes/media_blog.gwr
@@ -10,7 +10,7 @@ sql migrate --dbfile work/blog.sqlite
 
 web app setup-app:
     - web.nav --home style-switcher
-    - web.site --home reader --footer pending-todos
+    - web.site --home reader --footer gateway-cookbook,pending-todos
     - sql.crud --home posts?table=posts&dbfile=work/blog.sqlite
 help-db build
 web:

--- a/recipes/micro_blog.gwr
+++ b/recipes/micro_blog.gwr
@@ -10,7 +10,7 @@ sql migrate --dbfile work/blog.sqlite
 
 web app setup-app:
     - web.nav --home style-switcher
-    - web.site --home reader --footer pending-todos
+    - web.site --home reader --footer gateway-cookbook,pending-todos
     - web.auth --home login
     - sql.crud --home table?table=posts&dbfile=work/blog.sqlite
 help-db build

--- a/recipes/midblog.gwr
+++ b/recipes/midblog.gwr
@@ -10,7 +10,7 @@ sql migrate --dbfile work/blog.sqlite
 
 web app setup-app:
     - web.nav --home style-switcher
-    - web.site --home reader --footer pending-todos
+    - web.site --home reader --footer gateway-cookbook,pending-todos
     - sql.crud --home posts?table=posts&dbfile=work/blog.sqlite
 help-db build
 web:

--- a/recipes/skeleton.gwr
+++ b/recipes/skeleton.gwr
@@ -1,7 +1,7 @@
 # file: recipes/skeleton.gwr
 
 web app setup:
-    - web.site --home reader --footer pending-todos
+    - web.site --home reader --footer gateway-cookbook,pending-todos
     - cdv --home data-editor
     - etron --home extract-records
 help-db build

--- a/recipes/static_site.gwr
+++ b/recipes/static_site.gwr
@@ -2,7 +2,7 @@
 # Demo website using per-view static assets instead of bundled CSS/JS
 
 web app setup-app --mode manual:
-    - web.site --home reader --footer feedback,pending-todos
+    - web.site --home reader --footer feedback,gateway-cookbook,pending-todos
     - web.nav --home style-switcher
     - web.cookies --footer web.cookies:cookie-jar
     - web.message

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -4,7 +4,7 @@
 # Lines without a starting command repeat the previous with new params
 
 web app setup:
-    - web.site --home reader --footer feedback,pending-todos
+    - web.site --home reader --footer feedback,gateway-cookbook,pending-todos
     - awg --home awg-calculator
     - web.nav --home style-switcher
     - web.cookies --footer web.cookies:cookie-jar

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -4,7 +4,7 @@
 # Lines without a starting command repeat the previous with new params
 
 web app setup:
-    - web.site --home reader --footer feedback,pending-todos
+    - web.site --home reader --footer feedback,gateway-cookbook,pending-todos
     - web.nav --home style-switcher
     - web.cookies --footer web.cookies:cookie-jar
     - web.message

--- a/tests/test_gateway_cookbook.py
+++ b/tests/test_gateway_cookbook.py
@@ -1,0 +1,17 @@
+import unittest
+from gway import gw
+
+class GatewayCookbookTests(unittest.TestCase):
+    def test_listing_includes_recipe(self):
+        html = gw.web.site.view_gateway_cookbook()
+        self.assertIn('Micro Blog', html)
+        self.assertIn('Gateway Cookbook', html)
+
+    def test_recipe_view_renders(self):
+        html = gw.web.site.view_gateway_cookbook(recipe='micro_blog.gwr')
+        self.assertIn('micro_blog.gwr', html)
+        self.assertIn('# file:', html)
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- display a "Gateway Cookbook" with recipe browsing
- link the cookbook from the footer on all pages
- update recipes to include the cookbook in footers
- test cookbook view

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: 12 failures, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687db500294c8326a0d32090dd9de956