### PR TITLE
Fix CP simulator recipe

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -12,7 +12,9 @@ The submodules are:
 The landing page ``/ocpp/ocpp-dashboard`` shows a quick summary of these
 sub‑projects. When mounting the dashboard with ``web.app.setup_app`` the CSMS
 views and renders are discovered automatically because sub‑projects are treated
-as delegate modules under the ``/ocpp`` path.
+as delegate modules under the ``/ocpp`` path. To expose each sub‑project under
+its own route (for example ``/ocpp/evcs/cp-simulator``) pass ``--everything`` to
+``web.app.setup_app`` or register the sub‑projects explicitly.
 
 Launch a simulator session pointing at your CSMS with:
 

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -11,7 +11,7 @@ web app setup:
     - web.message
     - web.chat
     - vbox --home uploads
-    - ocpp --home ocpp-dashboard \
+    - ocpp --home ocpp-dashboard --everything \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - games --home toy-games --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
     - web.auth

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -10,7 +10,7 @@ web app setup:
     - web.message
     - awg --home awg-calculator
     - vbox --home uploads
-    - ocpp --auth required --home ocpp-dashboard \
+    - ocpp --auth required --home ocpp-dashboard --everything \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - web.chat.action --home gpt-actions --links audit-chatlog --auth required
     - games --home toy-games --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client


### PR DESCRIPTION
## Summary
- mount the ocpp.evcs subproject when launching the demo site
- clarify README that `--everything` is needed to expose subproject routes

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687ed7a8bc588326a959e525c29e0b18