### PR TITLE
Add authdb module with DuckDB identity database

### DIFF
--- a/data/static/authdb/README.rst
+++ b/data/static/authdb/README.rst
@@ -1,0 +1,26 @@
+Unified Authentication Database
+-------------------------------
+
+``projects/authdb`` provides a small helper that stores authentication
+information in a DuckDB database.  Multiple login methods can be linked
+via a shared ``identity_id`` so that a user authenticated by username
+and password can also be recognised via an RFID tag.
+
+The tables are created automatically using ``gw.sql.model`` the first time
+any helper function is called.  By default the database is stored in
+``work/auth.duckdb`` but all functions accept a custom ``dbfile``
+parameter for testing or advanced setups.
+
+Available helpers include:
+
+``create_identity`` – add a new identity and return its id.
+
+``set_basic_auth`` – store HTTP Basic credentials for an identity.
+
+``set_rfid`` – register an RFID token and optional balance.
+
+``verify_basic`` – validate a username/password pair.
+
+``verify_rfid`` – validate an RFID and check its ``allowed`` flag.
+
+``adjust_balance`` – modify the stored balance for a tag.

--- a/projects/authdb.py
+++ b/projects/authdb.py
@@ -1,0 +1,95 @@
+# file: projects/authdb.py
+"""Authentication database using gw.sql.model and DuckDB."""
+
+from gway import gw
+import base64
+
+DBFILE = "work/auth.duckdb"
+ENGINE = "duckdb"
+PROJECT = "authdb"
+
+IDENTITIES = """identities(
+    id INTEGER PRIMARY KEY,
+    name TEXT
+)"""
+
+BASIC_AUTH = """basic_auth(
+    username TEXT PRIMARY KEY,
+    b64 TEXT,
+    identity_id INTEGER
+)"""
+
+RFIDS = """rfids(
+    rfid TEXT PRIMARY KEY,
+    identity_id INTEGER,
+    balance REAL,
+    allowed INTEGER
+)"""
+
+def _model(spec, *, dbfile=None):
+    return gw.sql.model(spec, dbfile=dbfile or DBFILE, sql_engine=ENGINE, project=PROJECT)
+
+def _next_identity_id(dbfile=None):
+    # Ensure table exists before querying
+    _model(IDENTITIES, dbfile=dbfile)
+    conn = gw.sql.open_db(dbfile or DBFILE, sql_engine=ENGINE, project=PROJECT)
+    rows = gw.sql.execute("SELECT max(id) FROM identities", connection=conn)
+    max_id = rows[0][0] if rows and rows[0][0] is not None else 0
+    return max_id + 1
+
+def create_identity(name=None, *, dbfile=None):
+    iid = _next_identity_id(dbfile)
+    _model(IDENTITIES, dbfile=dbfile).create(id=iid, name=name)
+    return iid
+
+def set_basic_auth(username, password, *, identity_id, dbfile=None):
+    pw_b64 = base64.b64encode(password.encode("utf-8")).decode("ascii")
+    m = _model(BASIC_AUTH, dbfile=dbfile)
+    try:
+        m.delete(username, id_col="username")
+    except Exception:
+        pass
+    m.create(username=username, b64=pw_b64, identity_id=identity_id)
+
+def set_rfid(rfid, *, identity_id, balance=0.0, allowed=True, dbfile=None):
+    m = _model(RFIDS, dbfile=dbfile)
+    try:
+        m.delete(rfid, id_col="rfid")
+    except Exception:
+        pass
+    m.create(rfid=rfid, identity_id=identity_id, balance=balance, allowed=1 if allowed else 0)
+
+def verify_basic(username, password, *, dbfile=None):
+    row = _model(BASIC_AUTH, dbfile=dbfile).read(username, id_col="username")
+    if not row:
+        return False, None
+    try:
+        stored = base64.b64decode(row[1]).decode("utf-8")
+    except Exception:
+        return False, None
+    if stored != password:
+        return False, None
+    return True, row[2]
+
+def verify_rfid(rfid, *, dbfile=None):
+    row = _model(RFIDS, dbfile=dbfile).read(rfid, id_col="rfid")
+    if not row:
+        return False, None
+    if not bool(row[3]):
+        return False, row[1]
+    return True, row[1]
+
+def get_balance(rfid, *, dbfile=None):
+    row = _model(RFIDS, dbfile=dbfile).read(rfid, id_col="rfid")
+    return float(row[2]) if row else 0.0
+
+def adjust_balance(rfid, amount, *, dbfile=None):
+    row = _model(RFIDS, dbfile=dbfile).read(rfid, id_col="rfid")
+    if not row:
+        return False
+    new_bal = float(row[2]) + amount
+    _model(RFIDS, dbfile=dbfile).update(rfid, id_col="rfid", balance=new_bal)
+    return True
+
+def get_identity(identity_id, *, dbfile=None):
+    return _model(IDENTITIES, dbfile=dbfile).read(identity_id)

--- a/tests/test_authdb.py
+++ b/tests/test_authdb.py
@@ -1,0 +1,37 @@
+import unittest
+import os
+from gway import gw
+
+DB = "work/test_auth.duckdb"
+
+class AuthDBTests(unittest.TestCase):
+    def setUp(self):
+        path = gw.resource(DB)
+        if os.path.exists(path):
+            os.remove(path)
+
+    def tearDown(self):
+        gw.sql.close_connection(DB, sql_engine="duckdb", project="authdb")
+        path = gw.resource(DB)
+        if os.path.exists(path):
+            os.remove(path)
+
+    def test_basic_rfid_flow(self):
+        uid = gw.authdb.create_identity("Alice", dbfile=DB)
+        gw.authdb.set_basic_auth("alice", "secret", identity_id=uid, dbfile=DB)
+        gw.authdb.set_rfid("TAG1", identity_id=uid, balance=5, dbfile=DB)
+
+        ok, ident = gw.authdb.verify_basic("alice", "secret", dbfile=DB)
+        self.assertTrue(ok)
+        self.assertEqual(ident, uid)
+
+        ok, ident2 = gw.authdb.verify_rfid("TAG1", dbfile=DB)
+        self.assertTrue(ok)
+        self.assertEqual(ident2, uid)
+        self.assertEqual(gw.authdb.get_balance("TAG1", dbfile=DB), 5)
+
+        gw.authdb.adjust_balance("TAG1", 3, dbfile=DB)
+        self.assertEqual(gw.authdb.get_balance("TAG1", dbfile=DB), 8)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- create `authdb` project for unified identity storage using DuckDB
- document helper functions under `data/static/authdb/README.rst`
- add tests for the new authentication database

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_68801b50f14883269391ea708d9ef83d