### PR TITLE
Fix cookbook link duplication

### DIFF
--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -855,6 +855,6 @@ def render_footer_links() -> str:
                 href = f"{proj_root}/{name}".strip('/')
                 label = name.replace('-', ' ').replace('_', ' ').title()
             items.append(f'<a href="/{href}">{label}</a>')
-    cookbook = gw.web.app.build_url("web", "site", "gateway-cookbook")
+    cookbook = gw.web.app.build_url("gateway-cookbook")
     items.append(f'<a href="{cookbook}">Gateway Cookbook</a>')
     return '<p class="footer-links">' + ' | '.join(items) + '</p>' if items else ""

--- a/tests/test_gateway_cookbook_link.py
+++ b/tests/test_gateway_cookbook_link.py
@@ -1,0 +1,17 @@
+import unittest
+from gway import gw
+from paste.fixture import TestApp
+
+class GatewayCookbookLinkTests(unittest.TestCase):
+    def setUp(self):
+        self.app = gw.web.app.setup_app("web.site")
+        self.client = TestApp(self.app)
+
+    def test_footer_link_points_to_cookbook(self):
+        resp = self.client.get("/web/site/reader")
+        body = resp.body.decode()
+        self.assertIn("/web/site/gateway-cookbook", body)
+        self.assertNotIn("/web/site/web/site/gateway-cookbook", body)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix cookbook footer link to avoid duplicated endpoint
- add regression test for cookbook link

## Testing
- `gway test --coverage` *(fails: 10 failed, 2 errors)*

------
https://chatgpt.com/codex/tasks/task_e_687dc0b47c648326829a975108d04135