### PR TITLE
Adjust default watcher intervals

### DIFF
--- a/gway/runner.py
+++ b/gway/runner.py
@@ -252,8 +252,8 @@ def _retry_loop(fn, *, interval, stop_event, label):
         time.sleep(interval)
 
 
-def watch_url(url, on_change, *, 
-              interval=60.0, event="change", resend=False, value=None):
+def watch_url(url, on_change, *,
+              interval=300.0, event="change", resend=False, value=None):
     stop_event = threading.Event()
 
     def _check():
@@ -298,7 +298,7 @@ def watch_url(url, on_change, *,
     return stop_event
 
 
-def watch_pypi_package(package_name, on_change, *, interval=3000.0):
+def watch_pypi_package(package_name, on_change, *, interval=1800.0):
     stop_event = threading.Event()
     url = f"https://pypi.org/pypi/{package_name}/json"
 


### PR DESCRIPTION
## Summary
- update `watch_url` default interval to 300 seconds
- update `watch_pypi_package` default interval to 1800 seconds (30 minutes)

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_688001baccc4832689160ccfa4e33e74