### PR TITLE
Update OCPP RFID authorizers

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -111,13 +111,18 @@ chart of energy usage over time for selected chargers and dates.
 RFID Management
 ---------------
 
-RFID access entries are stored in ``work/ocpp/rfids.cdv``. Open
-``/ocpp/manage-rfids`` in your browser to edit these records. The page lists
-all tags with their balance and ``allowed`` flag so you can quickly update,
-credit or delete entries and add new ones.
+RFID access entries can be managed in two ways.  For quick local setups the
+records are stored in ``work/ocpp/rfids.cdv`` and edited via
+``/ocpp/manage-rfids``.  A more robust ``auth_db`` project stores the same
+information in a DuckDB database for use by the CSMS authorizers.
+
+The management page lists all tags with their balance and ``allowed`` flag so
+you can quickly update, credit or delete entries and add new ones.
 
 The ``ocpp.rfid`` module also exposes helper functions to manage the table
 programmatically.  Use ``create_entry`` to add a tag, ``update_entry`` to
 modify fields, ``delete_entry`` to remove a tag and ``enable`` or ``disable``
 to toggle the ``allowed`` flag.  Balances can be adjusted via ``credit`` and
-``debit`` which operate on the ``balance`` field.
+``debit`` which operate on the ``balance`` field.  When using ``auth_db`` the
+authorizer helpers accept a ``dbfile`` parameter to look up tags in the
+database instead of the CDV table.

--- a/tests/test_rfid_authorizers.py
+++ b/tests/test_rfid_authorizers.py
@@ -6,39 +6,41 @@ from gway import gw
 class RFIDAuthorizerTests(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
-        self.table = os.path.join(self.tmp.name, "rfids.cdv")
+        self.db = os.path.join(self.tmp.name, "auth.duckdb")
 
     def tearDown(self):
+        gw.sql.close_connection(self.db, sql_engine="duckdb", project="auth_db")
         self.tmp.cleanup()
 
     def _add(self, tag, balance="0", allowed=True):
-        gw.cdv.update(self.table, tag, balance=str(balance), allowed="True" if allowed else "False")
+        uid = gw.auth_db.create_identity(tag, dbfile=self.db)
+        gw.auth_db.set_rfid(tag, identity_id=uid, balance=float(balance), allowed=allowed, dbfile=self.db)
 
     def test_authorize_balance_and_allowed(self):
         tag = "GOOD"
         self._add(tag, balance="5", allowed=True)
         payload = {"idTag": tag}
-        self.assertTrue(gw.ocpp.rfid.authorize_balance(payload=payload, table=self.table))
-        self.assertTrue(gw.ocpp.rfid.authorize_allowed(payload=payload, table=self.table))
+        self.assertTrue(gw.ocpp.rfid.authorize_balance(payload=payload, dbfile=self.db))
+        self.assertTrue(gw.ocpp.rfid.authorize_allowed(payload=payload, dbfile=self.db))
 
     def test_denied_when_not_allowed(self):
         tag = "BLOCKED"
         self._add(tag, balance="100", allowed=False)
         payload = {"idTag": tag}
-        self.assertFalse(gw.ocpp.rfid.authorize_balance(payload=payload, table=self.table))
-        self.assertFalse(gw.ocpp.rfid.authorize_allowed(payload=payload, table=self.table))
+        self.assertFalse(gw.ocpp.rfid.authorize_balance(payload=payload, dbfile=self.db))
+        self.assertFalse(gw.ocpp.rfid.authorize_allowed(payload=payload, dbfile=self.db))
 
     def test_balance_check_only_affects_balance_authorizer(self):
         tag = "LOWBAL"
         self._add(tag, balance="0", allowed=True)
         payload = {"idTag": tag}
-        self.assertFalse(gw.ocpp.rfid.authorize_balance(payload=payload, table=self.table))
-        self.assertTrue(gw.ocpp.rfid.authorize_allowed(payload=payload, table=self.table))
+        self.assertFalse(gw.ocpp.rfid.authorize_balance(payload=payload, dbfile=self.db))
+        self.assertTrue(gw.ocpp.rfid.authorize_allowed(payload=payload, dbfile=self.db))
 
     def test_unknown_tag_rejected(self):
         payload = {"idTag": "MISSING"}
-        self.assertFalse(gw.ocpp.rfid.authorize_balance(payload=payload, table=self.table))
-        self.assertFalse(gw.ocpp.rfid.authorize_allowed(payload=payload, table=self.table))
+        self.assertFalse(gw.ocpp.rfid.authorize_balance(payload=payload, dbfile=self.db))
+        self.assertFalse(gw.ocpp.rfid.authorize_allowed(payload=payload, dbfile=self.db))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- support `auth_db` in OCPP RFID authorizers
- update rfid authorizer tests to use DuckDB
- mention auth_db in OCPP docs

## Testing
- `gway test --filter rfid_authorizers`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68802fad66bc8326a0bec7565f9cc4ca