### PR TITLE
Add release tagging workflow

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -1,0 +1,26 @@
+name: Test Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  test-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Run tests
+        run: gway test --coverage
+      - name: Mark ready for release
+        if: success()
+        run: echo "Ready for release to PyPI"

--- a/data/static/release/README.rst
+++ b/data/static/release/README.rst
@@ -2,3 +2,16 @@ Release Utilities
 -----------------
 
 Scripts for building distributions and uploading them to package indexes.
+
+Tagging Builds
+==============
+
+``gw.release.build`` accepts a ``--tag`` option that creates and pushes a git
+tag after the build completes. The tag name corresponds to the package version
+(e.g. ``v1.2.3``). This is typically used for release testing without uploading
+to PyPI::
+
+   gway release build --bump --git --tag
+
+GitHub will run the ``test-release`` workflow on every pushed tag and mark a
+successful run as ready for release to PyPI.

--- a/projects/release.py
+++ b/projects/release.py
@@ -37,6 +37,7 @@ def build(
     projects: bool = False,
     git: bool = False,
     notify: bool = False,
+    tag: bool = False,
     all: bool = False,
     force: bool = False
 ) -> None:
@@ -50,7 +51,7 @@ def build(
         force (bool): Skip version-exists check on PyPI if True.
         git (bool): Require a clean git repo and commit/push after release if True.
         notify (bool): Show a desktop notification when done.
-        vscode (bool): Build the vscode extension.
+        tag (bool): Create and push a git tag for the build version.
     """
     from pathlib import Path
     import sys
@@ -68,6 +69,7 @@ def build(
         git = True
         projects = True
         notify = True
+        tag = True
 
     gw.info(f"Running tests before project build.")
     test_result = gw.test()
@@ -277,6 +279,12 @@ def build(
         subprocess.run(["git", "commit", "-m", commit_msg], check=True)
         subprocess.run(["git", "push"], check=True)
         gw.info(f"Committed and pushed: {commit_msg}")
+
+    if tag:
+        tag_name = f"v{version}"
+        subprocess.run(["git", "tag", tag_name], check=True)
+        subprocess.run(["git", "push", "origin", tag_name], check=True)
+        gw.info(f"Created and pushed tag {tag_name}")
 
     if notify:
         gw.notify(f"Release v{version} build complete")

--- a/tests/test_release_tag.py
+++ b/tests/test_release_tag.py
@@ -1,0 +1,39 @@
+import unittest
+import tempfile
+import os
+from pathlib import Path
+from unittest.mock import patch
+import subprocess
+
+from gway import gw
+
+
+class ReleaseBuildTagTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.base = Path(self.tmp.name)
+        self.old = Path.cwd()
+        os.chdir(self.base)
+        Path("VERSION").write_text("0.0.1\n")
+        Path("requirements.txt").write_text("requests\n")
+        Path("README.rst").write_text("readme\n")
+
+    def tearDown(self):
+        os.chdir(self.old)
+        self.tmp.cleanup()
+
+    def test_tag_creates_git_tag(self):
+        cp = subprocess.CompletedProcess([], 0, "", "")
+        with patch.object(gw, "test", return_value=True), \
+             patch.object(gw, "resolve", return_value=""), \
+             patch.object(gw.hub, "commit", return_value="abc"), \
+             patch.object(gw.release, "update_changelog"), \
+             patch("subprocess.run", return_value=cp) as mock_run:
+            gw.release.build(git=True, tag=True)
+            mock_run.assert_any_call(["git", "tag", "v0.0.1"], check=True)
+            mock_run.assert_any_call(["git", "push", "origin", "v0.0.1"], check=True)
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- allow `gw.release.build` to push git tags
- describe release tagging in docs
- run release tests on tag push with a new workflow
- test tagging behavior

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68829a6496208326983c9c8590da7e80