### PR TITLE
Fix stale charger state

### DIFF
--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -52,6 +52,11 @@ def setup_app(*,
             _is_new_app = app is None or not isinstance(app, _FastAPI)
     if _is_new_app:
         app = _FastAPI()
+        # Reset lingering connection states
+        try:
+            gw.ocpp.data.reset_connections()
+        except Exception as exc:
+            gw.warn(f"[OCPP] Failed to reset connections: {exc}")
 
     validator = None
     if isinstance(authorize, str):

--- a/projects/ocpp/data.py
+++ b/projects/ocpp/data.py
@@ -316,6 +316,15 @@ def get_active_chargers() -> list[str]:
     )
     return [r[0] for r in rows]
 
+def reset_connections():
+    """Mark all chargers as disconnected on startup."""
+    gw.sql.model(CONNECTIONS, project="ocpp")
+    conn = gw.sql.open_db(project="ocpp")
+    gw.sql.execute(
+        "UPDATE connections SET connected=0",
+        connection=conn,
+    )
+
 def get_meter_values(charger_id: str, transaction_id: int):
     conn = gw.sql.open_db(project="ocpp")
     rows = gw.sql.execute(


### PR DESCRIPTION
## Summary
- reset OCPP connection states when csms app starts
- add helper to mark all chargers as disconnected

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687eb2865ca483268583cc9b32a19a85