### PR TITLE
Handle simulator start errors

### DIFF
--- a/projects/ocpp/evcs.py
+++ b/projects/ocpp/evcs.py
@@ -588,12 +588,20 @@ def view_cp_simulator(*args, _title="CP Simulator", **kwargs):
                 username=request.forms.get("username") or None,
                 password=request.forms.get("password") or None,
             )
-            started = _start_simulator(sim_params, cp=cp_idx)
-            msg = f"CP{cp_idx} started." if started else f"CP{cp_idx} already running."
+            try:
+                started = _start_simulator(sim_params, cp=cp_idx)
+                msg = (
+                    f"CP{cp_idx} started." if started else f"CP{cp_idx} already running."
+                )
+            except Exception as exc:  # pragma: no cover - unexpected
+                msg = f"Failed to start CP{cp_idx}: {exc}"
         elif action == "stop":
             cp_idx = int(request.forms.get("cp") or 1)
-            _stop_simulator(cp=cp_idx)
-            msg = f"CP{cp_idx} stop requested."
+            try:
+                _stop_simulator(cp=cp_idx)
+                msg = f"CP{cp_idx} stop requested."
+            except Exception as exc:  # pragma: no cover - unexpected
+                msg = f"Failed to stop CP{cp_idx}: {exc}"
         else:
             msg = "Unknown action."
 


### PR DESCRIPTION
## Summary
- handle errors when starting/stopping the OCPP simulator so tests don't get redirects

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687fc98843c083269254eb82ac9e4204