### PR TITLE
Add VIN and validator tracking

### DIFF
--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -170,6 +170,8 @@ def setup_app(*,
                                 transaction_id,
                                 now,
                                 id_tag=payload.get("idTag"),
+                                vin=payload.get("vin"),
+                                validator=getattr(validator, "__name__", None) if validator else None,
                                 meter_start=payload.get("meterStart"),
                                 charger_timestamp=cp_ts,
                             )

--- a/tests/test_ocpp_data.py
+++ b/tests/test_ocpp_data.py
@@ -35,7 +35,7 @@ class OcppDataTests(unittest.TestCase):
         ocpp_data.DBFILE = self.old_db
 
     def test_basic_record_cycle(self):
-        ocpp_data.record_transaction_start("A", 1, 100)
+        ocpp_data.record_transaction_start("A", 1, 100, vin="VIN123", validator="test")
         ocpp_data.record_meter_value("A", 1, 105, "Energy.Active.Import.Register", 500, "Wh")
         ocpp_data.record_transaction_stop("A", 1, 110, meter_stop=550)
         rows = list(ocpp_data.iter_transactions("A"))


### PR DESCRIPTION
## Summary
- extend OCPP transaction table to store VIN and validator
- record VIN and validator when a StartTransaction is accepted
- add weekly RFID consumption report per charger
- adjust tests for new arguments

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6882b188765c832697912b432bfa829f