### PR TITLE
Update charger state colors

### DIFF
--- a/data/static/ocpp/csms/charger_status.css
+++ b/data/static/ocpp/csms/charger_status.css
@@ -126,10 +126,10 @@
 
 /* Color stripe indicators */
 .charger-card.status-online    { border-right-color: #48e16c; }
-.charger-card.status-available { border-right-color: #48e16c; }
-.charger-card.status-error     { border-right-color: #ff3e3e; }
-.charger-card.status-offline   { border-right-color: #3a4b5c; }
-.charger-card.status-unknown   { border-right-color: #f6d94c; }
+.charger-card.status-available { border-right-color: #4cb0ff; }
+.charger-card.status-error     { border-right-color: #f6d94c; }
+.charger-card.status-offline   { border-right-color: #888; }
+.charger-card.status-unknown   { border-right-color: #ccc; }
 
 
 /* Responsive adjustments */

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -407,7 +407,7 @@ def _render_charger_card(cid, tx, state, raw_hb, *, show_controls=True):
     if state == "online":
         status = "Charging"
     elif state == "available":
-        status = "Idle"
+        status = "Available"
     elif state == "error":
         status = "Error"
     else:


### PR DESCRIPTION
## Summary
- color-code charger states in active charger view
- label idle chargers as `Available`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687e86cd3d8c83269bef664f5b9f8d7f