### PR TITLE
Fix Windows cleanup error in auth DB test

### DIFF
--- a/tests/test_auth_db.py
+++ b/tests/test_auth_db.py
@@ -66,6 +66,7 @@ class AuthDBTests(unittest.TestCase):
             ok, ident = gw.auth_db.verify_basic("bob", "pw", dbfile=local_db)
             self.assertTrue(ok)
             self.assertEqual(ident, uid)
+            gw.sql.close_connection(local_db, sql_engine="duckdb", project="auth_db")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- close DB connection in `test_sync_from_url`
- ensures TemporaryDirectory can clean up on Windows

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6882995d3d348326bf3f4bcb24f67536