### PR TITLE
Add document navigation to reader

### DIFF
--- a/tests/test_view_reader.py
+++ b/tests/test_view_reader.py
@@ -25,6 +25,7 @@ class ViewReaderTests(unittest.TestCase):
     def test_view_reader_renders(self):
         html = gw.web.site.view_reader(tome="README", origin="root")
         self.assertIn("Test RST resource", html)
+        self.assertIn("reader-select", html)
 
     def test_hidden_or_private_denied(self):
         self.assertIn("Access denied", gw.web.site.view_reader(tome=".secret", origin="root"))


### PR DESCRIPTION
## Summary
- extend `view_reader` to append a document selector and JavaScript filter
- expose list of readable docs from root and static directories
- test that reader page includes the new selector

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68801ab7e4648326b9e493e96e1dae81