### PR TITLE
Update simulator tab UX

### DIFF
--- a/data/static/tabs.css
+++ b/data/static/tabs.css
@@ -16,18 +16,22 @@
     color: #555;
     transition: background 0.18s;
 }
-.gw-tab.active,
+.gw-tab.active {
+    background: var(--accent, #007bff);
+    color: #fff;
+    border-bottom: 1.5px solid var(--accent, #007bff);
+}
 .gw-tab:hover {
-    background: #fff;
-    color: #000;
-    border-bottom: 1.5px solid #fff;
+    background: var(--accent-alt, #2483c8);
+    color: #fff;
+    border-bottom: 1.5px solid var(--accent-alt, #2483c8);
 }
 .gw-tab-block {
     display: none;
     border: 1.5px solid #ccc;
     border-radius: 0 0 12px 12px;
     padding: 16px 18px 14px 18px;
-    background: #fff;
+    background: #000;
     margin-bottom: 20px;
 }
 .gw-tab-block.active {

--- a/projects/ocpp/evcs.py
+++ b/projects/ocpp/evcs.py
@@ -673,7 +673,12 @@ def view_cp_simulator(*args, **kwargs):
         html.append(f"<div class='sim-msg'>{msg}</div>")
 
     html.append("<div class='gw-tabs'>")
-    html.append("<div class='gw-tabs-bar'><div class='gw-tab'>CP1</div><div class='gw-tab'>CP2</div></div>")
+    html.append(
+        "<div class='gw-tabs-bar'>"
+        "<div class='gw-tab'>Primary CP</div>"
+        "<div class='gw-tab'>Secondary CP</div>"
+        "</div>"
+    )
     html.append(f"<div class='gw-tab-block'>{render_block(1)}</div>")
     html.append(f"<div class='gw-tab-block'>{render_block(2)}</div>")
     html.append("</div>")


### PR DESCRIPTION
## Summary
- style tabs so selected is highlighted and container background is black
- rename simulator tabs to **Primary CP** and **Secondary CP**

## Testing
- `gway test --coverage` *(fails: Total 51.51%)*

------
https://chatgpt.com/codex/tasks/task_e_687e5b9bf96c8326b3ca90224d61f101