### PR TITLE
Add gist publish utility

### DIFF
--- a/data/static/gist/README.rst
+++ b/data/static/gist/README.rst
@@ -1,0 +1,7 @@
+Gist Utilities
+--------------
+
+Tools for exporting gateway results to GitHub Gists.
+
+``gw.gist.publish`` creates a gist from the current ``gw.results`` and
+returns the URL to view it.

--- a/projects/gist.py
+++ b/projects/gist.py
@@ -1,0 +1,52 @@
+# file: projects/gist.py
+
+"""Publish gateway results to a GitHub gist."""
+
+from gway import gw
+
+
+def publish(*, description: str = "GWAY results", public: bool = False, filename: str = "results.json") -> str:
+    """Create a GitHub gist with the current ``gw.results``.
+
+    Parameters
+    ----------
+    description: str
+        Optional description for the created gist.
+    public: bool
+        Whether the gist should be public. Defaults to ``False`` (secret gist).
+    filename: str
+        Name of the file inside the gist.
+
+    Returns
+    -------
+    str
+        URL of the created gist.
+    """
+    import json
+    import requests
+
+    data = gw.results.get_results()
+    if not data:
+        raise RuntimeError("No results available to publish")
+
+    token = gw.hub.get_token()
+    if not token:
+        raise RuntimeError("GitHub token not configured")
+
+    payload = {
+        "description": description,
+        "public": public,
+        "files": {filename: {"content": json.dumps(data, indent=2, default=str)}},
+    }
+    headers = {
+        "Authorization": f"token {token}",
+        "User-Agent": "gway-gist",
+        "Accept": "application/vnd.github+json",
+    }
+    resp = requests.post("https://api.github.com/gists", json=payload, headers=headers, timeout=10)
+    if resp.status_code != 201:
+        raise RuntimeError(f"GitHub API error: {resp.status_code} {resp.text}")
+
+    url = resp.json().get("html_url", "")
+    gw.success(url)
+    return url

--- a/tests/test_gist_publish.py
+++ b/tests/test_gist_publish.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from gway import gw
+
+
+class GistPublishTests(unittest.TestCase):
+    def test_publish_returns_url(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 201
+        mock_resp.json.return_value = {"html_url": "http://gist.example/1"}
+        with patch("requests.post", return_value=mock_resp) as post:
+            with patch.object(gw.hub, "get_token", return_value="TOKEN"):
+                with patch.object(gw.results, "get_results", return_value={"a": 1}):
+                    url = gw.gist.publish()
+        self.assertEqual(url, "http://gist.example/1")
+        post.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `gist.publish` to upload `gw.results` as a GitHub Gist
- document new gist project
- test gist publish helper

## Testing
- `gway test --coverage` *(fails: FileNotFoundError: '/tmp/tmp79yjs4wg/projects/games/qpig.py', among others)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f6098e2c83269cc94645522a66a1