### PR TITLE
Adjust AWG calculator defaults and button style

### DIFF
--- a/data/static/awg/README.rst
+++ b/data/static/awg/README.rst
@@ -44,8 +44,7 @@ Parameters
 ``phases``
   ``1`` or ``3`` phase AC systems (``2`` is treated as two phases).
 ``temperature``
-  Conductor temperature rating: ``60``/``75``/``90`` or ``None`` for automatic
-  selection.
+  Conductor temperature rating: ``60``/``75``/``90``. Default is ``60``.
 ``conduit``
   If provided the result includes the minimum trade size for ``emt``, ``imc``,
   ``rmc`` or ``fmc`` conduit.

--- a/data/static/awg/cable_finder.css
+++ b/data/static/awg/cable_finder.css
@@ -28,8 +28,8 @@
 }
 .cable-form button.submit {
     width: 100%;
-    padding: 4px 6px;
-    font-size: 1em;
+    padding: 6px 6px;
+    font-size: 1.1em;
     box-sizing: border-box;
 }
 .warning {

--- a/projects/awg.py
+++ b/projects/awg.py
@@ -254,7 +254,7 @@ def find_conduit(awg, cables, *, conduit="emt"):
 
 def view_awg_calculator(
     *, meters=None, amps="40", volts="220", material="cu",
-    max_lines="1", max_awg=None, phases="1", temperature=None,
+    max_lines="1", max_awg=None, phases="1", temperature="60",
     conduit=None, ground="1", neutral="0", **kwargs
 ):
     """Page builder for AWG calculator with HTML form and result."""
@@ -301,8 +301,7 @@ def view_awg_calculator(
                         <td>
                             <label for="temperature">Temperature:</label>
                             <select id="temperature" name="temperature">
-                                <option value="auto">Auto</option>
-                                <option value="60">60C (140F)</option>
+                                <option value="60" selected>60C (140F)</option>
                                 <option value="75">75C (167F)</option>
                                 <option value="90">90C (194F)</option>
                             </select>


### PR DESCRIPTION
## Summary
- default AWG calculator temperature to 60°C
- remove Auto temperature option
- enlarge Calculate button
- document new temperature behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687e953fa8b08326845bb41e9e362dc6