### PR TITLE
Add unit conversion support for interval flags

### DIFF
--- a/data/static/awg/README.rst
+++ b/data/static/awg/README.rst
@@ -31,6 +31,8 @@ Parameters
 
 ``meters``
   Cable length in meters (required).
+``yards``
+  Alternative to ``meters``. Values are converted to meters automatically.
 ``amps``
   Load in amperes, default ``40``.
 ``volts``

--- a/data/static/ocpp/README.rst
+++ b/data/static/ocpp/README.rst
@@ -30,7 +30,9 @@ The simulator can also be controlled via the web UI at
 The simulator accepts ``--kwh-min`` and ``--kwh-max`` to control the
 approximate energy delivered per session. For example, ``--kwh-min 40
 --kwh-max 70`` will produce sessions around 40–70 kWh. Use ``--interval``
-to specify how often MeterValues are sent (default 5s). The
+or ``--seconds`` to specify how often MeterValues are sent (default 5s).
+``--minutes``, ``--hours`` and ``--days`` are also accepted and converted
+to seconds automatically. The
 ``--pre-charge-delay`` option keeps the charger idle for the given
 number of seconds after connecting while it sends Heartbeats and idle
 MeterValues.
@@ -136,5 +138,5 @@ local file. Run it periodically with ``every``:
 
 .. code-block:: bash
 
-   every --interval 300 gw.auth_db.sync_from_url \
+   every --minutes 5 gw.auth_db.sync_from_url \
        http://example.com/work/auth.duckdb

--- a/gway/console.py
+++ b/gway/console.py
@@ -10,6 +10,8 @@ import argcomplete
 import csv
 from typing import get_origin, get_args, Literal, Union
 
+from . import units
+
 from .logging import setup_logging
 from .builtins import abort
 from .gateway import Gateway, gw
@@ -421,6 +423,29 @@ def add_func_args(subparser, func_obj):
                     opts = get_arg_opts(arg_name, param, gw)
                     subparser.add_argument(cli_name, **opts)
 
+                    # Add unit conversion flags if available
+                    for alt_name, conv in _unit_converters(arg_name):
+                        alt_cli = f"--{alt_name.replace('_', '-')}"
+                        base_type = opts.get("type", str)
+
+                        def _wrapper(val, _conv=conv, _cast=base_type):
+                            converted = _conv(val)
+                            if _cast is str and int in get_args(param.annotation):
+                                try:
+                                    return str(int(converted))
+                                except Exception:
+                                    return str(converted)
+                            return _cast(converted)
+
+                        alt_opts = {k: v for k, v in opts.items()
+                                    if k not in {"required", "default"}}
+                        alt_opts["dest"] = arg_name
+                        alt_opts["type"] = _wrapper
+                        alt_opts.setdefault(
+                            "help",
+                            f"Alias for --{arg_name} in {alt_name} units")
+                        subparser.add_argument(alt_cli, **alt_opts)
+
 
 def get_arg_opts(arg_name, param, gw=None):
     """Infer argparse options from parameter signature."""
@@ -444,6 +469,8 @@ def get_arg_opts(arg_name, param, gw=None):
             inferred_type = str
     elif annotation != inspect.Parameter.empty:
         inferred_type = annotation
+    elif isinstance(default, (int, float)):
+        inferred_type = type(default)
 
     opts["type"] = inferred_type
 
@@ -458,6 +485,17 @@ def get_arg_opts(arg_name, param, gw=None):
         opts["required"] = True
 
     return opts
+
+
+def _unit_converters(param_name: str):
+    """Return (alt_name, function) pairs for conversions to *param_name*."""
+    suffix = f"_to_{param_name}"
+    converters = []
+    for name, func in inspect.getmembers(units, inspect.isfunction):
+        if name.endswith(suffix) and name != suffix:
+            alt = name[: -len(suffix)]
+            converters.append((alt, func))
+    return converters
 
 
 ...

--- a/gway/units.py
+++ b/gway/units.py
@@ -1,0 +1,34 @@
+# file: gway/units.py
+"""Utility functions for unit conversions."""
+
+from __future__ import annotations
+
+
+def yards_to_meters(value: float | str) -> float:
+    """Convert yards to meters."""
+    return float(value) * 0.9144
+
+
+def meters_to_yards(value: float | str) -> float:
+    """Convert meters to yards."""
+    return float(value) / 0.9144
+
+
+def seconds_to_interval(value: float | str) -> float:
+    """Identity conversion for interval seconds."""
+    return float(value)
+
+
+def minutes_to_interval(value: float | str) -> float:
+    """Convert minutes to seconds for interval parameters."""
+    return float(value) * 60
+
+
+def hours_to_interval(value: float | str) -> float:
+    """Convert hours to seconds for interval parameters."""
+    return float(value) * 3600
+
+
+def days_to_interval(value: float | str) -> float:
+    """Convert days to seconds for interval parameters."""
+    return float(value) * 86400

--- a/projects/monitor/monitor.py
+++ b/projects/monitor/monitor.py
@@ -54,7 +54,9 @@ def start_watch(
     Start a watcher loop for a project.
       - project: Name of the GWAY project or subproject.
       - monitor: Name or list of monitor functions (string or list, without prefix).
-      - interval: Minimum seconds between checks.
+      - interval: Minimum seconds between checks. CLI users may also specify
+        ``--seconds``, ``--minutes``, ``--hours`` or ``--days`` which are
+        converted automatically.
       - delay: Startup delay (seconds).
       - block: Block main thread? (default False)
       - daemon: Async coroutine? (default True)

--- a/projects/studio/clip.py
+++ b/projects/studio/clip.py
@@ -45,7 +45,9 @@ def track_history(interval: int = 5, *, stop_after=None, notify=True):
     """Tracks clipboard history by polling at regular intervals.
 
     Args:
-        interval (int): Seconds to wait between checks. Default is 5 seconds.
+        interval (int): Seconds to wait between checks. CLI callers may also
+            provide ``--seconds``/``--minutes``/``--hours``/``--days`` which are
+            converted automatically. Default is 5 seconds.
         stop_after (int | None): Optional maximum duration (in seconds) before stopping.
         notify (bool): Whether to show GUI notifications for new entries.
 

--- a/projects/studio/screen.py
+++ b/projects/studio/screen.py
@@ -164,7 +164,9 @@ def reminder(message, *, interval: float = 20.0, daemon=False, lines: int = 2):
     """
     Starts a thread that periodically takes screenshots.
     If the screen hasn't changed between intervals, overlays a reminder
-    message and waits for user interaction before resuming.
+    message and waits for user interaction before resuming. When called from
+    the CLI ``interval`` can also be specified via ``--seconds``, ``--minutes``,
+    ``--hours`` or ``--days``.
     """
     import threading
     from PIL import ImageChops

--- a/projects/vbox.py
+++ b/projects/vbox.py
@@ -432,7 +432,9 @@ def poll_remote(server_url: str = '[SERVER_URL]', *, target='work/vbox/remote', 
     Poll the remote vbox for files and download new/updated ones to the local target directory.
     - server_url: Remote GWAY instance base URL
     - target: Local directory to save downloaded files
-    - interval: Seconds between polls (runs forever unless interval=None)
+    - interval: Seconds between polls (runs forever unless interval=None). CLI
+      callers may also pass ``--seconds``, ``--minutes``, ``--hours`` or
+      ``--days`` instead of ``--interval``.
     
     Skips files already downloaded by using the modified_since parameter.
     """

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -1,0 +1,27 @@
+import unittest
+from gway.console import process
+from gway import gw
+
+class UnitConversionTests(unittest.TestCase):
+    def test_yards_flag_converts_to_meters(self):
+        cmds = [['awg', 'find-awg', '--yards', '30', '--amps', '60']]
+        _, result = process(cmds)
+        expected = gw.awg.find_awg(meters=27, amps=60)
+        self.assertEqual(result['awg'], expected['awg'])
+        self.assertEqual(result['meters'], expected['meters'])
+
+    def test_interval_alias_seconds_and_minutes(self):
+        cmds = [['monitor', 'start-watch', 'rpi', '--no-daemon', '--interval', '60']]
+        process(cmds)
+        expected = gw.monitor.get_next_check_time('rpi')
+
+        cmds = [['monitor', 'start-watch', 'rpi', '--no-daemon', '--seconds', '60']]
+        process(cmds)
+        self.assertEqual(gw.monitor.get_next_check_time('rpi'), expected)
+
+        cmds = [['monitor', 'start-watch', 'rpi', '--no-daemon', '--minutes', '1']]
+        process(cmds)
+        self.assertEqual(gw.monitor.get_next_check_time('rpi'), expected)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add time unit converters in `gway.units`
- infer numeric types from default values in CLI parser
- document new `--seconds`, `--minutes`, `--hours` and `--days` flags
- update monitor, vbox and studio docs accordingly
- extend unit tests for interval flag aliases

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68843ac5fcf08326a34718770bae50c7