### PR TITLE
Add RFID record management utilities

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -115,3 +115,9 @@ RFID access entries are stored in ``work/ocpp/rfids.cdv``. Open
 ``/ocpp/manage-rfids`` in your browser to edit these records. The page lists
 all tags with their balance and ``allowed`` flag so you can quickly update,
 credit or delete entries and add new ones.
+
+The ``ocpp.rfid`` module also exposes helper functions to manage the table
+programmatically.  Use ``create_entry`` to add a tag, ``update_entry`` to
+modify fields, ``delete_entry`` to remove a tag and ``enable`` or ``disable``
+to toggle the ``allowed`` flag.  Balances can be adjusted via ``credit`` and
+``debit`` which operate on the ``balance`` field.

--- a/projects/ocpp/rfid.py
+++ b/projects/ocpp/rfid.py
@@ -1,5 +1,14 @@
 # file: projects/ocpp/rfid.py
-"""Authorization helpers for OCPP RFID transactions."""
+"""RFID authorization and management helpers.
+
+This module validates ``Authorize`` requests from charge points and
+stores RFID information in ``work/ocpp/rfids.cdv`` using the colon
+delimited value (CDV) helpers.  In addition to the validators it also
+provides convenience functions to manage RFID records:
+
+``create_entry``\ , ``update_entry``\ , ``delete_entry``\ , ``enable``\ ,
+``disable``\ , ``credit`` and ``debit``.
+"""
 
 import traceback
 from gway import gw
@@ -48,8 +57,6 @@ def authorize_allowed(*, payload=None, charger_id=None, action=None, table=RFID_
         return False
     return str(record.get("allowed", "true")).lower() not in {"false", "0", "no", "off", ""}
     
-# TODO: Create functions to manually create RFID entries, delete them, update them, enable, disable, credit and debit
-
 def create_entry(rfid, *, balance=0.0, allowed=True, table=RFID_TABLE, **fields):
     """Create or replace an RFID record."""
     fields.setdefault("balance", str(balance))

--- a/tests/test_rfid.py
+++ b/tests/test_rfid.py
@@ -1,0 +1,46 @@
+import unittest
+import os
+from gway import gw
+
+# Load the project to access helper functions
+gw.load_project("ocpp.rfid")
+import ocpp_rfid
+
+class RFIDHelperTests(unittest.TestCase):
+    TABLE = "work/test_rfids.cdv"
+
+    def setUp(self):
+        path = gw.resource(self.TABLE)
+        if os.path.exists(path):
+            os.remove(path)
+
+    def tearDown(self):
+        path = gw.resource(self.TABLE)
+        if os.path.exists(path):
+            os.remove(path)
+
+    def test_basic_entry_cycle(self):
+        ocpp_rfid.create_entry("TAG1", balance=10, allowed=True, user="foo", table=self.TABLE)
+        recs = gw.cdv.load_all(self.TABLE)
+        self.assertEqual(recs["TAG1"].get("balance"), "10")
+        self.assertEqual(recs["TAG1"].get("user"), "foo")
+        self.assertEqual(recs["TAG1"].get("allowed"), "True")
+
+        ocpp_rfid.update_entry("TAG1", table=self.TABLE, user="bar")
+        self.assertEqual(gw.cdv.load_all(self.TABLE)["TAG1"].get("user"), "bar")
+
+        ocpp_rfid.disable("TAG1", table=self.TABLE)
+        self.assertEqual(gw.cdv.load_all(self.TABLE)["TAG1"].get("allowed"), "False")
+        ocpp_rfid.enable("TAG1", table=self.TABLE)
+        self.assertEqual(gw.cdv.load_all(self.TABLE)["TAG1"].get("allowed"), "True")
+
+        self.assertTrue(ocpp_rfid.credit("TAG1", 5, table=self.TABLE))
+        self.assertEqual(gw.cdv.load_all(self.TABLE)["TAG1"].get("balance"), "15.0")
+        self.assertTrue(ocpp_rfid.debit("TAG1", 3, table=self.TABLE))
+        self.assertEqual(gw.cdv.load_all(self.TABLE)["TAG1"].get("balance"), "12.0")
+
+        ocpp_rfid.delete_entry("TAG1", table=self.TABLE)
+        self.assertEqual(gw.cdv.load_all(self.TABLE), {})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- document RFID management helpers
- expand RFID module docstring
- add helpers for managing RFID table (create/update/delete/etc)
- test RFID helper functions

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687edef2b5188326b4ed79ad2f143952