### PR TITLE
Update release workflow

### DIFF
--- a/data/static/release/README.rst
+++ b/data/static/release/README.rst
@@ -2,3 +2,10 @@ Release Utilities
 -----------------
 
 Scripts for building distributions and uploading them to package indexes.
+
+Before running the release commands make sure to reinstall the runtime
+dependencies:
+
+.. code-block:: bash
+
+   pip install -r requirements.txt

--- a/projects/release.py
+++ b/projects/release.py
@@ -57,6 +57,17 @@ def build(
     import subprocess
     import toml
 
+    gw.info("Installing requirements before release build...")
+    subprocess.run([
+        sys.executable,
+        "-m",
+        "pip",
+        "install",
+        "-U",
+        "-r",
+        "requirements.txt",
+    ], check=True)
+
     if not (token := gw.resolve("[PYPI_API_TOKEN]", "")):
         user = gw.resolve("[PYPI_USERNAME]")
         password = gw.resolve("[PYPI_PASSWORD]")


### PR DESCRIPTION
## Summary
- install requirements before release build starts
- clarify release docs on reinstalling requirements

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68829156c9b08326afc43978df24cd4e