### PR TITLE
Fix OCPP dashboard link

### DIFF
--- a/projects/ocpp/ocpp.py
+++ b/projects/ocpp/ocpp.py
@@ -77,7 +77,7 @@ def view_ocpp_dashboard(**_):
     sim_running = f"CP1: {s1}<br>CP2: {s2}"
 
     links = [
-        ("CSMS Status", "/ocpp/csms/active-chargers",
+        ("CSMS Status", "/ocpp/active-chargers",
          f"Active chargers: {active}"),
         ("Charger Summary", "/ocpp/charger-summary",
          f"Chargers: {chargers}<br>Sessions: {sessions}"),


### PR DESCRIPTION
## Summary
- use the same route as the nav for "Active Chargers"

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_687e80c4488c83269a851268b5660a58