### PR TITLE
Add Fahrenheit values to AWG calculator

### DIFF
--- a/projects/awg.py
+++ b/projects/awg.py
@@ -302,9 +302,9 @@ def view_awg_calculator(
                             <label for="temperature">Temperature:</label>
                             <select id="temperature" name="temperature">
                                 <option value="auto">Auto</option>
-                                <option value="60">60C</option>
-                                <option value="75">75C</option>
-                                <option value="90">90C</option>
+                                <option value="60">60C (140F)</option>
+                                <option value="75">75C (167F)</option>
+                                <option value="90">90C (194F)</option>
                             </select>
                         </td>
                     </tr>
@@ -361,6 +361,7 @@ def view_awg_calculator(
                     <li><strong>V</strong>: volt (voltage)</li>
                     <li><strong>m</strong>: meter (length)</li>
                     <li><strong>°C</strong>: degrees Celsius</li>
+                    <li><strong>°F</strong>: degrees Fahrenheit</li>
                     <li><strong>cu</strong>: copper conductor</li>
                     <li><strong>al</strong>: aluminum conductor</li>
                 </ul>


### PR DESCRIPTION
## Summary
- show Fahrenheit equivalents for AWG calculator temperature options
- add °F definition to glossary

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687e92ad2f0083268a301c2e205d8ac5