### PR TITLE
Add Django model project with CLI aliases

### DIFF
--- a/data/static/model/README.rst
+++ b/data/static/model/README.rst
@@ -1,0 +1,30 @@
+Django Model Bridge
+-------------------
+
+The ``model`` project exposes Django models from the `Arthexis`_ application
+through the ``gway`` CLI. All models from every installed app are merged into a
+single namespace so you never have to specify the originating app. Models are
+resolved on demand and their methods can be invoked directly. If multiple apps
+define a model with the same class name a warning is issued and the first model
+found is used.
+
+Usage
+=====
+
+From the command line::
+
+    gway model energy-account generate-report --params
+
+For convenience the project may also be referenced as ``mod`` or the percent
+symbol (``%``)::
+
+    gway % energy-account generate-report
+
+Environment
+===========
+
+By default the project assumes ``DJANGO_SETTINGS_MODULE`` is
+``config.settings``. Set the variable to point at an alternative settings
+module if needed.
+
+.. _Arthexis: https://github.com/arthexis/arthexis

--- a/gway/console.py
+++ b/gway/console.py
@@ -650,7 +650,10 @@ def load_recipe(recipe_filename):
 
 
 def normalize_token(token):
-    return token.replace("-", "_").replace(" ", "_").replace(".", "_")
+    token = token.replace("-", "_").replace(" ", "_").replace(".", "_")
+    if token == "%":
+        return "mod"
+    return token
 
 
 def _rows_to_csv(rows):

--- a/projects/mod.py
+++ b/projects/mod.py
@@ -1,0 +1,6 @@
+# file: projects/mod.py
+"""Alias to the :mod:`projects.model` project."""
+
+from .model import list_models, __getattr__
+
+__all__ = ["list_models", "__getattr__"]

--- a/projects/model.py
+++ b/projects/model.py
@@ -1,0 +1,84 @@
+# file: projects/model.py
+"""Virtual project exposing Django models from the Arthexis application.
+
+This project lazily loads Django and makes all registered models available
+as attributes. Model names may be referenced using their original CamelCase
+form or via CLI friendly variants like ``energy-account``. Any model method
+can then be called directly from the CLI. The project defaults the
+``DJANGO_SETTINGS_MODULE`` to ``config.settings`` (Arthexis) but respects
+an existing environment variable.
+
+Example
+=======
+
+``gway model energy-account generate-report --params``
+
+Aliases ``mod`` and ``%`` are available for convenience.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from typing import Dict, List
+
+try:  # pragma: no cover - optional dependency
+    import django
+    from django.apps import apps
+except Exception:  # pragma: no cover - runtime error if accessed
+    django = None
+    apps = None
+
+
+_MODEL_MAP: Dict[str, type] | None = None
+
+
+def _ensure_setup() -> None:
+    """Configure Django once and build the model map."""
+    global _MODEL_MAP
+
+    if django is None:  # pragma: no cover - handled at runtime
+        raise RuntimeError("Django is required for the 'model' project")
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings")
+    if not apps.ready:
+        django.setup()
+
+    if _MODEL_MAP is None:
+        models_map: Dict[str, type] = {}
+        for model in apps.get_models():
+            name = model.__name__
+            if name in models_map:
+                warnings.warn(
+                    f"Duplicate model name '{name}' encountered; using first occurrence",
+                    RuntimeWarning,
+                )
+                continue
+            models_map[name] = model
+        _MODEL_MAP = models_map
+
+
+def list_models() -> List[str]:
+    """Return a sorted list of model names from the current Django project."""
+    _ensure_setup()
+    return sorted(_MODEL_MAP or [])
+
+
+def _camelize(name: str) -> str:
+    parts = name.replace("-", "_").split("_")
+    return "".join(part.capitalize() for part in parts if part)
+
+
+def __getattr__(self, name: str):
+    """Return a model class matching ``name``.
+
+    ``name`` may be provided in kebab/underscore/camel case forms.
+    """
+    _ensure_setup()
+    target = _camelize(name)
+    if _MODEL_MAP and target in _MODEL_MAP:
+        model = _MODEL_MAP[target]
+        setattr(self, name, model)
+        setattr(self, model.__name__, model)
+        return model
+    raise AttributeError(f"Model '{name}' not found")

--- a/tests/test_model_project.py
+++ b/tests/test_model_project.py
@@ -1,0 +1,44 @@
+import pytest
+
+from gway.console import normalize_token
+
+
+def test_percent_alias_normalization():
+    assert normalize_token("%") == "mod"
+
+
+def test_model_project_django_lookup(monkeypatch):
+    django = pytest.importorskip("django")
+    monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tests.djproj.settings")
+    from gway import gw
+
+    mod_proj = gw.model
+    names = mod_proj.list_models()
+    assert {"User", "ContentType"}.issubset(set(names))
+    assert mod_proj.user is mod_proj.User
+    assert mod_proj.content_type is mod_proj.ContentType
+    # alias project
+    assert gw.mod.User is mod_proj.User
+
+
+def test_duplicate_model_warning(monkeypatch):
+    django = pytest.importorskip("django")
+    monkeypatch.setenv("DJANGO_SETTINGS_MODULE", "tests.djproj.settings")
+    from gway import gw
+    import importlib
+    import gway.projects.model as model_proj
+
+    # ensure fresh model map and cache
+    importlib.reload(model_proj)
+    gw._cache.pop("model", None)
+    gw._cache.pop("mod", None)
+
+    class A: __name__ = "Thing"
+    class B: __name__ = "Thing"
+
+    monkeypatch.setattr(model_proj.apps, "get_models", lambda: [A, B])
+
+    with pytest.warns(RuntimeWarning):
+        names = gw.model.list_models()
+    assert names == ["Thing"]
+    assert gw.model.thing in {A, B}


### PR DESCRIPTION
## Summary
- expose all Django app models in a merged namespace via `model` project
- warn when multiple apps register the same model name
- document model namespace behavior and cover duplicate name handling in tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c02f02ea4c8326950f173f6c411e35