### PR TITLE
Add view interface for GIF animator

### DIFF
--- a/projects/studio/screen.py
+++ b/projects/studio/screen.py
@@ -401,3 +401,36 @@ def _display_and_save(pil_images, frame_files, output_gif):
     )
     print(f"Saved GIF → {output_gif}")
 
+
+def view_animate_gif(*, pattern: str = None, output_gif: str = None):
+    """Simple web form to run :func:`animate_gif`."""
+    from bottle import request
+    import html
+
+    msg = ""
+    if request.method == "POST":
+        pattern = request.forms.get("pattern") or pattern
+        output_gif = request.forms.get("output_gif") or output_gif
+        if not pattern:
+            msg = "<p class='error'>Pattern is required.</p>"
+        else:
+            try:
+                result = animate_gif(pattern, output_gif=output_gif)
+                msg = f"<p>Saved GIF to {html.escape(result)}</p>"
+            except Exception as exc:
+                gw.exception(exc)
+                msg = f"<p class='error'>Error: {html.escape(str(exc))}</p>"
+
+    pattern_val = html.escape(pattern or "")
+    output_val = html.escape(output_gif or "")
+
+    return (
+        "<h1>Animate GIF</h1>"
+        f"{msg}"
+        "<form method='post'>"
+        f"<input name='pattern' placeholder='Pattern' required value='{pattern_val}'> "
+        f"<input name='output_gif' placeholder='Output GIF' value='{output_val}'> "
+        "<button type='submit'>Animate</button>"
+        "</form>"
+    )
+

--- a/projects/studio/studio.py
+++ b/projects/studio/studio.py
@@ -1,0 +1,30 @@
+from gway import gw
+
+
+def view_studio_bench(*, _title="Studio Bench", **_):
+    """Landing page listing available Studio web views."""
+    links = [
+        (
+            "Animate GIF",
+            gw.web.build_url("studio.screen", "animate-gif"),
+            "Convert image frames into a GIF",
+        ),
+    ]
+    html = ["<h1>Studio Bench</h1>"]
+    html.append(
+        "<style>"
+        ".studio-cards{display:flex;flex-wrap:wrap;gap:1em;margin:1em 0;}"
+        ".studio-card{display:block;padding:1em;border:1px solid var(--muted,#ccc);"
+        "border-radius:8px;background:var(--card-bg,#f9f9f9);width:16em;"
+        "text-decoration:none;color:inherit;}"
+        ".studio-card h2{margin-top:0;font-size:1.2em;}"
+        ".studio-card p{margin:.4em 0;}"
+        "</style>"
+    )
+    html.append("<div class='studio-cards'>")
+    for label, url, info in links:
+        html.append(
+            f"<a class='studio-card' href='{url}'><h2>{label}</h2><p>{info}</p></a>"
+        )
+    html.append("</div>")
+    return "\n".join(html)

--- a/tests/test_view_animate_gif.py
+++ b/tests/test_view_animate_gif.py
@@ -1,0 +1,28 @@
+import unittest
+from gway import gw
+from paste.fixture import TestApp
+from unittest.mock import patch
+
+class ViewAnimateGifTests(unittest.TestCase):
+    def setUp(self):
+        self.app = gw.web.app.setup_app("studio.screen")
+        self.client = TestApp(self.app)
+
+    def test_post_triggers_animation(self):
+        import importlib
+        screen_mod = importlib.import_module(
+            gw.studio.screen.animate_gif.__module__
+        )
+        with patch.object(screen_mod, "animate_gif", return_value="/tmp/out.gif") as ag, \
+             patch.object(gw.web.app, "render_template", lambda **kw: kw["content"]):
+            resp = self.client.post(
+                "/studio/screen/animate-gif",
+                {"pattern": "frames", "output_gif": "result.gif"},
+            )
+        self.assertEqual(resp.status, 200)
+        text = resp.body.decode()
+        self.assertIn("result.gif", text)
+        ag.assert_called_once_with("frames", output_gif="result.gif")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_view_studio_bench.py
+++ b/tests/test_view_studio_bench.py
@@ -1,0 +1,21 @@
+import unittest
+from gway import gw
+from paste.fixture import TestApp
+from unittest.mock import patch
+
+
+class ViewStudioBenchTests(unittest.TestCase):
+    def setUp(self):
+        self.app = gw.web.app.setup_app("studio.studio")
+        self.client = TestApp(self.app)
+
+    def test_bench_lists_subviews(self):
+        with patch.object(gw.web.app, "render_template", lambda **kw: kw["content"]):
+            resp = self.client.get("/studio/studio/studio-bench")
+        self.assertEqual(resp.status, 200)
+        text = resp.body.decode()
+        self.assertIn("/studio/screen/animate-gif", text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add new `view_animate_gif` page under `studio.screen`
- expose new view via `view_studio_bench` landing page
- exercise both views via tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_687ee0485ad08326b1f26f0f5b2f89ff