### PR TITLE
Fix evcs thread interrupt handling and cleanup import

### DIFF
--- a/projects/ocpp/evcs.py
+++ b/projects/ocpp/evcs.py
@@ -509,6 +509,9 @@ def _run_simulator_thread(cp_idx, params):
             asyncio.set_event_loop(loop)
             loop.run_until_complete(coro)
         state["last_status"] = "Simulator finished."
+    except KeyboardInterrupt as e:
+        state["last_status"] = "Error"
+        state["last_error"] = f"{e}\n{traceback.format_exc()}"
     except Exception as e:
         state["last_status"] = "Error"
         state["last_error"] = f"{e}\n{traceback.format_exc()}"

--- a/projects/web/server.py
+++ b/projects/web/server.py
@@ -1,7 +1,6 @@
 # file: projects/web/server.py
 
 import socket
-from numpy import iterable
 from gway import gw, __
 
 # Registry for active apps and their hosts/ports


### PR DESCRIPTION
## Summary
- clean unused import in web server module
- keep simulator thread from killing the main process on Ctrl+C

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687ec06055e483268d74611755f9c370