### PR TITLE
Fix Game Box layout and rename to Toy Games

### DIFF
--- a/data/static/games/README.rst
+++ b/data/static/games/README.rst
@@ -1,4 +1,4 @@
-Game Box
---------
+Toy Games
+---------
 
 Shared helpers for simple demo games.

--- a/data/static/web/cards.css
+++ b/data/static/web/cards.css
@@ -6,6 +6,7 @@
     margin: 1em 0;
 }
 .gw-card {
+    position: relative;
     display: block;
     padding: 1em;
     border: 1px solid var(--muted, #ccc);
@@ -13,6 +14,9 @@
     background: var(--card-bg, #f9f9f9);
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
     width: 16em;
+}
+.gw-card .main-link {
+    display: block;
     text-decoration: none;
     color: inherit;
 }
@@ -22,4 +26,9 @@
 }
 .gw-card p {
     margin: .4em 0;
+}
+.gw-card .wiki {
+    position: absolute;
+    top: .5em;
+    right: .5em;
 }

--- a/projects/games/games.py
+++ b/projects/games/games.py
@@ -72,13 +72,15 @@ def view_game_box():
     """Home view listing all available games."""
     html = [
         '<link rel="stylesheet" href="/static/web/cards.css">',
-        "<h1>Game Box</h1>",
+        "<h1>Toy Games</h1>",
         "<div class='gw-cards'>",
     ]
     for title, route, desc, link in _DEF:
-        wiki = f'<a href="{link}" target="_blank" class="wiki">{WIKI_ICON}</a>'
         html.append(
-            f"<a class='gw-card' href='/games/{route}'><h2>{title}</h2><p>{desc} {wiki}</p></a>"
+            "<div class='gw-card'>"
+            f"<a href='/games/{route}' class='main-link'><h2>{title}</h2><p>{desc}</p></a>"
+            f"<a href='{link}' target='_blank' class='wiki'>{WIKI_ICON}</a>"
+            "</div>"
         )
     html.append("</div>")
     return "\n".join(html)

--- a/tests/test_nav_links.py
+++ b/tests/test_nav_links.py
@@ -36,7 +36,7 @@ class NavLinksTests(unittest.TestCase):
         nav.gw.web.cookies = self.orig_cookies
 
     def test_render_includes_project_links(self):
-        homes = [('Game Box', 'games/game-of-life')]
+        homes = [('Toy Games', 'games/game-of-life')]
         html = nav.render(homes=homes, links={'games/game-of-life': ['score', 'about']})
         soup = BeautifulSoup(html, 'html.parser')
         sub = soup.find('ul', class_='sub-links')


### PR DESCRIPTION
## Summary
- rename Game Box view to Toy Games
- keep name and explanation in the same card
- style internal wiki links inside cards
- update tests and docs

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687e8beffe4c8326b6d2ed040fe118c8