### PR TITLE
Switch setup-app flag from --everything to --full

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -38,7 +38,7 @@ Unreleased
 - add --install option to test command
 - allow backslash line continuations in recipe files
 - fix missing ``/ocpp/csms`` route for charger details
-- add ``--everything`` flag to ``web.app.setup_app`` to auto-load sub-projects
+- add ``--full`` flag to ``web.app.setup_app`` to auto-load sub-projects
   and resolve sub-project views without wrappers
 
 0.4.51 [build edbd5b]

--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -13,7 +13,7 @@ The landing page ``/ocpp/ocpp-dashboard`` shows a quick summary of these
 sub‑projects. When mounting the dashboard with ``web.app.setup_app`` the CSMS
 views and renders are discovered automatically because sub‑projects are treated
 as delegate modules under the ``/ocpp`` path. To expose each sub‑project under
-its own route (for example ``/ocpp/evcs/cp-simulator``) pass ``--everything`` to
+its own route (for example ``/ocpp/evcs/cp-simulator``) pass ``--full`` to
 ``web.app.setup_app`` or register the sub‑projects explicitly.
 
 Launch a simulator session pointing at your CSMS with:

--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -137,7 +137,7 @@ def setup_app(project,
     auth="disabled",       # Accept "optional"/"disabled" words to disable
     engine="bottle",
     delegates=None,
-    everything: bool = False,
+    full: bool = False,
     **setup_kwargs,
 ):
     """
@@ -149,13 +149,13 @@ def setup_app(project,
     ``footer`` accepts a list of links similar to ``links`` but rendered in the
     page footer instead of the navigation sidebar. Sub-projects of the loaded
     project are always scanned for missing handlers. Use ``delegates`` to
-    specify additional fallback projects. Set ``everything`` to ``True`` to
+    specify additional fallback projects. Set ``full`` to ``True`` to
     automatically initialize all sub-projects as delegates.
     """
     global _ver, _homes, _enabled, _static_route, _shared_route
 
-    if "all" in setup_kwargs and not everything:
-        everything = bool(setup_kwargs.pop("all"))
+    if "all" in setup_kwargs and not full:
+        full = bool(setup_kwargs.pop("all"))
 
     auth_required = str(auth).strip().lower() not in {
         "none", "false", "disabled", "optional"
@@ -302,7 +302,7 @@ def setup_app(project,
         gw.web.footer.add_footer_links(_homes[-1][1], footer, project)
 
     # Recursively setup sub-projects when requested (before main routes)
-    if everything and delegate_modules:
+    if full and delegate_modules:
         base_path = path if path is not None else project.replace('.', '/')
         for mod in delegate_modules:
             sub_name = getattr(mod, '_name', None)
@@ -318,7 +318,7 @@ def setup_app(project,
                     sub_name,
                     app=app,
                     path=sub_path,
-                    everything=False,
+                    full=False,
                     **setup_kwargs,
                 )
             except Exception as exc:

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -12,7 +12,7 @@ web app setup:
     - web.message
     - web.chat
     - vbox --home uploads
-    - ocpp --home ocpp-dashboard --everything \
+    - ocpp --home ocpp-dashboard --full \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - games --home toy-games --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
     - web.auth

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -11,11 +11,11 @@ web app setup:
     - web.message
     - awg --home awg-calculator
     - vbox --home uploads
-    - ocpp --auth required --home ocpp-dashboard --everything \
+    - ocpp --auth required --home ocpp-dashboard --full \
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - web.chat.action --home gpt-actions --links audit-chatlog --auth required
     - games --home toy-games --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
-    - studio --home studio-bench --links animate-gif
+    - studio --home studio-bench --links animate-gif --full
     - web.auth
 
 help-db build

--- a/tests/test_evcs_view.py
+++ b/tests/test_evcs_view.py
@@ -6,7 +6,7 @@ from importlib import import_module
 
 class EvcsViewTests(unittest.TestCase):
     def setUp(self):
-        app = gw.web.app.setup('ocpp', everything=True)
+        app = gw.web.app.setup('ocpp', full=True)
         self.client = TestApp(app)
 
     def test_cp_simulator_view_renders(self):

--- a/tests/test_setup_app_all.py
+++ b/tests/test_setup_app_all.py
@@ -3,7 +3,7 @@ from gway import gw
 
 class SetupAppAllTests(unittest.TestCase):
     def test_delegates_subprojects(self):
-        app = gw.web.app.setup_app("ocpp", everything=True)
+        app = gw.web.app.setup_app("ocpp", full=True)
         bottle_app = app[0] if isinstance(app, tuple) else app
         has_csms_route = any(r.rule.startswith('/ocpp/csms/') for r in bottle_app.routes)
         self.assertTrue(has_csms_route, "csms routes not registered")

--- a/tests/test_setup_app_everything.py
+++ b/tests/test_setup_app_everything.py
@@ -3,14 +3,14 @@ from gway import gw
 
 class SetupAppEverythingTests(unittest.TestCase):
     def test_delegates_subprojects(self):
-        app = gw.web.app.setup_app("ocpp", everything=True)
+        app = gw.web.app.setup_app("ocpp", full=True)
         bottle_app = app[0] if isinstance(app, tuple) else app
         has_csms_route = any(r.rule.startswith('/ocpp/csms/') for r in bottle_app.routes)
         self.assertTrue(has_csms_route, "csms routes not registered")
 
     def test_subproject_view_resolution(self):
         self.assertFalse(hasattr(gw.ocpp, 'view_active_chargers'))
-        app = gw.web.app.setup_app("ocpp", everything=True)
+        app = gw.web.app.setup_app("ocpp", full=True)
         bottle_app = app[0] if isinstance(app, tuple) else app
         generic_route = next((r for r in bottle_app.routes if r.rule == '/ocpp/<view:path>'), None)
         self.assertIsNotNone(generic_route, 'generic ocpp view route missing')


### PR DESCRIPTION
## Summary
- rename `everything` argument in `web.app.setup_app` to `full`
- update docs and recipes to use `--full`
- update tests for the new `full` parameter
- add `--full` to studio setup in website recipe

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68813fea08cc8326a809a6ef31a717e3