### PR TITLE
Ensure AWG calculator reloads wire data on first use

### DIFF
--- a/projects/sql/sql.py
+++ b/projects/sql/sql.py
@@ -283,6 +283,11 @@ def open_db(
     # Reuse cached connection if available
     if key in _connection_cache:
         conn = _connection_cache[key]
+        if autoload and conn._engine == "sqlite" and (force or not getattr(conn, "_autoloaded", False)):
+            load_csv(connection=conn, force=force)
+            load_excel(connection=conn, force=force)
+            load_cdv(connection=conn, force=force)
+            conn._autoloaded = True
         if row_factory:
             gw.warning("Row factory change requires close_db(). Reconnect manually.")
         gw.verbose(f"Reusing connection: {key}")
@@ -330,6 +335,7 @@ def open_db(
         load_csv(connection=conn, force=force)
         load_excel(connection=conn, force=force)
         load_cdv(connection=conn, force=force)
+        conn._autoloaded = True
 
     return conn
 


### PR DESCRIPTION
## Summary
- Reload CSV/Excel/CDV tables when reusing a cached SQLite connection
- Drop AWG-specific DB reload helper and rely on SQL autoload in AWG utilities

## Testing
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68916a02aed88326b6bb578dad5236cf