### PR TITLE
Improve nav bar current page handling

### DIFF
--- a/projects/web/nav.py
+++ b/projects/web/nav.py
@@ -50,13 +50,6 @@ def render(*, homes=None, links=None):
     if homes:
         for home_title, home_route in homes:
             home_routes.add(home_route.strip("/"))
-    if (
-        cookies_ok
-        and current_route not in home_routes
-        and current_route not in visited_set
-    ):
-        entries.append((current_title, current_route))
-        visited_set.add(current_route)
 
     # --- Build HTML links ---
     links_html = ""
@@ -85,7 +78,7 @@ def render(*, homes=None, links=None):
                             name.replace("-", " ").replace("_", " ").title()
                         )
                     active = (
-                        ' class="active"' if sub_route == current_route else ""
+                        ' class="current"' if sub_route == current_route else ""
                     )
                     links_html += (
                         f'<li><a href="/{sub_route}"{active}>{label}</a></li>'

--- a/tests/test_nav_links.py
+++ b/tests/test_nav_links.py
@@ -45,5 +45,26 @@ class NavLinksTests(unittest.TestCase):
         self.assertIn('/games/score', hrefs)
         self.assertIn('/games/about', hrefs)
 
+    def test_sub_link_highlight_and_no_current_page(self):
+        nav.gw.web.cookies = type('C', (), {'accepted': lambda self2: True,
+                                             'get': lambda self2, n, d=None: None})()
+        nav.gw.web.app = type('A', (), {'is_setup': lambda self2, n: True})()
+        nav.request = FakeRequest('/games/score')
+        homes = [('Game Box', 'games/game-of-life')]
+        html = nav.render(homes=homes, links={'games/game-of-life': ['score', 'about']})
+        soup = BeautifulSoup(html, 'html.parser')
+        score_links = soup.find_all('a', href='/games/score')
+        self.assertEqual(len(score_links), 1)
+        self.assertIn('current', score_links[0].get('class', []))
+
+    def test_current_page_not_added_when_missing(self):
+        nav.gw.web.cookies = type('C', (), {'accepted': lambda self2: True,
+                                             'get': lambda self2, n, d=None: None})()
+        nav.gw.web.app = type('A', (), {'is_setup': lambda self2, n: True})()
+        nav.request = FakeRequest('/unlisted/page')
+        homes = [('Game Box', 'games/game-of-life')]
+        html = nav.render(homes=homes)
+        self.assertNotIn('/unlisted/page', html)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- skip showing the active page in nav when it's not part of the nav links
- highlight sub-links using the same `current` class
- test nav bar current page behaviour and sub-link highlight

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687e8b9c5a8c832697a73a8d925e9b5f