### PR TITLE
Rename close_connection to close_db

### DIFF
--- a/gway/builtins/help_utils.py
+++ b/gway/builtins/help_utils.py
@@ -53,7 +53,7 @@ def help(*args, full: bool = False, list_flags: bool = False):
         cur0.execute("SELECT tests FROM help LIMIT 1")
     except sqlite3.OperationalError:
         gw.help_db.build(update=True)
-        gw.sql.close_connection(datafile=db_path)
+        gw.sql.close_db(datafile=db_path)
         conn = gw.sql.open_db(db_path, row_factory=True)
 
     with conn as cur:

--- a/projects/help_db.py
+++ b/projects/help_db.py
@@ -125,7 +125,7 @@ def build(*, update: bool = False):
                 )
 
         cursor.execute("COMMIT")
-    gw.sql.close_connection(all=True)
+    gw.sql.close_db(all=True)
     gw.info(f"Help database built at {db_path}")
     return db_path
 

--- a/projects/sql/sql.py
+++ b/projects/sql/sql.py
@@ -284,7 +284,7 @@ def open_db(
     if key in _connection_cache:
         conn = _connection_cache[key]
         if row_factory:
-            gw.warning("Row factory change requires close_connection(). Reconnect manually.")
+            gw.warning("Row factory change requires close_db(). Reconnect manually.")
         gw.verbose(f"Reusing connection: {key}")
         return conn
 
@@ -334,7 +334,7 @@ def open_db(
     return conn
 
 
-def close_connection(datafile=None, *, project=None, sql_engine=None, all=False):
+def close_db(datafile=None, *, project=None, sql_engine=None, all=False):
     """
     Explicitly close one or all cached database connections.
     Shuts down writer thread if all connections closed.
@@ -796,5 +796,5 @@ def model(defn, *, dbfile=None, create=True, name=None, sql_engine=None, project
 
 # Backwards compatibility aliases
 open_connection = open_db
-close_db = close_connection
+close_connection = close_db
 

--- a/tests/test_auth_db.py
+++ b/tests/test_auth_db.py
@@ -11,7 +11,7 @@ class AuthDBTests(unittest.TestCase):
             os.remove(path)
 
     def tearDown(self):
-        gw.sql.close_connection(DB, sql_engine="duckdb", project="auth_db")
+        gw.sql.close_db(DB, sql_engine="duckdb", project="auth_db")
         path = gw.resource(DB)
         if os.path.exists(path):
             os.remove(path)
@@ -46,7 +46,7 @@ class AuthDBTests(unittest.TestCase):
             uid = gw.auth_db.create_identity("Bob", dbfile=remote_db)
             gw.auth_db.set_basic_auth("bob", "pw", identity_id=uid, dbfile=remote_db)
 
-            gw.sql.close_connection(remote_db, sql_engine="duckdb", project="auth_db")
+            gw.sql.close_db(remote_db, sql_engine="duckdb", project="auth_db")
 
             handler = http.server.SimpleHTTPRequestHandler
             cwd = os.getcwd()
@@ -66,6 +66,7 @@ class AuthDBTests(unittest.TestCase):
             ok, ident = gw.auth_db.verify_basic("bob", "pw", dbfile=local_db)
             self.assertTrue(ok)
             self.assertEqual(ident, uid)
+            gw.sql.close_db(local_db, sql_engine="duckdb", project="auth_db")
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_duckdb_concurrency.py
+++ b/tests/test_duckdb_concurrency.py
@@ -17,13 +17,13 @@ class DuckDBConcurrencyTests(unittest.TestCase):
         path = gw.resource(TEMP_DB)
         if os.path.exists(path):
             os.remove(path)
-        gw.sql.close_connection(all=True)
+        gw.sql.close_db(all=True)
 
     def setUp(self):
         self.conn = gw.sql.open_db(TEMP_DB, sql_engine="duckdb", project="ducktest")
 
     def tearDown(self):
-        gw.sql.close_connection(TEMP_DB, sql_engine="duckdb", project="ducktest")
+        gw.sql.close_db(TEMP_DB, sql_engine="duckdb", project="ducktest")
 
     def test_concurrent_writes(self):
         gw.sql.execute(
@@ -38,7 +38,7 @@ class DuckDBConcurrencyTests(unittest.TestCase):
                 connection=c,
                 args=(val, val),
             )
-            gw.sql.close_connection(TEMP_DB, sql_engine="duckdb", project="ducktest")
+            gw.sql.close_db(TEMP_DB, sql_engine="duckdb", project="ducktest")
 
         threads = [threading.Thread(target=write_db, args=(i,)) for i in range(10)]
         for t in threads:

--- a/tests/test_help_params.py
+++ b/tests/test_help_params.py
@@ -5,7 +5,7 @@ from gway import gw
 class HelpParamTests(unittest.TestCase):
     def test_help_parameters_and_providers(self):
         gw.help_db.build(update=True)
-        gw.sql.close_connection(all=True)
+        gw.sql.close_db(all=True)
         mod = __import__(gw.web.app.setup_app.__module__)
         saved_enabled = getattr(mod, "_enabled", set()).copy()
         saved_homes = getattr(mod, "_homes", []).copy()

--- a/tests/test_ocpp_data.py
+++ b/tests/test_ocpp_data.py
@@ -24,7 +24,7 @@ class OcppDataTests(unittest.TestCase):
             os.remove(path)
 
     def tearDown(self):
-        gw.sql.close_connection(all=True)
+        gw.sql.close_db(all=True)
         if self.old_cfg is not None:
             self.sql_mod._db_configs["ocpp"] = self.old_cfg
         else:
@@ -52,7 +52,7 @@ class OcppDataTests(unittest.TestCase):
             " status TEXT, error_code TEXT, info TEXT\n)",
             connection=conn,
         )
-        gw.sql.close_connection(self.DB, project="ocpp", sql_engine=ocpp_data.ENGINE)
+        gw.sql.close_db(self.DB, project="ocpp", sql_engine=ocpp_data.ENGINE)
         ocpp_data.set_connection_status("B", True)
         ocpp_data.record_last_msg("B", 123)
         conn = gw.sql.open_db(project="ocpp")

--- a/tests/test_rfid_authorizers.py
+++ b/tests/test_rfid_authorizers.py
@@ -9,7 +9,7 @@ class RFIDAuthorizerTests(unittest.TestCase):
         self.db = os.path.join(self.tmp.name, "auth.duckdb")
 
     def tearDown(self):
-        gw.sql.close_connection(self.db, sql_engine="duckdb", project="auth_db")
+        gw.sql.close_db(self.db, sql_engine="duckdb", project="auth_db")
         self.tmp.cleanup()
 
     def _add(self, tag, balance="0", allowed=True):

--- a/tests/test_sql_crud.py
+++ b/tests/test_sql_crud.py
@@ -16,7 +16,7 @@ class SqlCrudTests(unittest.TestCase):
             cur.execute('CREATE TABLE items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, qty INT)')
 
     def tearDown(self):
-        gw.sql.close_connection(self.DB)
+        gw.sql.close_db(self.DB)
         path = gw.resource(self.DB)
         if os.path.exists(path):
             os.remove(path)

--- a/tests/test_sql_model.py
+++ b/tests/test_sql_model.py
@@ -17,8 +17,8 @@ class SqlModelTests(unittest.TestCase):
             os.remove(dpath)
 
     def tearDown(self):
-        gw.sql.close_connection(self.DB)
-        gw.sql.close_connection(self.DB_DUCK, sql_engine="duckdb")
+        gw.sql.close_db(self.DB)
+        gw.sql.close_db(self.DB_DUCK, sql_engine="duckdb")
         path = gw.resource(self.DB)
         if os.path.exists(path):
             os.remove(path)
@@ -76,7 +76,7 @@ class SqlModelTests(unittest.TestCase):
         nid = notes.create(text="auto")
         row = notes.read(nid)
         self.assertEqual(row[1], "auto")
-        gw.sql.close_connection(DBFILE)
+        gw.sql.close_db(DBFILE)
         del globals()["DBFILE"]
 
     def test_add_missing_columns(self):
@@ -87,7 +87,7 @@ class SqlModelTests(unittest.TestCase):
         conn = gw.sql.open_db(self.DB)
         cols = [r[1] for r in gw.sql.execute("PRAGMA table_info(tbl)", connection=conn)]
         self.assertIn("b", cols)
-        gw.sql.close_connection(self.DB)
+        gw.sql.close_db(self.DB)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- rename `close_connection` to `close_db` in the SQL project
- update all callers and docs

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6882995d3d348326bf3f4bcb24f67536