### PR TITLE
Add Studio web dashboard

### DIFF
--- a/projects/studio/studio.py
+++ b/projects/studio/studio.py
@@ -10,21 +10,19 @@ def view_studio_bench(*, _title="Studio Bench", **_):
             "Convert image frames into a GIF",
         ),
     ]
-    html = ["<h1>Studio Bench</h1>"]
-    html.append(
-        "<style>"
-        ".studio-cards{display:flex;flex-wrap:wrap;gap:1em;margin:1em 0;}"
-        ".studio-card{display:block;padding:1em;border:1px solid var(--muted,#ccc);"
-        "border-radius:8px;background:var(--card-bg,#f9f9f9);width:16em;"
-        "text-decoration:none;color:inherit;}"
-        ".studio-card h2{margin-top:0;font-size:1.2em;}"
-        ".studio-card p{margin:.4em 0;}"
-        "</style>"
-    )
-    html.append("<div class='studio-cards'>")
+    html = [
+        '<link rel="stylesheet" href="/static/web/cards.css">',
+        "<h1>Studio Bench</h1>",
+        "<div class='gw-cards'>",
+    ]
     for label, url, info in links:
         html.append(
-            f"<a class='studio-card' href='{url}'><h2>{label}</h2><p>{info}</p></a>"
+            "<div class='gw-card'>"
+            f"<a href='{url}' class='main-link'><h2>{label}</h2><p>{info}</p></a>"
+            "</div>"
         )
     html.append("</div>")
     return "\n".join(html)
+
+
+view_studio_bench._title = "Studio Bench"

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -15,6 +15,7 @@ web app setup:
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - web.chat.action --home gpt-actions --links audit-chatlog --auth required
     - games --home toy-games --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
+    - studio --home studio-bench --links animate-gif
     - web.auth
 
 help-db build


### PR DESCRIPTION
## Summary
- update `studio` web dashboard view to use shared CSS
- expose the studio dashboard via the website recipe

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68801dfea34c8326ae0ff922bc7feb1a