### PR TITLE
Add dynamic sitemap generation

### DIFF
--- a/projects/web/app.py
+++ b/projects/web/app.py
@@ -619,6 +619,13 @@ def setup_app(project,
         return HTTPResponse(status=404, body="favicon.ico not found")
     add_route(app, "/favicon.ico", "GET", favicon)
 
+    if is_setup("web.sitemap"):
+        def sitemap_xml():
+            mod = gw.find_project("web.sitemap")
+            return mod.view_sitemap_xml()
+
+        add_route(app, "/sitemap.xml", "GET", sitemap_xml)
+
     if gw.verbose:
         gw.info(f"Registered homes: {_homes}")
         debug_routes(app)

--- a/projects/web/sitemap.py
+++ b/projects/web/sitemap.py
@@ -1,0 +1,55 @@
+"""Automatic sitemap.xml generation for GWAY websites."""
+
+from gway import gw
+import datetime
+import html
+import sys
+
+__all__ = ["generate", "view_sitemap_xml"]
+
+
+def _collect_routes():
+    """Return a sorted set of route paths from the current web app."""
+    webapp = sys.modules[gw.web.app.setup_app.__module__]
+    homes = getattr(webapp, "_homes", [])
+    links_map = getattr(webapp, "_links", {})
+    routes = set()
+
+    for _, route in homes:
+        base = route.strip("/")
+        routes.add(base)
+        sub = links_map.get(route, [])
+        proj_root = base.rsplit("/", 1)[0] if "/" in base else base
+        for name in sub:
+            if isinstance(name, tuple):
+                proj, view = name
+                target = f"{proj.replace('.', '/')}/{view}".strip("/")
+            else:
+                target = f"{proj_root}/{name}".strip("/")
+            routes.add(target)
+    return sorted(routes)
+
+
+def generate(base_url: str | None = None) -> str:
+    """Return sitemap XML for the configured routes."""
+    base = (base_url or gw.web.base_url()).rstrip("/")
+    today = datetime.date.today().isoformat()
+    entries = []
+    for path in _collect_routes():
+        loc = html.escape(f"{base}/{path}")
+        entries.append(f"  <url><loc>{loc}</loc><lastmod>{today}</lastmod></url>")
+    xml = (
+        "<?xml version='1.0' encoding='UTF-8'?>\n"
+        "<urlset xmlns='http://www.sitemaps.org/schemas/sitemap/0.9'>\n"
+        + "\n".join(entries)
+        + "\n</urlset>"
+    )
+    return xml
+
+
+def view_sitemap_xml():
+    """Bottle view that serves ``sitemap.xml``."""
+    from bottle import response
+
+    response.content_type = "application/xml"
+    return generate()

--- a/recipes/test/website.gwr
+++ b/recipes/test/website.gwr
@@ -16,6 +16,7 @@ web app setup:
         --links active-chargers,charger-summary,time-series,cp-simulator,manage-rfids
     - games --home toy-games --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
     - web.auth
+    - web.sitemap
 
 help-db build
 

--- a/recipes/website.gwr
+++ b/recipes/website.gwr
@@ -17,6 +17,7 @@ web app setup:
     - games --home toy-games \
         --links game-of-life,divination-wars,qpig-farm,massive-snake,four-in-a-row,fantastic-client
     - web.auth
+    - web.sitemap
 
 help-db build
 

--- a/tests/test_sitemap.py
+++ b/tests/test_sitemap.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest.mock import patch
+from paste.fixture import TestApp
+from gway import gw
+
+
+class SitemapXMLTests(unittest.TestCase):
+    def setUp(self):
+        gw.results.clear()
+        gw.context.clear()
+
+    def test_sitemap_contains_registered_routes(self):
+        app = gw.web.app.setup_app("dummy", home="index")
+        gw.web.app.setup_app("web.sitemap", app=app)
+        with patch.object(gw.web, "base_url", return_value="https://example.com"):
+            client = TestApp(app)
+            resp = client.get("/sitemap.xml")
+            body = resp.body.decode()
+            self.assertIn("<loc>https://example.com/dummy/index</loc>", body)
+            self.assertIn("<loc>https://example.com/dummy/about</loc>", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- generate sitemap.xml via new `web.sitemap` project
- expose `/sitemap.xml` route from `web.app`
- test sitemap creation
- only register `/sitemap.xml` when `web.sitemap` is enabled
- add `web.sitemap` to the website recipe

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6882d922ddbc83268e95f6051a38cd81