### PR TITLE
Condense OCPP charger cards

### DIFF
--- a/data/static/ocpp/csms/charger_status.css
+++ b/data/static/ocpp/csms/charger_status.css
@@ -116,7 +116,7 @@
 .charger-card {
     width: 100%;
     max-width: 1200px;
-    margin: 0 auto 28px auto;
+    margin: 0 auto 20px auto;
     background: #242b32;
     color: #fff;
     border-radius: 1rem;
@@ -125,7 +125,7 @@
     /* Right border color comes from status class */
     border-right-width: 25px;
     border-right-style: solid;
-    padding: 1.3em 2.1em 2.3em 2.1em;
+    padding: 1.2em 2.1em 1.6em 2.1em;
     display: block;
     box-sizing: border-box;
     transition: border-right-color 0.3s;

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -461,8 +461,6 @@ def _render_charger_card(cid, tx, state, raw_hb, *, show_controls=True):
               <tr>
                 <td class="label">ID</td>
                 <td class="value">{cid}</td>
-              </tr>
-              <tr>
                 <td class="label">TXN</td>
                 <td class="value">{tx_id}</td>
               </tr>
@@ -484,11 +482,9 @@ def _render_charger_card(cid, tx, state, raw_hb, *, show_controls=True):
               </tr>
               <tr>
                 <td class="label">Updated</td>
-                <td class="value" colspan="3">{last_updated}</td>
-              </tr>
-              <tr>
+                <td class="value">{last_updated}</td>
                 <td class="label">Status</td>
-                <td class="value" colspan="3">{status}</td>
+                <td class="value">{status}</td>
               </tr>
             </table>
           </td>


### PR DESCRIPTION
## Summary
- compact charger card info layout
- shrink padding/margins in charger cards

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_688017dfbcf48326b871df30b4476532