### PR TITLE
Add computer player and leaderboard to Massive Snake

### DIFF
--- a/projects/games/games.py
+++ b/projects/games/games.py
@@ -105,6 +105,10 @@ def view_massive_snake(*args, **kwargs):
     return massive_snake.view_massive_snake(*args, **kwargs)
 
 
+def view_snake_leaderboard(*args, **kwargs):
+    return massive_snake.view_snake_leaderboard(*args, **kwargs)
+
+
 def view_four_in_a_row(*args, **kwargs):
     return four_in_a_row.view_four_in_a_row(*args, **kwargs)
 

--- a/tests/test_snake_game.py
+++ b/tests/test_snake_game.py
@@ -1,0 +1,36 @@
+import os
+import unittest
+from gway import gw
+from paste.fixture import TestApp
+
+class SnakeGameTests(unittest.TestCase):
+    BOARD = "work/shared/games/massive_snake.json"
+    ASC = "work/games/ascensions.cdv"
+
+    def setUp(self):
+        for path in (self.BOARD, self.ASC):
+            p = gw.resource(path)
+            if os.path.exists(p):
+                os.remove(p)
+        self.app = gw.web.app.setup_app("games")
+        self.client = TestApp(self.app)
+
+    def tearDown(self):
+        for path in (self.BOARD, self.ASC):
+            p = gw.resource(path)
+            if os.path.exists(p):
+                os.remove(p)
+
+    def test_hegemony_player_present(self):
+        resp = self.client.get("/games/massive-snake")
+        self.assertEqual(resp.status, 200)
+        text = resp.body.decode()
+        self.assertIn("Hegemony", text)
+
+    def test_leaderboard_view(self):
+        gw.cdv.update(self.ASC, "Tester", count="2")
+        resp = self.client.get("/games/snake-leaderboard")
+        self.assertEqual(resp.status, 200)
+        text = resp.body.decode()
+        self.assertIn("Ascension Leaderboard", text)
+        self.assertIn("Tester", text)


### PR DESCRIPTION
## Summary
- add Hegemony AI player with grey color and automatic rolls
- record ascensions in `work/games/ascensions.cdv`
- show leaderboard link and page
- cover new behavior with tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6880ee1457a083269b9d9ce7c4c43375