### PR TITLE
Fix nested recipe link generation

### DIFF
--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -718,20 +718,20 @@ def view_gateway_cookbook(*, recipe: str | None = None) -> str:
 
     tree: dict = {}
 
-    def insert(node: dict, parts: tuple[str, ...]):
+    def insert(node: dict, parts: tuple[str, ...], rel_path: str) -> None:
         head, *tail = parts
         if tail:
             node = node.setdefault(head, {})
-            insert(node, tuple(tail))
+            insert(node, tuple(tail), rel_path)
         else:
-            node.setdefault("_files", []).append("/".join(parts))
+            node.setdefault("_files", []).append(rel_path)
 
     for path in sorted(base_dir.rglob("*.gwr")):
         rel = path.relative_to(base_dir)
         parts = rel.parts
         if any(_is_hidden_or_private(p) for p in parts):
             continue
-        insert(tree, parts)
+        insert(tree, parts, rel.as_posix())
 
     def render(node: dict, root: bool = False) -> str:
         items = []

--- a/tests/test_gateway_cookbook.py
+++ b/tests/test_gateway_cookbook.py
@@ -1,5 +1,6 @@
 import unittest
 from gway import gw
+from paste.fixture import TestApp
 
 class GatewayCookbookTests(unittest.TestCase):
     def test_listing_includes_recipe(self):
@@ -11,6 +12,16 @@ class GatewayCookbookTests(unittest.TestCase):
         html = gw.web.site.view_gateway_cookbook(recipe='micro_blog.gwr')
         self.assertIn('micro_blog.gwr', html)
         self.assertIn('# file:', html)
+
+    def test_nested_recipe_link_in_listing(self):
+        app = gw.web.app.setup_app("web.site", footer="gateway-cookbook", home="reader")
+        client = TestApp(app)
+        resp = client.get("/web/site/gateway-cookbook")
+        body = resp.body.decode()
+        self.assertIn(
+            "/web/site/gateway-cookbook?recipe=etron%2Flocal.gwr",
+            body,
+        )
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- ensure nested cookbook recipes keep their relative path
- validate nested recipe links via tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687e835372a4832695474d29bb4868e6