### PR TITLE
Track win streak in Tetrad

### DIFF
--- a/data/static/games/four_in_a_row/README.rst
+++ b/data/static/games/four_in_a_row/README.rst
@@ -42,3 +42,7 @@ checks for a winning move of its own first. If such a column exists it will
 take it, otherwise it checks if the player threatens an immediate win next turn
 and blocks that column. If neither case applies, it selects a random legal
 column and stores the updated board back in the cookie.
+
+A separate ``fiar_streak`` cookie tracks consecutive player wins. Each
+victory increases the value by one while a loss or manual reset returns it
+to zero.

--- a/data/static/games/four_in_a_row/four_in_a_row.css
+++ b/data/static/games/four_in_a_row/four_in_a_row.css
@@ -15,3 +15,9 @@
     width: 100%;
     height: 32px;
 }
+
+.fiar-streak {
+    margin-left: 1em;
+    font-weight: 600;
+    color: #5a5100;
+}


### PR DESCRIPTION
## Summary
- track Four in a Row win streak in cookie
- show "Streak" next to New Game button and confirm before resetting
- document streak cookie
- style streak label

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68802be003b08326a3d452428a936d27