### PR TITLE
Add RFID approval regression tests

### DIFF
--- a/tests/test_rfid_approve.py
+++ b/tests/test_rfid_approve.py
@@ -1,0 +1,57 @@
+import unittest
+import os
+import tempfile
+from gway import gw
+
+# Ensure project functions are available
+gw.load_project("ocpp.rfid")
+
+
+class RFIDApproveTests(unittest.TestCase):
+    TABLE = "work/test_rfids_approve.cdv"
+
+    def setUp(self):
+        path = gw.resource(self.TABLE)
+        if os.path.exists(path):
+            os.remove(path)
+
+    def tearDown(self):
+        path = gw.resource(self.TABLE)
+        if os.path.exists(path):
+            os.remove(path)
+
+    def test_approve_allows_valid_tag(self):
+        gw.ocpp.rfid.create_entry("OK", balance=2, allowed=True, table=self.TABLE)
+        payload = {"idTag": "OK"}
+        self.assertTrue(gw.ocpp.rfid.approve(payload=payload, table=self.TABLE))
+
+    def test_approve_rejects_unknown_tag(self):
+        payload = {"idTag": "MISSING"}
+        self.assertFalse(gw.ocpp.rfid.approve(payload=payload, table=self.TABLE))
+
+    def test_approve_rejects_low_balance(self):
+        gw.ocpp.rfid.create_entry("LOW", balance=0, allowed=True, table=self.TABLE)
+        payload = {"idTag": "LOW"}
+        self.assertFalse(gw.ocpp.rfid.approve(payload=payload, table=self.TABLE))
+
+    def test_approve_rejects_not_allowed(self):
+        gw.ocpp.rfid.create_entry("BLOCK", balance=5, allowed=False, table=self.TABLE)
+        payload = {"idTag": "BLOCK"}
+        self.assertFalse(gw.ocpp.rfid.approve(payload=payload, table=self.TABLE))
+
+    def test_approve_with_auth_db(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dbfile = os.path.join(tmp, "auth.duckdb")
+            uid = gw.auth_db.create_identity(dbfile=dbfile)
+            gw.auth_db.set_rfid("TAG", identity_id=uid, balance=5, allowed=True, dbfile=dbfile)
+            payload = {"idTag": "TAG"}
+            self.assertTrue(gw.ocpp.rfid.approve(payload=payload, dbfile=dbfile))
+            gw.auth_db.set_rfid("TAG", identity_id=uid, balance=0, allowed=True, dbfile=dbfile)
+            self.assertFalse(gw.ocpp.rfid.approve(payload=payload, dbfile=dbfile))
+            gw.auth_db.set_rfid("TAG", identity_id=uid, balance=5, allowed=False, dbfile=dbfile)
+            self.assertFalse(gw.ocpp.rfid.approve(payload=payload, dbfile=dbfile))
+            gw.sql.close_db(dbfile, sql_engine="duckdb", project="auth_db")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add unit tests covering RFID approval logic for valid, unknown, low-balance, and disallowed tags
- verify RFID approval path works when using the auth_db backend

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pip install django`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68af1ad9a9a8832693b4d0c5c3d1d8b2