### PR TITLE
Update charger detail layout

### DIFF
--- a/data/static/ocpp/csms/charger_status.css
+++ b/data/static/ocpp/csms/charger_status.css
@@ -188,3 +188,44 @@
 .ocpp-summary td {
     vertical-align: top;
 }
+
+/* Transaction details table */
+.ocpp-details {
+    border-collapse: collapse;
+    width: 100%;
+    margin-top: 0.5em;
+}
+.ocpp-details th,
+.ocpp-details td {
+    border: 1px solid #bbb;
+    padding: 4px 8px;
+}
+
+/* Date range selector */
+#tx-range {
+    display: flex;
+    gap: 12px;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    margin: 1em 0;
+}
+#tx-range label {
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 0;
+}
+#tx-range input[type="date"] {
+    width: auto;
+    margin-bottom: 0;
+    padding: 0.35em 0.5em;
+}
+[data-theme="dark"] #tx-range input[type="date"],
+body.dark #tx-range input[type="date"],
+.dark #tx-range input[type="date"] {
+    color-scheme: dark;
+}
+[data-theme="dark"] #tx-range input[type="date"]::-webkit-calendar-picker-indicator,
+body.dark #tx-range input[type="date"]::-webkit-calendar-picker-indicator,
+.dark #tx-range input[type="date"]::-webkit-calendar-picker-indicator {
+    filter: invert(1);
+}

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -663,10 +663,14 @@ def view_charger_detail(*, charger_id=None, **_):
     )
 
     html.append(
-        f'''<form id="tx-range" method="get" style="margin:1em 0;">
+        f'''<form id="tx-range" method="get">
             <input type="hidden" name="charger_id" value="{charger_id}">
-            <label>From: <input type="date" name="since" value="{since}"></label>
-            <label>To: <input type="date" name="until" value="{until}"></label>
+            <label>From:
+                <input type="date" name="since" value="{since}">
+            </label>
+            <label>To:
+                <input type="date" name="until" value="{until}">
+            </label>
             <button type="submit">Apply</button>
         </form>'''
     )


### PR DESCRIPTION
## Summary
- align date filters on one row in charger detail view
- tweak calendar icon for dark themes and add padding
- style transactions table

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_687fe6a648a0832689fe901318d6fa86