### PR TITLE
Add kiosk project for Windows web apps

### DIFF
--- a/data/static/kiosk/README.rst
+++ b/data/static/kiosk/README.rst
@@ -1,0 +1,26 @@
+Kiosk Project
+-------------
+
+The ``kiosk`` project launches a minimal browser window on Windows.
+Use it to present a local web application without any browser chrome.
+
+Usage
+=====
+
+From a recipe::
+
+    kiosk show --url http://127.0.0.1:8888
+
+Parameters
+==========
+
+``url``
+  Full address to load. If omitted, ``host`` and ``port`` are used.
+``host``
+  Host name when constructing the URL, default ``0.0.0.0``.
+``port``
+  Port number when constructing the URL, default ``8888``.
+``width`` and ``height``
+  Window dimensions in pixels.
+``fullscreen``
+  If ``True`` the window occupies the entire screen.

--- a/projects/kiosk/__init__.py
+++ b/projects/kiosk/__init__.py
@@ -1,0 +1,5 @@
+"""Simple kiosk-style browser window launcher."""
+
+from .window import show
+
+__all__ = ["show"]

--- a/projects/kiosk/window.py
+++ b/projects/kiosk/window.py
@@ -1,0 +1,47 @@
+"""Launch a minimal browser window on Windows using ``pywebview``."""
+
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+from gway import __, gw
+
+
+def show(
+    *,
+    url: Optional[str] = None,
+    host: str = __("[SITE_HOST]", "0.0.0.0"),
+    port: int = __('[SITE_PORT]', '8888'),
+    width: int = 1024,
+    height: int = 768,
+    fullscreen: bool = False,
+) -> None:
+    """Open ``url`` in a borderless window.
+
+    Parameters
+    ----------
+    url:
+        Full address to load. Defaults to ``http://{host}:{port}``.
+    host, port:
+        Used when ``url`` is not provided.
+    width, height:
+        Window size when ``fullscreen`` is ``False``.
+    fullscreen:
+        Launch the window in kiosk mode.
+    """
+    target = url or f"http://{host}:{port}"
+    gw.verbose(f"[kiosk] Opening {target}")
+
+    import webview
+
+    webview.create_window(
+        "App",
+        url=target,
+        width=width,
+        height=height,
+        frameless=True,
+        resizable=False,
+        fullscreen=fullscreen,
+    )
+    webview.start(gui="edgechromium" if sys.platform == "win32" else None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Software Project Infrastructure by https://www.gelectriic.com"
 requires-python = ">=3.10"
 license = "MIT"
 classifiers = [ "Programming Language :: Python :: 3", "Operating System :: OS Independent",]
-dependencies = [ "toml", "setuptools", "twine", "build", "colorama", "bottle", "paste", "requests", "dateparser", "fastapi", "uvicorn", "docutils", "croniter", "qrcode[pil]", "cryptography", "jinja2", "pygame", "python-multipart", "httpx", "websockets", "pyperclip; platform_system == \"Windows\"", "plyer", "numpy", "pygetwindow; platform_system == \"Windows\"", "duckdb", "pywin32; platform_system == \"Windows\"", "selenium", "webdriver-manager", "bs4", "markdown", "pandas", "openpyxl", "coverage", "argcomplete", "PyJWT", "sounddevice", "PyYAML",]
+dependencies = [ "toml", "setuptools", "twine", "build", "colorama", "bottle", "paste", "requests", "dateparser", "fastapi", "uvicorn", "docutils", "croniter", "qrcode[pil]", "cryptography", "jinja2", "pygame", "python-multipart", "httpx", "websockets", "pyperclip; platform_system == \"Windows\"", "plyer", "numpy", "pygetwindow; platform_system == \"Windows\"", "duckdb", "pywin32; platform_system == \"Windows\"", "selenium", "webdriver-manager", "bs4", "markdown", "pandas", "openpyxl", "coverage", "argcomplete", "PyJWT", "sounddevice", "PyYAML", "pywebview; platform_system == \"Windows\"",]
 [[project.authors]]
 name = "Rafael J. Guillén-Osorio"
 email = "tecnologia@gelectriic.com"

--- a/recipes/kiosk.gwr
+++ b/recipes/kiosk.gwr
@@ -1,0 +1,3 @@
+# file: recipes/kiosk.gwr
+
+kiosk show --url http://127.0.0.1:8888 --width 1024 --height 768

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,3 +35,4 @@ argcomplete
 PyJWT
 sounddevice
 PyYAML
+pywebview; platform_system == "Windows"


### PR DESCRIPTION
## Summary
- create `kiosk` project to show a frameless webview
- document usage in project README
- provide example recipe
- include `pywebview` as optional Windows dependency

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_687ecd27c4d48326aa6e7c2db870a853