### PR TITLE
Set Dark Materials as default navbar style

### DIFF
--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -5,7 +5,7 @@
 
 web app setup:
     - web.site --home reader --footer feedback,gateway-cookbook,pending-todos
-    - web.nav --home style-switcher
+    - web.nav --home style-switcher --default-style dark-material.css
     - web.cookies --footer cookie-jar
     - web.message
     - awg --home awg-calculator


### PR DESCRIPTION
## Summary
- tweak website recipe to default the navbar to Dark Materials

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687e91705e1883268fdf8a04194bd874