### PR TITLE
Add simple block strategy to Four in a Row

### DIFF
--- a/data/static/games/four_in_a_row/README.rst
+++ b/data/static/games/four_in_a_row/README.rst
@@ -37,6 +37,7 @@ Pseudo code::
 
 Use the cookie key ``fiar_board`` (expiry e.g. two weeks). When loading the
 page, decode the cookie value to restore the board. Player moves are triggered
-by clicking a column with an open slot. After the player's drop, generate a
-random legal column for the computer and store the updated board back in the
-cookie.
+by clicking a column with an open slot. After the player's drop, the computer
+first checks if that move created a threat of an immediate win on the next
+turn. If so it blocks that column, otherwise it selects a random legal column
+and stores the updated board back in the cookie.

--- a/projects/games/four_in_a_row.py
+++ b/projects/games/four_in_a_row.py
@@ -75,7 +75,16 @@ def view_four_in_a_row(*, board=None, col=None, reset=None):
                 # computer move
                 choices = [c for c in range(COLS) if board_state[0][c] == 0]
                 if choices:
-                    _drop(board_state, random.choice(choices), 2)
+                    block_col = None
+                    for c in choices:
+                        temp = [row[:] for row in board_state]
+                        _drop(temp, c, 1)
+                        if _check_win(temp, 1):
+                            block_col = c
+                            break
+
+                    computer_col = block_col if block_col is not None else random.choice(choices)
+                    _drop(board_state, computer_col, 2)
                     if _check_win(board_state, 2):
                         message = "Computer wins!"
                         game_over = True


### PR DESCRIPTION
## Summary
- add a check for imminent player wins in Four in a Row
- update game docs to mention the blocking behaviour

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687ec2aa090483269fc619f8bca1833d