### PR TITLE
Set PyPI watcher interval

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,8 +61,9 @@ Core Concepts
   ``envs/servers/<host>.env`` are read automatically.  A file can specify a
   ``BASE_ENV`` to inherit defaults from another file.
 - **Async & Watchers**: coroutines are executed in background threads.  Use
-  ``gw.until`` with file or URL watchers (and even PyPI version checks) to keep
-  services running until a condition changes.
+   ``gw.until`` with file or URL watchers (and even PyPI version checks) to keep
+   services running until a condition changes. PyPI version checks poll every
+   30 minutes by default.
 - **Web Helpers**: ``gw.web.app.setup`` registers views named ``view_*``
   (HTML), ``api_*`` (JSON) and ``render_*`` (fragments).  ``gw.web.server.start_app``
   launches a Bottle server.  Static assets live under ``data/static``.

--- a/gway/runner.py
+++ b/gway/runner.py
@@ -324,7 +324,11 @@ def watch_url(url, on_change, *,
     return stop_event
 
 
-def watch_pypi_package(package_name, on_change, *, interval=1800.0):
+# Default interval (in seconds) for PyPI version polling.
+DEFAULT_PYPI_INTERVAL = 30 * 60
+
+
+def watch_pypi_package(package_name, on_change, *, interval=DEFAULT_PYPI_INTERVAL):
     stop_event = threading.Event()
     url = f"https://pypi.org/pypi/{package_name}/json"
 


### PR DESCRIPTION
## Summary
- define `DEFAULT_PYPI_INTERVAL` (30 mins) and use it for `watch_pypi_package`
- document the 30 minute polling interval in README

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6882d642a23c832681e4780ec516d9f6