### PR TITLE
Add CP simulator start test

### DIFF
--- a/tests/test_evcs_view.py
+++ b/tests/test_evcs_view.py
@@ -1,6 +1,8 @@
 import unittest
 from gway import gw
 from paste.fixture import TestApp
+from unittest.mock import patch
+from importlib import import_module
 
 class EvcsViewTests(unittest.TestCase):
     def setUp(self):
@@ -12,6 +14,20 @@ class EvcsViewTests(unittest.TestCase):
         self.assertEqual(resp.status, 200)
         text = resp.body.decode()
         self.assertIn('<h1>OCPP Charge Point Simulator</h1>', text)
+
+    def test_cp_simulator_start_action(self):
+        """Starting the simulator via POST should call _start_simulator."""
+        # Ensure the module is loaded so patching succeeds
+        import_module('ocpp_evcs')
+        with patch('ocpp_evcs._start_simulator', return_value=True) as start:
+            resp = self.client.post('/ocpp/evcs/cp-simulator', {
+                'cp': '1',
+                'action': 'start',
+            })
+        self.assertEqual(resp.status, 200)
+        text = resp.body.decode()
+        self.assertIn('CP1 started.', text)
+        start.assert_called_once()
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_gateway_cookbook.py
+++ b/tests/test_gateway_cookbook.py
@@ -5,12 +5,12 @@ from paste.fixture import TestApp
 class GatewayCookbookTests(unittest.TestCase):
     def test_listing_includes_recipe(self):
         html = gw.web.site.view_gateway_cookbook()
-        self.assertIn('Micro Blog', html)
+        self.assertIn('Midblog', html)
         self.assertIn('Gateway Cookbook', html)
 
     def test_recipe_view_renders(self):
-        html = gw.web.site.view_gateway_cookbook(recipe='micro_blog.gwr')
-        self.assertIn('micro_blog.gwr', html)
+        html = gw.web.site.view_gateway_cookbook(recipe='midblog.gwr')
+        self.assertIn('midblog.gwr', html)
         self.assertIn('# file:', html)
 
     def test_nested_recipe_link_in_listing(self):


### PR DESCRIPTION
## Summary
- add test for CP simulator Start action
- update cookbook tests to use `midblog.gwr`

## Testing
- `gway test --filter evcs_view`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687ef978e73483269de45c61b5ee9310