### PR TITLE
Rename Toy Games view title

### DIFF
--- a/data/static/games/README.rst
+++ b/data/static/games/README.rst
@@ -1,4 +1,4 @@
-Toy Games
----------
+Toys & Games
+------------
 
 Shared helpers for simple demo games.

--- a/projects/games/games.py
+++ b/projects/games/games.py
@@ -68,11 +68,11 @@ _DEF = [
 ]
 
 
-def view_toy_games():
+def view_toy_games(*, _title="Toys & Games"):
     """Home view listing all available games."""
     html = [
         '<link rel="stylesheet" href="/static/web/cards.css">',
-        "<h1>Toy Games</h1>",
+        "<h1>Toys & Games</h1>",
         "<div class='gw-cards'>",
     ]
     for title, route, desc, link in _DEF:
@@ -84,6 +84,9 @@ def view_toy_games():
         )
     html.append("</div>")
     return "\n".join(html)
+
+
+view_toy_games._title = "Toys & Games"
 
 
 def view_game_of_life(*args, **kwargs):

--- a/tests/test_nav_links.py
+++ b/tests/test_nav_links.py
@@ -36,7 +36,7 @@ class NavLinksTests(unittest.TestCase):
         nav.gw.web.cookies = self.orig_cookies
 
     def test_render_includes_project_links(self):
-        homes = [('Toy Games', 'games/game-of-life')]
+        homes = [('Toys & Games', 'games/game-of-life')]
         html = nav.render(homes=homes, links={'games/game-of-life': ['score', 'about']})
         soup = BeautifulSoup(html, 'html.parser')
         sub = soup.find('ul', class_='sub-links')
@@ -50,7 +50,7 @@ class NavLinksTests(unittest.TestCase):
                                              'get': lambda self2, n, d=None: None})()
         nav.gw.web.app = type('A', (), {'is_setup': lambda self2, n: True})()
         nav.request = FakeRequest('/games/score')
-        homes = [('Toy Games', 'games/game-of-life')]
+        homes = [('Toys & Games', 'games/game-of-life')]
         html = nav.render(homes=homes, links={'games/game-of-life': ['score', 'about']})
         soup = BeautifulSoup(html, 'html.parser')
         score_links = soup.find_all('a', href='/games/score')
@@ -62,7 +62,7 @@ class NavLinksTests(unittest.TestCase):
                                              'get': lambda self2, n, d=None: None})()
         nav.gw.web.app = type('A', (), {'is_setup': lambda self2, n: True})()
         nav.request = FakeRequest('/unlisted/page')
-        homes = [('Toy Games', 'games/game-of-life')]
+        homes = [('Toys & Games', 'games/game-of-life')]
         html = nav.render(homes=homes)
         self.assertNotIn('/unlisted/page', html)
 

--- a/tests/test_toy_games_title.py
+++ b/tests/test_toy_games_title.py
@@ -1,0 +1,19 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+from gway import gw
+
+
+class ToyGamesTitleTests(unittest.TestCase):
+    def test_func_title_resolves(self):
+        nav_path = Path(__file__).resolve().parents[1] / 'projects' / 'web' / 'nav.py'
+        spec = importlib.util.spec_from_file_location('webnav', nav_path)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        title = module._func_title('games', 'toy-games')
+        self.assertEqual(title, 'Toys & Games')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- set `view_toy_games._title` to `"Toys & Games"` and update heading
- update navigation tests for new title
- add unit test checking `_func_title` for toy games
- rename project README heading

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_688019bb507c8326b822945580578d22