### PR TITLE
Add Cable & Conduit calculator info column

### DIFF
--- a/data/static/awg/cable_finder.css
+++ b/data/static/awg/cable_finder.css
@@ -60,3 +60,71 @@
     }
 }
 
+/* Layout for calculator and info box */
+.calc-layout {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    position: relative;
+}
+
+.form-wrapper {
+    flex: 1 1 320px;
+    min-width: 240px;
+}
+
+.calc-info {
+    border: 1px solid #ccc;
+    padding: 0.6em 0.8em;
+    background: var(--card-bg, #fafafa);
+    flex: 1 1 220px;
+    min-width: 220px;
+    position: relative;
+}
+
+.info-toggle,
+.info-close {
+    position: absolute;
+    top: 0.4em;
+    right: 0.4em;
+    border: none;
+    background: none;
+    font-size: 1.1em;
+    cursor: pointer;
+}
+
+.info-toggle.hidden,
+.info-close.hidden {
+    display: none;
+}
+
+@media (max-width: 767px) {
+    .calc-info {
+        display: none;
+        width: 100%;
+    }
+    .calc-info.open {
+        display: block;
+        margin-top: 0.5em;
+    }
+    .info-toggle {
+        display: block;
+    }
+    .info-close {
+        display: none;
+    }
+}
+
+@media (min-width: 768px) {
+    .info-toggle,
+    .info-close {
+        display: none !important;
+    }
+    .calc-layout {
+        align-items: flex-start;
+    }
+    .calc-info {
+        display: block !important;
+    }
+}
+

--- a/data/static/awg/calc_info.js
+++ b/data/static/awg/calc_info.js
@@ -1,0 +1,18 @@
+// file: data/static/awg/calc_info.js
+window.addEventListener('DOMContentLoaded', function () {
+    var toggle = document.getElementById('info-toggle');
+    var box = document.getElementById('calc-info');
+    var close = document.getElementById('info-close');
+    if (!toggle || !box || !close) return;
+    toggle.addEventListener('click', function () {
+        box.classList.add('open');
+        toggle.classList.add('hidden');
+        close.classList.remove('hidden');
+    });
+    close.addEventListener('click', function () {
+        box.classList.remove('open');
+        toggle.classList.remove('hidden');
+        close.classList.add('hidden');
+    });
+});
+

--- a/projects/awg.py
+++ b/projects/awg.py
@@ -260,7 +260,10 @@ def view_awg_calculator(
     """Page builder for AWG calculator with HTML form and result."""
     if not meters:
         return '''<link rel="stylesheet" href="/static/awg/cable_finder.css">
+            <script src="/static/awg/calc_info.js"></script>
             <h1>Cable & Conduit Calculator</h1>
+            <div class="calc-layout">
+            <div class="form-wrapper">
             <form method="post" class="cable-form">
                 <table class="form-table two-col">
                     <tr>
@@ -347,6 +350,13 @@ def view_awg_calculator(
                     </tr>
                 </table>
             </form>
+            </div>
+            <div id="calc-info" class="calc-info">
+                <button type="button" id="info-close" class="info-close hidden">[X]</button>
+                <p>This tool helps you select cable sizes and conduit using standard AWG tables. Fill in your system details and press Calculate.</p>
+            </div>
+            <button type="button" id="info-toggle" class="info-toggle">&#128278;</button>
+            </div>
         '''
     if max_awg in (None, ""):
         max_awg = None


### PR DESCRIPTION
## Summary
- add bordered info box for AWG calculator
- hide info box on mobile with toggle button
- wire up a small JS helper for show/hide

## Testing
- `pip install -e .`
- `gway test --coverage` *(fails: Cookie jar unauthorized, theme tests and others)*

------
https://chatgpt.com/codex/tasks/task_e_687dc24d93088326b89b82671e1849f8