### PR TITLE
Add test for skeleton recipe nav top

### DIFF
--- a/tests/test_nav_top.py
+++ b/tests/test_nav_top.py
@@ -25,6 +25,37 @@ class NavTopTests(unittest.TestCase):
         finally:
             gw.web.nav.setup_app(side=old_side)
 
+    def test_skeleton_recipe_sets_nav_top(self):
+        from gway.console import load_recipe, process
+        import sys
+
+        # Ensure nav module is loaded and store state for restoration
+        _ = gw.web.nav.side()
+        old_module = sys.modules['web_nav']
+        old_side = old_module._side
+        old_cache = gw._cache.get('web.nav')
+
+        try:
+            cmds, _ = load_recipe('skeleton.gwr')
+            with patch.object(gw.web.server, 'start_app'), \
+                 patch.object(gw, 'until'), \
+                 patch.object(gw.web.static, 'collect'), \
+                 patch.object(gw.help_db, 'build'):
+                process(cmds)
+
+            nav_mod = sys.modules['web_nav']
+            self.assertEqual(nav_mod._side, 'top')
+            with patch.object(nav_mod, 'request', FakeRequest()):
+                html = nav_mod.render(homes=[('Home', 'web/site')],
+                                      links={'web/site': ['about']})
+            self.assertIn('<nav', html)
+            self.assertIn('top-bar', html)
+            self.assertNotIn('<aside', html)
+        finally:
+            sys.modules['web_nav'] = old_module
+            old_module._side = old_side
+            gw._cache['web.nav'] = old_cache
+
 if __name__ == '__main__':
     unittest.main()
 


### PR DESCRIPTION
## Summary
- ensure skeleton recipe sets web.nav side to top
- verify rendered HTML uses top-bar nav layout

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_687f990784ac8326a2642271e9ab6616