### PR TITLE
Remove TODO request option from pending list

### DIFF
--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -817,19 +817,9 @@ def view_pending_todos():
         html_parts.append("<table class='todo-table'>")
         for func, todo in todos[proj]:
             link = gw.web.app.build_url("web", "site", "help", topic=f"{proj}/{func}")
-            subject = f"TODO Request @ {proj}.{func}"
-            message = (
-                "Please add the following TODO items to the given function:\n" + todo
-            )
-            req_url = gw.web.app.build_url(
-                "feedback",
-                topic=subject,
-                message=message,
-            )
             html_parts.append(
                 f"<tr><td><a href='{link}'>{html.escape(func)}</a></td>"
-                f"<td><pre class='todo-text'>{html.escape(todo)}</pre></td>"
-                f"<td><button class='btn-small' onclick=\"location.href='{req_url}'\">Create TODO Request</button></td></tr>"
+                f"<td><pre class='todo-text'>{html.escape(todo)}</pre></td></tr>"
             )
         html_parts.append("</table>")
     return "".join(html_parts)

--- a/tests/test_view_pending_todos.py
+++ b/tests/test_view_pending_todos.py
@@ -8,9 +8,6 @@ class ViewPendingTodosTests(unittest.TestCase):
         self.assertIn('<table', html)
         self.assertIn('ocpp.rfid', html)
         self.assertNotIn('Function</th>', html)
-        self.assertIn('Create TODO Request', html)
-        self.assertIn('topic=TODO+Request+%40+ocpp.rfid', html)
-        self.assertGreaterEqual(html.count('Create TODO Request'), 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- drop the Create TODO Request button
- update tests accordingly

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: test_home_title_uses_project_name, test_links_append_to_last_home, test_repeated_project_setup_creates_clean_app, test_defaults_from_project_functions)*

------
https://chatgpt.com/codex/tasks/task_e_687e794772cc83269cff8174a434f08f