### PR TITLE
Split Odoo quote tags with whitespace into separate tags

### DIFF
--- a/recipes/odoo_split_ws_tags.gwr
+++ b/recipes/odoo_split_ws_tags.gwr
@@ -1,0 +1,4 @@
+# file: recipes/odoo_split_ws_tags.gwr
+
+# Split tags with whitespace into separate tags on all quotes
+odoo split-ws-quote-tags


### PR DESCRIPTION
## Summary
- add `split_ws_quote_tags` helper to replace space-separated quote tags with individual tags
- provide gway recipe to run whitespace tag migration
- cover whitespace tag splitting with unit test

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_688d3a0004448326a3f7f5578ae267ef