### PR TITLE
Replace deprecated gw.halt helper

### DIFF
--- a/projects/cdv.py
+++ b/projects/cdv.py
@@ -59,7 +59,7 @@ def load_all(pathlike: str) -> dict[str, dict[str, str]]:
         path = _resolve_path(pathlike)
         return _read_table(path)
     except Exception as e:
-        gw.halt(f"Failed to read table '{pathlike}': {e}")
+        gw.abort(f"Failed to read table '{pathlike}': {e}")
 
 
 def update(table_path: str, entry_id: str, **fields):

--- a/projects/ocpp/evcs.py
+++ b/projects/ocpp/evcs.py
@@ -165,7 +165,7 @@ def simulate(
                 while any(t.is_alive() for t in threads_list):
                     await asyncio.sleep(0.5)
             except asyncio.CancelledError:
-                gw.halt("[Simulator] Orchestration cancelled.")
+                gw.abort("[Simulator] Orchestration cancelled.")
             for t in threads_list:
                 t.join()
         state["last_status"] = "Simulator finished."

--- a/projects/odoo.py
+++ b/projects/odoo.py
@@ -30,7 +30,7 @@ def execute_kw(*args, model: str, method: str, **kwargs) -> dict:
 
     gw.info(f"Odoo Execute: {model=} {method=} @ {url=} {db_name=} {username=}")
     if url.startswith("[") or "ODOO_BASE_URL" in url:
-        gw.halt("Odoo XML-RPC url not configured. Please set ODOO_BASE_URL correctly.")
+        gw.abort("Odoo XML-RPC url not configured. Please set ODOO_BASE_URL correctly.")
     try:
         common_client = client.ServerProxy(f"{url}/xmlrpc/2/common")
     except Exception as e:

--- a/tests/test_abort.py
+++ b/tests/test_abort.py
@@ -1,0 +1,24 @@
+import os
+import unittest
+from gway import gw
+
+odoo = gw.load_project("odoo")
+
+class AbortTests(unittest.TestCase):
+    def test_execute_kw_abort_on_bad_url(self):
+        old_url = os.environ.get("ODOO_BASE_URL")
+        os.environ["ODOO_BASE_URL"] = "[ODOO_BASE_URL]"
+        os.environ.setdefault("ODOO_DB_NAME", "db")
+        os.environ.setdefault("ODOO_ADMIN_USER", "user")
+        os.environ.setdefault("ODOO_ADMIN_PASSWORD", "pass")
+        try:
+            with self.assertRaises(SystemExit):
+                odoo.execute_kw(model="res.partner", method="read")
+        finally:
+            if old_url is None:
+                os.environ.pop("ODOO_BASE_URL", None)
+            else:
+                os.environ["ODOO_BASE_URL"] = old_url
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use `gw.abort` instead of removed `gw.halt`
- cover abort path for `odoo.execute_kw`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687ea7d0a1048326884ac133253dcaf8