### PR TITLE
Add GPT Actions landing page

### DIFF
--- a/data/static/web/chat/README.rst
+++ b/data/static/web/chat/README.rst
@@ -1,8 +1,24 @@
-Chat Actions
-------------
+GPT Actions
+-----------
 
 ``web.chat.actions`` exposes endpoints for invoking GWAY functions via ChatGPT Actions.
-Authentication uses a short passphrase printed to the server console.  Submit the phrase
+Authentication uses a short passphrase printed to the server console. Submit the phrase
 with your first request to trust the session.
 
-An audit log of all API messages can be viewed at ``/web/chat/audit-chatlog``.
+The ``GPT Actions`` home page lists available utilities in a card layout. The Audit
+Chatlog can be reached via the dedicated card.
+
+Registering the endpoint
+------------------------
+
+1. Start the web server with the actions module enabled::
+
+       gway web.app setup-app web.chat.action --home gpt-actions
+
+2. Open ``/api/web/chat/action/manifest`` and copy the URL.
+3. In ChatGPT choose **Import from URL** and paste the manifest address.
+4. Send authenticated POST requests to ``/api/web/chat/action/action``. Your first
+   call will print a passphrase in the server log—repeat the request with that
+   value in the ``trust`` field to run any action.
+
+An audit log of all API messages can still be viewed at ``/web/chat/audit-chatlog``.

--- a/projects/web/chat/action.py
+++ b/projects/web/chat/action.py
@@ -35,3 +35,7 @@ def view_trust_status(*args, **kwargs):
 
 def view_audit_chatlog(*args, **kwargs):
     return _actions().view_audit_chatlog(*args, **kwargs)
+
+
+def view_gpt_actions(*args, **kwargs):
+    return _actions().view_gpt_actions(*args, **kwargs)

--- a/projects/web/chat/actions.py
+++ b/projects/web/chat/actions.py
@@ -286,3 +286,20 @@ def view_audit_chatlog(*, page: int = 1):
         parts.append("</p>")
 
     return "".join(parts)
+
+
+def view_gpt_actions():
+    """Landing page for the ChatGPT Actions module."""
+    parts = [
+        "<link rel='stylesheet' href='/static/web/cards.css'>",
+        "<h1>GPT Actions</h1>",
+        "<div class='gw-cards'>",
+    ]
+    audit_url = gw.web.app.build_url("audit-chatlog")
+    parts.append(
+        f"<a class='gw-card' href='{audit_url}'><h2>Audit Chatlog</h2>"
+        "<p>Review API message history</p></a>"
+    )
+    parts.append("</div>")
+    parts.append(gw.web.site.view_reader(tome="web/chat/README"))
+    return "\n".join(parts)

--- a/recipes/static_site.gwr
+++ b/recipes/static_site.gwr
@@ -11,7 +11,7 @@ web app setup-app --mode manual:
     - ocpp.csms --auth required --home active-chargers
     - ocpp.evcs --auth required --home cp-simulator
     - ocpp.data --auth required --home charger-summary
-    - web.chat.action --home audit-chatlog --auth required
+    - web.chat.action --home gpt-actions --links audit-chatlog --auth required
     - games --home game-box --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
     - web.auth
 

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -12,7 +12,7 @@ web app setup:
     - vbox --home uploads
     - ocpp --auth required --home ocpp-dashboard \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
-    - web.chat.action --home audit-chatlog --auth required
+    - web.chat.action --home gpt-actions --links audit-chatlog --auth required
     - games --home game-box --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
     - web.auth
 


### PR DESCRIPTION
## Summary
- implement `view_gpt_actions` for ChatGPT Actions module
- expose new view via `web.chat.action`
- update Chat Actions documentation with registration instructions
- set GPT Actions as the default home link in recipes

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: test suite reports failures)*

------
https://chatgpt.com/codex/tasks/task_e_687dba2e7db4832688f3cd04e1b0932d