### PR TITLE
Fix data editor path validation

### DIFF
--- a/projects/cdv.py
+++ b/projects/cdv.py
@@ -286,6 +286,8 @@ def view_data_editor(*, cdv: str = None, text: str = None):
     cdv_safe = _sanitize_cdv_path(cdv)
     try:
         path = gw.resource(*cdv_safe.split("/"))
+        if os.path.isdir(path):
+            raise IsADirectoryError(path)
     except Exception as e:
         return f"<p>Invalid CDV path: {html.escape(str(e))}</p>"
 


### PR DESCRIPTION
## Summary
- treat directory paths as invalid in the CDV data editor

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_687f99a897588326b7d94473263a5648