### PR TITLE
Prevent projects dir pollution during tests

### DIFF
--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -84,11 +84,18 @@ class GatewayTests(unittest.TestCase):
             wrapped()
 
     def test_find_project_returns_first(self):
-        project = gw.find_project("does.not.exist", "studio.qr")
-        self.assertIsNotNone(project)
-        self.assertTrue(hasattr(project, "generate_url"))
-        none_proj = gw.find_project("nope1", "nope2")
-        self.assertIsNone(none_proj)
+        from pathlib import Path
+        from unittest.mock import patch
+
+        def fake_resource(*parts, **kw):
+            return Path().joinpath(*parts)
+
+        with patch.object(gw, "resource", fake_resource):
+            project = gw.find_project("does.not.exist", "studio.qr")
+            self.assertIsNotNone(project)
+            self.assertTrue(hasattr(project, "generate_url"))
+            none_proj = gw.find_project("nope1", "nope2")
+            self.assertIsNone(none_proj)
 
     def test_prefixes_constant_available(self):
         self.assertIsInstance(gw.prefixes, tuple)


### PR DESCRIPTION
## Summary
- patch `test_find_project_returns_first` to avoid creating directories

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687edeb98294832696cc12e6c38b5949