### PR TITLE
Add ws_tag filter for Odoo quote fetching

### DIFF
--- a/projects/odoo.py
+++ b/projects/odoo.py
@@ -64,6 +64,7 @@ def fetch_quotes(
     salesperson=None,
     customer=None,
     tag=None,
+    ws_tag=None,
     **kwargs
 ):
     """
@@ -75,6 +76,7 @@ def fetch_quotes(
         salesperson (str, optional): Filter quotations by the salesperson's name or part of it.
         customer (str, optional): Filter quotations by the customer's name or part of it.
         tag (str | int, optional): Filter quotations by tag name or id.
+        ws_tag (str | int, optional): Filter quotations by tag containing whitespace.
         kwargs (list, optional): Additional domain filters for the query.
 
     Returns:
@@ -91,6 +93,8 @@ def fetch_quotes(
         domain_filter.append(('user_id.name', 'ilike', salesperson))
     if customer:
         domain_filter.append(('partner_id.name', 'ilike', customer))
+    if ws_tag and not tag:
+        tag = ws_tag
     if tag:
         try:
             tag_id = int(tag)

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -69,7 +69,7 @@ class GatewayBuiltinsTests(unittest.TestCase):
 
     def test_help_list_flags(self):
         flags = gw.help(list_flags=True)["Test Flags"]
-        expected = {"failure", "ocpp", "proxy", "screen"}
+        expected = {"failure", "ocpp", "proxy", "screen", "odoo"}
         self.assertEqual(set(flags.keys()), expected)
         for tests in flags.values():
             self.assertIsInstance(tests, list)

--- a/tests/test_odoo.py
+++ b/tests/test_odoo.py
@@ -1,16 +1,19 @@
 import os
 import unittest
 from unittest.mock import patch
+import pytest
 from gway import gw
+from gway.builtins import is_test_flag
+
+pytestmark = pytest.mark.odoo
 
 odoo = gw.load_project("odoo")
 
 
+@unittest.skipUnless(is_test_flag("odoo"), "Odoo tests disabled")
 class TestCreateTask(unittest.TestCase):
     def test_title_defaults_to_customer(self):
         calls = {}
-        self.skipTest("Odoo configuration unavailable")
-
         def fake_execute_kw(args, kwargs, *, model, method):
             if model == 'res.partner' and method == 'create':
                 calls['partner'] = args[0]
@@ -41,10 +44,9 @@ class TestCreateTask(unittest.TestCase):
         self.assertEqual(task[0]['description'], 'Phone: 123\nHello')
 
 
+@unittest.skipUnless(is_test_flag("odoo"), "Odoo tests disabled")
 class TestQuoteTags(unittest.TestCase):
     def test_fetch_quote_tags(self):
-        self.skipTest("Odoo configuration unavailable")
-
         def fake_execute_kw(args, kwargs, *, model, method):
             self.assertEqual(model, 'crm.tag')
             self.assertEqual(method, 'search_read')
@@ -56,8 +58,6 @@ class TestQuoteTags(unittest.TestCase):
         self.assertEqual(res[0]['name'], 'VIP')
 
     def test_fetch_quotes_with_tag(self):
-        self.skipTest("Odoo configuration unavailable")
-
         captured = {}
 
         def fake_execute_kw(args, kwargs, *, model, method):
@@ -68,11 +68,21 @@ class TestQuoteTags(unittest.TestCase):
             odoo.fetch_quotes(tag='VIP')
         self.assertIn(('tag_ids.name', 'ilike', 'VIP'), captured['domain'])
 
+    def test_fetch_quotes_with_ws_tag(self):
+        captured = {}
 
+        def fake_execute_kw(args, kwargs, *, model, method):
+            captured['domain'] = args[0]
+            return []
+
+        with patch('odoo.execute_kw', side_effect=fake_execute_kw):
+            odoo.fetch_quotes(ws_tag='VIP Customer')
+        self.assertIn(('tag_ids.name', 'ilike', 'VIP Customer'), captured['domain'])
+
+
+@unittest.skipUnless(is_test_flag("odoo"), "Odoo tests disabled")
 class TestFindQuotes(unittest.TestCase):
     def test_find_quotes_with_tag(self):
-        self.skipTest("Odoo configuration unavailable")
-
         captured = {}
 
         def fake_execute_kw(args, kwargs, *, model, method):


### PR DESCRIPTION
## Summary
- extend `fetch_quotes` to accept a `ws_tag` parameter
- test whitespace tag filtering
- mark Odoo tests with `odoo` flag and update expected flags list

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6882c6448c6c8326b1ea475113c4a263