### PR TITLE
Add VIN and validator tracking

### DIFF
--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -107,6 +107,8 @@ Two additional views provide more insight into stored data:
 ``view_charger_details`` displays transaction records for one charger
 with simple filtering and pagination. ``view_time_series`` returns a
 chart of energy usage over time for selected chargers and dates.
+``view_weekly_report`` shows kWh per RFID for a selected week,
+grouped by charger.
 
 
 RFID Management

--- a/projects/ocpp/csms.py
+++ b/projects/ocpp/csms.py
@@ -170,6 +170,8 @@ def setup_app(*,
                                 transaction_id,
                                 now,
                                 id_tag=payload.get("idTag"),
+                                vin=payload.get("vin"),
+                                validator=getattr(validator, "__name__", None) if validator else None,
                                 meter_start=payload.get("meterStart"),
                                 charger_timestamp=cp_ts,
                             )

--- a/projects/ocpp/data.py
+++ b/projects/ocpp/data.py
@@ -16,6 +16,8 @@ TRANSACTIONS = """transactions(
     start_time INTEGER,
     stop_time INTEGER,
     id_tag TEXT,
+    vin TEXT,
+    validator TEXT,
     meter_start REAL,
     meter_stop REAL,
     reason TEXT,
@@ -60,6 +62,8 @@ def record_transaction_start(
     start_time: int,
     *,
     id_tag: Optional[str] = None,
+    vin: Optional[str] = None,
+    validator: Optional[str] = None,
     meter_start: Optional[float] = None,
     charger_timestamp: Optional[int] = None,
 ):
@@ -68,6 +72,8 @@ def record_transaction_start(
         transaction_id=transaction_id,
         start_time=int(start_time),
         id_tag=id_tag,
+        vin=vin,
+        validator=validator,
         meter_start=meter_start,
         charger_start_ts=charger_timestamp,
     )
@@ -249,7 +255,7 @@ def iter_transactions(
     """Iterate transaction rows with optional filtering and sorting."""
     conn = gw.sql.open_db(project="ocpp")
     sql = (
-        "SELECT charger_id, transaction_id, start_time, stop_time, meter_start, meter_stop, reason, id_tag "
+        "SELECT charger_id, transaction_id, start_time, stop_time, meter_start, meter_stop, reason, id_tag, vin, validator "
         "FROM transactions WHERE 1=1"
     )
     args: list = []
@@ -546,5 +552,69 @@ def view_time_series(*, chargers: list = None, start: str = None, end: str = Non
         "new Chart(document.getElementById('tschart'), {type:'line', data:{datasets}, options:{parsing:false, scales:{x:{type:'time',time:{unit:'day'}}, y:{title:{display:true,text:'kWh'}}}}});"
     )
     html.append('</script>')
+    return "\n".join(html)
+
+
+def view_weekly_report(*, week: str = None, **_):
+    """Show energy usage per RFID for the selected week, grouped by charger."""
+    from datetime import timedelta, date as _date
+
+    if week:
+        try:
+            week_dt = datetime.fromisoformat(week)
+        except Exception:
+            week_dt = datetime.utcnow()
+    else:
+        week_dt = datetime.utcnow()
+
+    start_dt = week_dt - timedelta(days=week_dt.weekday())
+    start_ts = int(datetime(start_dt.year, start_dt.month, start_dt.day).timestamp())
+    end_ts = start_ts + 7 * 24 * 3600
+
+    conn = gw.sql.open_db(project="ocpp")
+    rows = gw.sql.execute(
+        """
+        SELECT charger_id, id_tag, vin,
+               SUM(COALESCE(meter_stop,0) - COALESCE(meter_start,0)) AS energy
+        FROM transactions
+        WHERE start_time>=? AND start_time<?
+        GROUP BY charger_id, id_tag, vin
+        ORDER BY charger_id, id_tag
+        """,
+        connection=conn,
+        args=(start_ts, end_ts),
+    )
+
+    grouped: dict[str, list] = {}
+    for cid, tag, vin, energy in rows:
+        grouped.setdefault(cid, []).append(
+            {
+                "id_tag": tag,
+                "vin": vin,
+                "energy": round((energy or 0.0) / 1000.0, 3),
+            }
+        )
+
+    html = [f"<h1>RFID Consumption for week of {start_dt.isoformat()}</h1>"]
+    html.append(
+        "<form method='get' style='margin-bottom:1em;'>"
+        f"<label>Week of: <input type='date' name='week' value='{start_dt.isoformat()}'></label> "
+        "<button type='submit'>Show</button></form>"
+    )
+
+    if not grouped:
+        html.append("<p>No data.</p>")
+        return "\n".join(html)
+
+    for cid, entries in grouped.items():
+        html.append(f"<h2>Charger {cid}</h2>")
+        html.append("<table class='ocpp-details'>")
+        html.append("<tr><th>RFID</th><th>VIN</th><th>Energy(kWh)</th></tr>")
+        for e in entries:
+            html.append(
+                f"<tr><td>{e['id_tag'] or '-'}</td><td>{e['vin'] or '-'}</td><td>{e['energy']}</td></tr>"
+            )
+        html.append("</table>")
+
     return "\n".join(html)
 

--- a/projects/ocpp/ocpp.py
+++ b/projects/ocpp/ocpp.py
@@ -83,6 +83,8 @@ def view_ocpp_dashboard(*, _title="OCPP Dashboard", **_):
          f"Chargers: {chargers}<br>Sessions: {sessions}"),
         ("Energy Time Series", "/ocpp/time-series",
          f"Total Energy: {energy} kWh"),
+        ("Weekly RFID Report", "/ocpp/weekly-report",
+         "Consumption by tag"),
         ("CP Simulator", "/ocpp/evcs/cp-simulator",
          sim_running),
     ]

--- a/tests/test_ocpp_data.py
+++ b/tests/test_ocpp_data.py
@@ -35,7 +35,7 @@ class OcppDataTests(unittest.TestCase):
         ocpp_data.DBFILE = self.old_db
 
     def test_basic_record_cycle(self):
-        ocpp_data.record_transaction_start("A", 1, 100)
+        ocpp_data.record_transaction_start("A", 1, 100, vin="VIN123", validator="test")
         ocpp_data.record_meter_value("A", 1, 105, "Energy.Active.Import.Register", 500, "Wh")
         ocpp_data.record_transaction_stop("A", 1, 110, meter_stop=550)
         rows = list(ocpp_data.iter_transactions("A"))


### PR DESCRIPTION
## Summary
- extend OCPP transaction table to store VIN and validator
- record VIN and validator when a StartTransaction is accepted
- add weekly RFID consumption report per charger
- add link to the RFID report from the OCPP dashboard
- adjust docs for new view
- rename `view_rfid_weekly_report` to `view_weekly_report`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6882b188765c832697912b432bfa829f