### PR TITLE
Implement broken link tracker

### DIFF
--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -266,7 +266,14 @@ def setup_app(project,
 
         @app.error(404)
         def handle_404(error):
-            return gw.web.error.redirect(f"404 Not Found: {request.url}", err=error)
+            """Redirect 404 responses and log the missing URL."""
+            try:
+                gw.web.site.record_broken_link(request.url)
+            except Exception:
+                pass
+            return gw.web.error.redirect(
+                f"404 Not Found: {request.url}", err=error
+            )
     
     elif home:
         add_home(home, path, project)

--- a/tests/test_gateway_cookbook_link.py
+++ b/tests/test_gateway_cookbook_link.py
@@ -6,6 +6,8 @@ class GatewayCookbookLinkTests(unittest.TestCase):
     def setUp(self):
         gw.results.clear()
         gw.context.clear()
+        self.app = gw.web.app.setup_app("web.site")
+        self.client = TestApp(self.app)
 
     def test_footer_link_not_included_by_default(self):
         app = gw.web.app.setup_app("web.site")


### PR DESCRIPTION
## Summary
- log 404 URLs to `work/web/broken_links.txt`
- show collected links via new `view_broken_links`
- add footer link for the new view
- update tests for gateway cookbook footer
- log broken links via `gw.web.site.record_broken_link`

## Testing
- `gway test --coverage` *(fails: see below)*


------
https://chatgpt.com/codex/tasks/task_e_687e5ca1d26c8326b358fcc01d305b11