### PR TITLE
Add auth db sync timer

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -126,3 +126,12 @@ to toggle the ``allowed`` flag.  Balances can be adjusted via ``credit`` and
 ``debit`` which operate on the ``balance`` field.  When using ``auth_db`` the
 authorizer helpers accept a ``dbfile`` parameter to look up tags in the
 database instead of the CDV table.
+
+To keep multiple instances in sync a helper ``gw.auth_db.sync_from_url``
+can download the database from a remote HTTP endpoint and replace the
+local file. Run it periodically with ``every``:
+
+.. code-block:: bash
+
+   every --interval 300 gw.auth_db.sync_from_url \
+       http://example.com/work/auth.duckdb

--- a/recipes/test/etron/local_proxy.gwr
+++ b/recipes/test/etron/local_proxy.gwr
@@ -14,6 +14,7 @@ ocpp csms setup:
 
 web:
  - static collect
+ - every --interval 300 gw.auth_db.sync_from_url http://127.0.0.1:18000/work/auth.duckdb
  - server start-app --host 0.0.0.0 --port 18888 --ws-port 19900 --proxy http://127.0.0.1:18000
 
 until --version

--- a/tests/test_auth_db.py
+++ b/tests/test_auth_db.py
@@ -33,5 +33,39 @@ class AuthDBTests(unittest.TestCase):
         gw.auth_db.adjust_balance("TAG1", 3, dbfile=DB)
         self.assertEqual(gw.auth_db.get_balance("TAG1", dbfile=DB), 8)
 
+    def test_sync_from_url(self):
+        import tempfile
+        import http.server
+        import socketserver
+        import threading
+
+        with tempfile.TemporaryDirectory() as tmp:
+            remote_db = os.path.join(tmp, "remote.duckdb")
+            local_db = os.path.join(tmp, "local.duckdb")
+
+            uid = gw.auth_db.create_identity("Bob", dbfile=remote_db)
+            gw.auth_db.set_basic_auth("bob", "pw", identity_id=uid, dbfile=remote_db)
+
+            gw.sql.close_connection(remote_db, sql_engine="duckdb", project="auth_db")
+
+            handler = http.server.SimpleHTTPRequestHandler
+            cwd = os.getcwd()
+            os.chdir(tmp)
+            httpd = socketserver.TCPServer(("127.0.0.1", 0), handler)
+            port = httpd.server_address[1]
+            thr = threading.Thread(target=httpd.serve_forever, daemon=True)
+            thr.start()
+            try:
+                url = f"http://127.0.0.1:{port}/remote.duckdb"
+                gw.auth_db.sync_from_url(url, dbfile=local_db)
+            finally:
+                httpd.shutdown()
+                thr.join()
+                os.chdir(cwd)
+
+            ok, ident = gw.auth_db.verify_basic("bob", "pw", dbfile=local_db)
+            self.assertTrue(ok)
+            self.assertEqual(ident, uid)
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `gw.auth_db.sync_from_url` helper to fetch remote DB
- provide new `every` runner method for periodic tasks
- sync auth DB in `recipes/test/etron/local_proxy.gwr`
- document database sync in OCPP README
- test remote DB sync

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_688104f614c083269928cc0437b1697e