### PR TITLE
Require % prefix for eager sigil resolution

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,9 @@ Core Concepts
   referenced by name.  Use sigils like ``[result.key]`` to pull values into
   later calls.
 - **Sigils**: ``[VAR]`` or ``[object.attr]`` placeholders resolve from previous
-  results, ``gw.context`` and environment variables.
+  results, ``gw.context`` and environment variables. Automatic resolution only
+  happens for sigils prefixed with ``%`` (e.g. ``%[VAR]``); other sigils remain
+  lazy until passed to ``gw.resolve`` or ``gw["VAR"]``.
 - **Recipes** ``.gwr``: text files listing commands.  Indented lines reuse the
   previous command allowing very compact scripts.  Run them via
   ``gway -r file`` or ``gw.run_recipe('file.gwr')``.

--- a/data/static/render.js
+++ b/data/static/render.js
@@ -82,7 +82,7 @@
   }
 
   function replaceSigilsInString(str, data) {
-    return str.replace(/\[([^\[\]]+)\]/g, (m, key) => {
+    return str.replace(/%\[([^\[\]]+)\]/g, (m, key) => {
       key = key.split('|')[0].trim();
       return Object.prototype.hasOwnProperty.call(data, key) ? data[key] : m;
     });

--- a/data/static/web/README.rst
+++ b/data/static/web/README.rst
@@ -34,7 +34,7 @@ insertion via ``render.js`` or inclusion in an ``iframe``.
   is or contains a form, fields are posted along with data attributes.
 - ``gw-view`` – call the named ``view_*`` function without the page layout. Form
   values are sent just like ``gw-render``.
-- ``gw-api`` – call the named ``api_*`` function and replace any ``[sigils]``
+- ``gw-api`` – call the named ``api_*`` function and replace any ``%[sigils]``
   in the element with values from the JSON response. If the element is a form,
   or contains one, form fields are posted as parameters. A different form can
   be specified with ``gw-form``.

--- a/gway/gateway.py
+++ b/gway/gateway.py
@@ -222,14 +222,14 @@ class Gateway(Resolver, Runner):
                         value = self.find_value(name)
                         if value is None:
                             default_val = bound_args.arguments.get(name, param.default)
-                            if isinstance(default_val, (Sigil, Spool)):
+                            if isinstance(default_val, (Sigil, Spool)) and getattr(default_val, 'is_eager', False):
                                 value = default_val.resolve(self)
                             else:
                                 value = default_val
                     else:
                         # Check for context/env first
                         default_val = bound_args.arguments.get(name, param.default)
-                        if isinstance(default_val, (Sigil, Spool)):
+                        if isinstance(default_val, (Sigil, Spool)) and getattr(default_val, 'is_eager', False):
                             value = default_val.resolve(self)
                         else:
                             value = default_val

--- a/projects/kiosk/window.py
+++ b/projects/kiosk/window.py
@@ -11,8 +11,8 @@ from gway import __, gw
 def show(
     *,
     url: Optional[str] = None,
-    host: str = __("[SITE_HOST]", "0.0.0.0"),
-    port: int = __('[SITE_PORT]', '8888'),
+    host: str = __("%[SITE_HOST]", "0.0.0.0"),
+    port: int = __('%[SITE_PORT]', '8888'),
     width: int = 1024,
     height: int = 768,
     fullscreen: bool = False,

--- a/projects/ocpp/evcs.py
+++ b/projects/ocpp/evcs.py
@@ -39,8 +39,8 @@ def _unique_cp_path(cp_path, idx, total_threads):
 
 def simulate(
     *,
-    host: str = __("[SITE_HOST]", "127.0.0.1") ,
-    ws_port: int = __("[WEBSOCKET_PORT]", "9000"),
+    host: str = __("%[SITE_HOST]", "127.0.0.1") ,
+    ws_port: int = __("%[WEBSOCKET_PORT]", "9000"),
     rfid: str = "FFFFFFFF",
     cp_path: str = "CPX",
     duration: int = 600,

--- a/projects/web/server.py
+++ b/projects/web/server.py
@@ -7,9 +7,9 @@ from gway import gw, __
 _active_servers = {}  # key: label or index, value: dict with host/port/ws_port
 
 def start_app(*,
-    host            = __('[SITE_HOST]', '[BASE_HOST]', '0.0.0.0'),
-    port : int      = __('[SITE_PORT]', '[BASE_PORT]', '8888'),
-    ws_port : int   = __('[WS_PORT]', '[WEBSOCKET_PORT]', '9999'),
+    host            = __('%[SITE_HOST]', '%[BASE_HOST]', '0.0.0.0'),
+    port : int      = __('%[SITE_PORT]', '%[BASE_PORT]', '8888'),
+    ws_port : int   = __('%[WS_PORT]', '%[WEBSOCKET_PORT]', '9999'),
     debug=False,
     proxy=None,
     proxy_mode: str = "extend",

--- a/projects/web/site.py
+++ b/projects/web/site.py
@@ -11,7 +11,7 @@ from gway import gw, __
 from gway.console import process, chunk
 import markdown as mdlib
 
-_DEFAULT_TOME = __('[README]', 'README')
+_DEFAULT_TOME = __('%[README]', 'README')
 
 def view_reader(
     *parts,

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -78,10 +78,18 @@ class GatewayTests(unittest.TestCase):
     def test_wrap_callable_raises_on_unresolved_sigils(self):
         from gway.sigils import Sigil
         gw.context.clear()
-        def func(x=Sigil("[NOT_PRESENT]")): return x
+        def func(x=Sigil("%[NOT_PRESENT]")): return x
         wrapped = gw.wrap_callable("failtest", func)
         with self.assertRaises(KeyError):
             wrapped()
+
+    def test_lazy_sigils_are_not_auto_resolved(self):
+        from gway.sigils import Sigil
+        def func(x=Sigil("[LATE]")):
+            return x
+        wrapped = gw.wrap_callable("lazytest", func)
+        result = wrapped()
+        self.assertIsInstance(result, Sigil)
 
     def test_find_project_returns_first(self):
         from pathlib import Path


### PR DESCRIPTION
## Summary
- implement `%` prefix for eager sigil resolution
- update resolver and gateway logic for new behaviour
- update CLI default resolution logic
- change API block sigil replacement to expect `%[sigil]`
- update docs and tests
- mark spool defaults with `%` so they keep resolving automatically

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_6887b4f006dc8326a5fefea035ae6311