### PR TITLE
Rename game-box view to toy-games

### DIFF
--- a/projects/games/games.py
+++ b/projects/games/games.py
@@ -68,7 +68,7 @@ _DEF = [
 ]
 
 
-def view_game_box():
+def view_toy_games():
     """Home view listing all available games."""
     html = [
         '<link rel="stylesheet" href="/static/web/cards.css">',

--- a/recipes/static_site.gwr
+++ b/recipes/static_site.gwr
@@ -12,7 +12,7 @@ web app setup-app --mode manual:
     - ocpp.evcs --auth required --home cp-simulator
     - ocpp.data --auth required --home charger-summary
     - web.chat.action --home gpt-actions --links audit-chatlog --auth required
-    - games --home game-box --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
+    - games --home toy-games --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
     - web.auth
 
 help-db build

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -13,7 +13,7 @@ web app setup:
     - vbox --home uploads
     - ocpp --home ocpp-dashboard \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
-    - games --home game-box --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
+    - games --home toy-games --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
     - web.auth
 
 help-db build

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -13,7 +13,7 @@ web app setup:
     - ocpp --auth required --home ocpp-dashboard \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - web.chat.action --home gpt-actions --links audit-chatlog --auth required
-    - games --home game-box --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
+    - games --home toy-games --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
     - web.auth
 
 help-db build

--- a/tests/test_nav_links.py
+++ b/tests/test_nav_links.py
@@ -50,7 +50,7 @@ class NavLinksTests(unittest.TestCase):
                                              'get': lambda self2, n, d=None: None})()
         nav.gw.web.app = type('A', (), {'is_setup': lambda self2, n: True})()
         nav.request = FakeRequest('/games/score')
-        homes = [('Game Box', 'games/game-of-life')]
+        homes = [('Toy Games', 'games/game-of-life')]
         html = nav.render(homes=homes, links={'games/game-of-life': ['score', 'about']})
         soup = BeautifulSoup(html, 'html.parser')
         score_links = soup.find_all('a', href='/games/score')
@@ -62,7 +62,7 @@ class NavLinksTests(unittest.TestCase):
                                              'get': lambda self2, n, d=None: None})()
         nav.gw.web.app = type('A', (), {'is_setup': lambda self2, n: True})()
         nav.request = FakeRequest('/unlisted/page')
-        homes = [('Game Box', 'games/game-of-life')]
+        homes = [('Toy Games', 'games/game-of-life')]
         html = nav.render(homes=homes)
         self.assertNotIn('/unlisted/page', html)
 


### PR DESCRIPTION
## Summary
- rename `view_game_box` -> `view_toy_games`
- update website recipes to use toy-games as home
- adjust nav link tests to match new page title

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687ec116d5408326a0f7447c55e09324