### PR TITLE
Add camera capture and display utilities

### DIFF
--- a/projects/studio/video.py
+++ b/projects/studio/video.py
@@ -1,0 +1,90 @@
+"""Video stream helpers for studio project."""
+
+from __future__ import annotations
+
+from typing import Iterator, Iterable
+from gway import gw
+
+
+def capture_camera(*, source: int = 0) -> Iterator:
+    """Capture frames from a camera device.
+
+    Parameters
+    ----------
+    source:
+        Camera index passed to ``cv2.VideoCapture``. Defaults to ``0``.
+
+    Returns
+    -------
+    Iterator
+        Generator yielding frames as numpy arrays. The capture device is
+        released automatically when iteration stops.
+    """
+    import cv2
+
+    gw.debug(f"Opening camera source {source}")
+    cap = cv2.VideoCapture(source)
+    if not cap.isOpened():
+        raise RuntimeError(f"Could not open camera {source}")
+
+    def _generator() -> Iterator:
+        try:
+            while True:
+                ret, frame = cap.read()
+                if not ret:
+                    break
+                yield frame
+        finally:
+            cap.release()
+            gw.debug("Camera released")
+
+    return _generator()
+
+
+def display_video(stream: Iterable, *, screen: int = 0) -> bool:
+    """Display frames from ``stream`` using pygame.
+
+    Parameters
+    ----------
+    stream:
+        An iterable yielding numpy array frames (H x W x 3, BGR).
+    screen:
+        Screen index (currently unused, placeholder for multi-screen setups).
+
+    Returns
+    -------
+    bool
+        ``True`` when the stream is consumed without errors.
+    """
+    if not hasattr(stream, "__iter__"):
+        raise ValueError("stream must be an iterable of frames")
+
+    import numpy as np  # noqa: F401 - only for type expectations
+    import cv2
+    import pygame
+
+    iterator = iter(stream)
+    try:
+        first = next(iterator)
+    except StopIteration:
+        return True
+
+    height, width = first.shape[:2]
+    pygame.init()
+    window = pygame.display.set_mode((width, height))
+
+    def _show(frame):
+        surf = pygame.surfarray.make_surface(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+        window.blit(surf, (0, 0))
+        pygame.display.flip()
+
+    try:
+        _show(first)
+        for frame in iterator:
+            _show(frame)
+            for event in pygame.event.get():
+                if event.type == pygame.QUIT:
+                    return True
+        return True
+    finally:
+        pygame.quit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ colorama
 pygetwindow; platform_system == "Windows"
 duckdb
 pywin32; platform_system == "Windows"
-selenium 
+selenium
 webdriver-manager
 bs4
 markdown
@@ -30,3 +30,4 @@ PyJWT
 sounddevice
 PyYAML
 pywebview
+opencv-python

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,0 +1,69 @@
+import unittest
+import importlib.util
+from pathlib import Path
+from unittest.mock import MagicMock
+import types
+import numpy as np
+
+from gway import gw
+
+
+def _load_video():
+    video_path = Path(__file__).resolve().parents[1] / "projects" / "studio" / "video.py"
+    spec = importlib.util.spec_from_file_location("video", video_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class CaptureCameraTests(unittest.TestCase):
+    def test_capture_camera_yields_frames_and_releases(self):
+        video = _load_video()
+        frame = np.zeros((10, 10, 3), dtype="uint8")
+
+        fake_cap = MagicMock()
+        fake_cap.isOpened.return_value = True
+        fake_cap.read.side_effect = [(True, frame), (False, None)]
+        fake_cv2 = types.SimpleNamespace(VideoCapture=MagicMock(return_value=fake_cap))
+
+        with unittest.mock.patch.dict('sys.modules', {'cv2': fake_cv2}):
+            gen = video.capture_camera(source=0)
+            frames = list(gen)
+
+        self.assertEqual(len(frames), 1)
+        fake_cap.release.assert_called_once()
+
+
+class DisplayVideoTests(unittest.TestCase):
+    def test_display_video_rejects_non_iterable(self):
+        video = _load_video()
+        with self.assertRaises(ValueError):
+            video.display_video(123)
+
+    def test_display_video_consumes_stream(self):
+        video = _load_video()
+        frames = [np.zeros((5, 5, 3), dtype="uint8") for _ in range(2)]
+        stream = (f for f in frames)
+
+        fake_display = MagicMock()
+        fake_display.set_mode.return_value = MagicMock()
+        fake_pygame = types.SimpleNamespace(
+            init=MagicMock(),
+            quit=MagicMock(),
+            display=fake_display,
+            surfarray=types.SimpleNamespace(make_surface=MagicMock(return_value=MagicMock())),
+            event=types.SimpleNamespace(get=MagicMock(return_value=[])),
+            QUIT=1,
+        )
+        fake_cv2 = types.SimpleNamespace(colorConverter=MagicMock(), COLOR_BGR2RGB=0, cvtColor=lambda f, code: f)
+
+        with unittest.mock.patch.dict('sys.modules', {'pygame': fake_pygame, 'cv2': fake_cv2}):
+            result = video.display_video(stream)
+
+        self.assertTrue(result)
+        fake_display.set_mode.assert_called_once()
+        fake_pygame.quit.assert_called_once()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `capture_camera` for iterating camera frames
- add `display_video` using pygame to show frame streams
- declare `opencv-python` dependency and test coverage

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_68c08688cbf0832684b4e65c599e5470