### PR TITLE
Fix cookbook footer link duplication

### DIFF
--- a/data/static/web/README.rst
+++ b/data/static/web/README.rst
@@ -11,6 +11,7 @@ Web Project Notes
 * When reusing `setup_app`, provide unique paths or homes to avoid collisions.
 * CLI flags resolve to a single value. Lists like ``--home a,b,c`` are not supported. Call the command once per value instead.
 * `web.site.view_reader` serves ``.md`` or ``.rst`` files from the resource root and can be used for a lightweight blog. Subfolders and hidden files are not allowed.
+* Footer links should be configured via the ``--footer`` option or template designs. Avoid editing ``render_footer_links`` directly to inject items, as that may cause duplicates like the ``Gateway Cookbook`` link.
 
 View and Render
 ---------------

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -862,6 +862,4 @@ def render_footer_links() -> str:
                 href = f"{proj_root}/{name}".strip('/')
                 label = name.replace('-', ' ').replace('_', ' ').title()
             items.append(f'<a href="/{href}">{label}</a>')
-    cookbook = gw.web.app.build_url("web", "site", "gateway-cookbook")
-    items.append(f'<a href="{cookbook}">Gateway Cookbook</a>')
     return '<p class="footer-links">' + ' | '.join(items) + '</p>' if items else ""

--- a/tests/test_gateway_cookbook_link.py
+++ b/tests/test_gateway_cookbook_link.py
@@ -4,14 +4,22 @@ from paste.fixture import TestApp
 
 class GatewayCookbookLinkTests(unittest.TestCase):
     def setUp(self):
-        self.app = gw.web.app.setup_app("web.site")
-        self.client = TestApp(self.app)
+        gw.results.clear()
+        gw.context.clear()
 
-    def test_footer_link_points_to_cookbook(self):
-        resp = self.client.get("/web/site/reader")
+    def test_footer_link_not_included_by_default(self):
+        app = gw.web.app.setup_app("web.site")
+        client = TestApp(app)
+        resp = client.get("/web/site/reader")
+        body = resp.body.decode()
+        self.assertNotIn("/web/site/gateway-cookbook", body)
+
+    def test_footer_link_added_via_option(self):
+        app = gw.web.app.setup_app("web.site", footer="gateway-cookbook")
+        client = TestApp(app)
+        resp = client.get("/web/site/reader")
         body = resp.body.decode()
         self.assertIn("/web/site/gateway-cookbook", body)
-        self.assertNotIn("/web/site/web/site/gateway-cookbook", body)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- remove hardcoded Gateway Cookbook footer link
- note how to add footer links in web project README
- update footer link test

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: test suite has errors)*

------
https://chatgpt.com/codex/tasks/task_e_687e3345eba083268efb0595e679131c