### PR TITLE
Adjust pending TODO view

### DIFF
--- a/data/static/base.css
+++ b/data/static/base.css
@@ -110,6 +110,9 @@ pre {
     font-size: 0.9em;
     line-height: 1.6;
 }
+.todo-text {
+    font-size: 0.8em;
+}
 pre code {
     background: none;
     color: inherit;

--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -814,21 +814,23 @@ def view_pending_todos():
     for proj in sorted(todos):
         html_parts.append(f"<h2>{html.escape(proj)}</h2>")
         html_parts.append(
-            "<table class='todo-table'><tr><th>Function</th><th>TODO</th><th></th></tr>"
+            "<table class='todo-table'><tr><th>Function</th><th>TODO</th></tr>"
         )
         for func, todo in todos[proj]:
             link = gw.web.app.build_url("web", "site", "help", topic=f"{proj}/{func}")
-            fb_url = gw.web.app.build_url(
-                "feedback",
-                topic=f"TODO request for {proj}.{func}",
-                message=f"Please add a TODO for {proj}.{func}"
-            )
             html_parts.append(
                 f"<tr><td><a href='{link}'>{html.escape(func)}</a></td>"
-                f"<td><pre>{html.escape(todo)}</pre></td>"
-                f"<td><a class='btn-small' href='{fb_url}'>Request TODO</a></td></tr>"
+                f"<td><pre class='todo-text'>{html.escape(todo)}</pre></td></tr>"
             )
         html_parts.append("</table>")
+
+    fb_url = gw.web.app.build_url(
+        "feedback",
+        topic="TODO request",
+        message="Please add TODOs for the listed functions"
+    )
+    html_parts.append(f"<p><a class='btn-small' href='{fb_url}'>Request TODO</a></p>")
+
     return "".join(html_parts)
 
 

--- a/tests/test_view_pending_todos.py
+++ b/tests/test_view_pending_todos.py
@@ -7,9 +7,9 @@ class ViewPendingTodosTests(unittest.TestCase):
         html = gw.web.site.view_pending_todos()
         self.assertIn('<table', html)
         self.assertIn('ocpp.rfid', html)
-        self.assertIn('?topic=ocpp.rfid%2Fauthorize_balance', html)
         self.assertIn('Request TODO', html)
-        self.assertIn('TODO+request+for+ocpp.rfid.authorize_balance', html)
+        self.assertIn('?topic=TODO+request', html)
+        self.assertEqual(html.count('Request TODO'), 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- make TODO entries slightly smaller
- consolidate "Request TODO" button at the bottom of the Pending TODOs page
- update tests for new button placement

## Testing
- `gway test --coverage` *(fails: Non-200 status code and other tests)*
- `gway test --filter view_pending_todos`

------
https://chatgpt.com/codex/tasks/task_e_687dc116b8c88326ab38b92d97f900fa