### PR TITLE
Fix charger card column alignment

### DIFF
--- a/data/static/ocpp/csms/charger_status.css
+++ b/data/static/ocpp/csms/charger_status.css
@@ -23,6 +23,13 @@
     width: 100%;
     font-size: 1.08em;
     border-collapse: collapse;
+    table-layout: fixed;
+}
+.charger-info-table col.label-col {
+    width: 6.2em;
+}
+.charger-info-table col.value-col {
+    width: 8.4em;
 }
 .charger-info-table td.label {
     color: #bcd;

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -452,6 +452,12 @@ def _render_charger_card(cid, tx, state, raw_hb, *, show_controls=True):
         <tr>
           <td class="charger-info-td">
             <table class="charger-info-table">
+              <colgroup>
+                <col class="label-col">
+                <col class="value-col">
+                <col class="label-col">
+                <col class="value-col">
+              </colgroup>
               <tr>
                 <td class="label">ID</td>
                 <td class="value">{cid}</td>


### PR DESCRIPTION
## Summary
- add column groups to charger info table so widths match
- define explicit widths for charger info columns

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687fdb14eee48326a76aeb2172f8246a