### PR TITLE
Add list_models helper for Django project

### DIFF
--- a/projects/django.py
+++ b/projects/django.py
@@ -18,6 +18,12 @@ def _ensure_setup():
         django.setup()
 
 
+def list_models() -> list[str]:
+    """Return a sorted list of model names from the current Django project."""
+    _ensure_setup()
+    return sorted(model.__name__ for model in apps.get_models())
+
+
 def __getattr__(self, name: str):
     """Return a model class from the current Django project.
 

--- a/tests/test_django_models.py
+++ b/tests/test_django_models.py
@@ -20,3 +20,10 @@ def test_access_user_model():
     model = gw.django.User
     assert model is User
 
+
+def test_list_models():
+    from gway import gw
+
+    models = gw.django.list_models()
+    assert "User" in models
+


### PR DESCRIPTION
## Summary
- allow retrieving model names from the Django virtual project via `list_models`
- cover Django model listing with a unit test

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --filter test_django_models` *(no tests discovered)*
- `PYTHONPATH=. pytest tests/test_django_models.py::test_list_models -q`

------
https://chatgpt.com/codex/tasks/task_e_6890bc41d9f0832682f41421f461bffa