### PR TITLE
Add unit conversion support for CLI flags

### DIFF
--- a/data/static/awg/README.rst
+++ b/data/static/awg/README.rst
@@ -31,6 +31,8 @@ Parameters
 
 ``meters``
   Cable length in meters (required).
+``yards``
+  Alternative to ``meters``. Values are converted to meters automatically.
 ``amps``
   Load in amperes, default ``40``.
 ``volts``

--- a/gway/units.py
+++ b/gway/units.py
@@ -1,0 +1,14 @@
+# file: gway/units.py
+"""Utility functions for unit conversions."""
+
+from __future__ import annotations
+
+
+def yards_to_meters(value: float | str) -> float:
+    """Convert yards to meters."""
+    return float(value) * 0.9144
+
+
+def meters_to_yards(value: float | str) -> float:
+    """Convert meters to yards."""
+    return float(value) / 0.9144

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,14 @@
+import unittest
+from gway.console import process
+from gway import gw
+
+class UnitConversionTests(unittest.TestCase):
+    def test_yards_flag_converts_to_meters(self):
+        cmds = [['awg', 'find-awg', '--yards', '30', '--amps', '60']]
+        _, result = process(cmds)
+        expected = gw.awg.find_awg(meters=27, amps=60)
+        self.assertEqual(result['awg'], expected['awg'])
+        self.assertEqual(result['meters'], expected['meters'])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- introduce `gway.units` with basic converters
- allow CLI flags to convert units if matching converters exist
- mention yards in AWG README
- test that yards flag resolves for `find-awg`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68843ac5fcf08326a34718770bae50c7