### PR TITLE
Add auth DB refresh to local proxy recipe

### DIFF
--- a/recipes/test/etron/local_proxy.gwr
+++ b/recipes/test/etron/local_proxy.gwr
@@ -16,4 +16,6 @@ web:
  - static collect
  - server start-app --host 0.0.0.0 --port 18888 --ws-port 19900 --proxy http://127.0.0.1:18000 --proxy-mode remote
 
+every --minutes 5 gw.auth_db.sync_from_url http://127.0.0.1:18000/work/auth.duckdb
+
 until --version

--- a/tests/test_proxy_fallback.py
+++ b/tests/test_proxy_fallback.py
@@ -15,6 +15,7 @@ import requests
 from gway import gw
 
 KNOWN_TAG = "FFFFFFFF"
+UNKNOWN_TAG = "00000000"
 
 @unittest.skipUnless(is_test_flag("proxy"), "Proxy tests disabled")
 class ProxyFallbackTests(unittest.TestCase):
@@ -92,5 +93,23 @@ class ProxyFallbackTests(unittest.TestCase):
 
         resp2 = requests.get("http://127.0.0.1:18888/web/cookies/cookie-jar")
         self.assertEqual(resp2.status_code, 200)
+
+    def test_offline_invalid_rfid_rejected(self):
+        async def run_session():
+            await gw.ocpp.evcs.simulate_cp.__wrapped__(
+                0,
+                "127.0.0.1",
+                19900,
+                UNKNOWN_TAG,
+                "SIM_BAD",
+                1,
+                1,
+                1,
+                1,
+            )
+        asyncio.run(run_session())
+
+        records = os.path.join("work", "ocpp", "records", "SIM_BAD")
+        self.assertFalse(os.path.isdir(records) and os.listdir(records))
 
 


### PR DESCRIPTION
## Summary
- periodically sync `auth_db` in `local_proxy.gwr`
- extend proxy fallback tests with invalid RFID scenario

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6884288dbd208326974f2c8996b4b617