### PR TITLE
Expose Django models via gw.django

### DIFF
--- a/projects/django.py
+++ b/projects/django.py
@@ -1,0 +1,34 @@
+# file: projects/django.py
+"""Virtual project providing access to Django models via attribute lookup.
+
+The project assumes ``DJANGO_SETTINGS_MODULE`` points to a valid Django
+settings module. Models from the configured Django project can then be
+accessed as attributes from ``gw.django``.
+"""
+
+from __future__ import annotations
+
+import django
+from django.apps import apps
+
+
+def _ensure_setup():
+    """Initialize Django if it hasn't been configured yet."""
+    if not apps.ready:
+        django.setup()
+
+
+def __getattr__(self, name: str):
+    """Return a model class from the current Django project.
+
+    Example
+    -------
+    ``gw.django.User`` → ``django.contrib.auth.models.User``
+    """
+    _ensure_setup()
+    for model in apps.get_models():
+        if model.__name__ == name:
+            setattr(self, name, model)
+            return model
+    raise AttributeError(f"Model '{name}' not found")
+

--- a/tests/djproj/__init__.py
+++ b/tests/djproj/__init__.py
@@ -1,0 +1,1 @@
+# file: tests/djproj/__init__.py

--- a/tests/djproj/settings.py
+++ b/tests/djproj/settings.py
@@ -1,0 +1,9 @@
+# file: tests/djproj/settings.py
+SECRET_KEY = "test"
+INSTALLED_APPS = [
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+]
+DATABASES = {
+    "default": {"ENGINE": "django.db.backends.sqlite3", "NAME": ":memory:"}
+}

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -1,0 +1,22 @@
+# file: tests/test_django_models.py
+import os
+
+import pytest
+
+pytest.importorskip("django")
+
+
+def setup_module():
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "tests.djproj.settings")
+    import django
+
+    django.setup()
+
+
+def test_access_user_model():
+    from gway import gw
+    from django.contrib.auth.models import User
+
+    model = gw.django.User
+    assert model is User
+


### PR DESCRIPTION
## Summary
- allow project modules to supply a custom `__getattr__` that is attached to their gateway `Project`
- add virtual `django` project exposing models from the configured Django app via attribute access
- introduce tests covering Django model access

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_688ecdb50a9c832690b67094842b528d