### PR TITLE
Improve gw lookup parsing

### DIFF
--- a/gway/runner.py
+++ b/gway/runner.py
@@ -19,10 +19,25 @@ class Runner:
         super().__init__(*args, **kwargs)
 
     def _resolve_callable(self, name):
+        """Return a callable from a dotted/space path or via gw lookup."""
+        import re
+
         if callable(name):
             return name
+
+        key = str(name).strip()
+        key = re.sub(r"^(gw|gway)[. ]+", "", key)
+
+        if hasattr(self, "__getitem__"):
+            try:
+                func = self[key]
+                if callable(func):
+                    return func
+            except Exception:
+                pass
+
         obj = self
-        for part in str(name).split('.'):
+        for part in re.split(r"[. ]+", key):
             obj = getattr(obj, part)
         return obj
 

--- a/gway/sigils.py
+++ b/gway/sigils.py
@@ -59,6 +59,7 @@ def _resolve_single(raw, lookup_fn):
     raw = raw.strip()
     quoted = (raw.startswith('"') and raw.endswith('"')) or (raw.startswith("'") and raw.endswith("'"))
     key = _unquote(raw) if quoted else raw
+    key = re.sub(r"^(gw|gway)[. ]+", "", key)
 
     val = lookup_fn(key)
     if val is None:
@@ -181,6 +182,9 @@ class Resolver:
         return fallback
 
     def _resolve_key(self, key: str, fallback: str = None) -> str:
+        key = key.strip()
+        key = re.sub(r"^(gw|gway)[. ]+", "", key)
+
         val = self.find_value(key, None)
         if val is not None:
             return val
@@ -194,7 +198,7 @@ class Resolver:
                 except KeyError:
                     return fallback
 
-        parts = key.replace('-', '_').split('.')
+        parts = re.split(r"[. ]+", key.replace('-', '_'))
         current = self
         for part in parts:
             if part.startswith('_'):

--- a/projects/web/proxy.py
+++ b/projects/web/proxy.py
@@ -268,6 +268,8 @@ def _wire_error_fallback(app, endpoint: str, path: str):
 
 def _wire_trigger_fallback(app, endpoint: str, callback):
     """Attach middleware/hooks to proxy when callback(request) returns True."""
+    if isinstance(callback, str):
+        callback = gw[callback]
     if not callable(callback):
         raise ValueError("callback must be callable for trigger mode")
 


### PR DESCRIPTION
## Summary
- allow leading `gw.` or `gway.` to be ignored when resolving values
- support spaces as path separators in gw lookup strings
- resolve periodic tasks via `gw[...]`
- allow proxy trigger callbacks specified as strings

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_6887b5e246888326b33c3e9da7df310e