### PR TITLE
Track which functions are tested

### DIFF
--- a/gway/builtins/help_utils.py
+++ b/gway/builtins/help_utils.py
@@ -48,7 +48,9 @@ def help(*args, full: bool = False, list_flags: bool = False):
 
     conn = gw.sql.open_db(db_path, row_factory=True)
     try:
-        conn.cursor().execute("SELECT 1 FROM param_types LIMIT 1")
+        cur0 = conn.cursor()
+        cur0.execute("SELECT 1 FROM param_types LIMIT 1")
+        cur0.execute("SELECT tests FROM help LIMIT 1")
     except sqlite3.OperationalError:
         gw.help_db.build(update=True)
         gw.sql.close_connection(datafile=db_path)
@@ -146,6 +148,9 @@ def help(*args, full: bool = False, list_flags: bool = False):
                 )
                 if cur.fetchone():
                     entry["Provides"] = r_row["type"]
+            tests_raw = row["tests"].strip() if row["tests"] else ""
+            tests_list = [t for t in tests_raw.splitlines() if t.strip()]
+            entry["Tests"] = tests_list if tests_list else ["No tests found"]
             if full:
                 entry["Full Code"] = row["source"]
             else:

--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -447,6 +447,10 @@ def _render_help_section(info, use_query_links=False, highlight=False, *args, **
         elif key in ("Docstring", "TODOs"):
             value = f"<div class='doc'>{html.escape(str(value))}</div>"
 
+        elif key == "Tests" and isinstance(value, list):
+            items = ''.join(f"<li>{html.escape(str(v))}</li>" for v in value)
+            value = f"<ul class='test-list'>{items}</ul>"
+
         # Only for regular text fields, run _autolink_refs
         elif use_query_links and isinstance(value, str):
             value = _autolink_refs(value)


### PR DESCRIPTION
## Summary
- scan test suite during help_db build
- store test references in help table
- expose test references via `gw.help`
- render test references in the HTML help view
- rebuild DB if `tests` column missing

## Testing
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_687f92e1181c83268cab92334ff7d04f