### PR TITLE
Add I2C LCD display module

### DIFF
--- a/data/static/lcd/README.rst
+++ b/data/static/lcd/README.rst
@@ -1,0 +1,48 @@
+LCD
+---
+
+Utilities for driving a 16×2 character LCD with an I²C backpack.
+
+Setup
+=====
+
+1. Enable the I²C interface:
+
+   ``sudo raspi-config`` → Interface Options → **I2C** → Enable
+2. Install the required packages:
+
+   .. code-block:: bash
+
+      sudo apt-get update
+      sudo apt-get install -y i2c-tools python3-smbus
+3. (Optional) allow running without ``sudo``:
+
+   .. code-block:: bash
+
+      sudo adduser pi i2c
+      sudo reboot
+
+Wire the backpack's ``VCC`` to 5V, ``GND`` to ground, ``SDA`` to GPIO2 and
+``SCL`` to GPIO3.
+
+Usage
+=====
+
+From the command line::
+
+    gway lcd show "Hello world"
+    gway lcd show "Hello [USER]"
+    gway lcd show "Scrolling text" --scroll
+    gway lcd show "Fast" --scroll --ms 500
+
+``--scroll`` moves the message across the first line of the display.
+The ``--ms`` option changes the speed (milliseconds per character, default
+2000).  Message text may include ``[sigils]`` that are resolved before
+display.
+
+Programmatically::
+
+    from gway import gw
+    gw.context["USER"] = "world"
+    gw.lcd.show("Hello [USER]\nWorld")
+    gw.lcd.show("Scrolling", scroll=True, ms=500)

--- a/projects/lcd.py
+++ b/projects/lcd.py
@@ -1,0 +1,128 @@
+# file: projects/lcd.py
+"""I²C LCD helpers.
+
+Display messages on a 16×2 character LCD connected via an I²C backpack
+(PCF8574 based).  The Raspberry Pi must have the I²C interface enabled
+and the `python3-smbus` package installed.
+
+Setup steps::
+
+    sudo raspi-config      # Interface Options → I2C → Enable
+    sudo apt-get update
+    sudo apt-get install -y i2c-tools python3-smbus
+    sudo adduser pi i2c    # optional, allows running without sudo
+    sudo reboot
+
+Wiring (typical backpack):
+* VCC → 5V
+* GND → GND
+* SDA → GPIO2 (SDA1)
+* SCL → GPIO3 (SCL1)
+"""
+
+from __future__ import annotations
+
+import time
+from gway import gw
+
+# LCD constants
+LCD_WIDTH = 16
+LCD_CHR = 1
+LCD_CMD = 0
+LCD_LINE_1 = 0x80
+LCD_LINE_2 = 0xC0
+LCD_BACKLIGHT = 0x08
+ENABLE = 0b00000100
+E_PULSE = 0.0005
+E_DELAY = 0.0005
+
+
+def _lcd_toggle_enable(bus, addr: int, data: int) -> None:
+    """Toggle enable bit to latch data."""
+    time.sleep(E_DELAY)
+    bus.write_byte(addr, data | ENABLE)
+    time.sleep(E_PULSE)
+    bus.write_byte(addr, data & ~ENABLE)
+    time.sleep(E_DELAY)
+
+
+def _lcd_byte(bus, addr: int, value: int, mode: int) -> None:
+    """Send a single command or character byte."""
+    high = mode | (value & 0xF0) | LCD_BACKLIGHT
+    low = mode | ((value << 4) & 0xF0) | LCD_BACKLIGHT
+    for nibble in (high, low):
+        bus.write_byte(addr, nibble)
+        _lcd_toggle_enable(bus, addr, nibble)
+
+
+def _lcd_init(bus, addr: int) -> None:
+    """Initialise display in 4‑bit mode."""
+    for cmd in (0x33, 0x32, 0x06, 0x0C, 0x28, 0x01):
+        _lcd_byte(bus, addr, cmd, LCD_CMD)
+    time.sleep(E_DELAY)
+
+
+def _lcd_string(bus, addr: int, message: str, line: int) -> None:
+    """Write a string to one line of the display."""
+    message = message.ljust(LCD_WIDTH)[:LCD_WIDTH]
+    _lcd_byte(bus, addr, line, LCD_CMD)
+    for ch in message:
+        _lcd_byte(bus, addr, ord(ch), LCD_CHR)
+
+
+def show(
+    message: str,
+    *,
+    addr: int = 0x27,
+    scroll: bool = False,
+    ms: int = 2000,
+) -> None:
+    """Display *message* on the LCD.
+
+    Parameters
+    ----------
+    message:
+        Text to show.  ``[sigils]`` are resolved prior to display.  A
+        newline character splits the message across the two lines of the
+        display.  When ``scroll`` is true the message is scrolled across
+        the first line.
+    addr:
+        I²C address of the backpack.  ``0x27`` and ``0x3F`` are common.
+    scroll:
+        Scroll the message instead of showing static text.
+    ms:
+        Delay in milliseconds between each scroll step.  Defaults to
+        ``2000`` (2 seconds).
+
+    Raises
+    ------
+    RuntimeError
+        If the ``smbus`` module is not available.  Ensure the
+        prerequisites above are completed.
+    """
+    message = gw.resolve(message)
+
+    try:  # defer import so tests can mock the module
+        import smbus  # type: ignore
+    except ModuleNotFoundError as exc:  # pragma: no cover - import error path
+        raise RuntimeError(
+            "smbus module not found. Enable I2C and install "
+            "'i2c-tools' and 'python3-smbus'."
+        ) from exc
+
+    bus = smbus.SMBus(1)
+    _lcd_init(bus, addr)
+
+    if scroll:
+        delay = ms / 1000.0
+        padding = " " * LCD_WIDTH
+        text = f"{padding}{message}{padding}"
+        for idx in range(len(text) - LCD_WIDTH + 1):
+            segment = text[idx : idx + LCD_WIDTH]
+            _lcd_string(bus, addr, segment, LCD_LINE_1)
+            time.sleep(delay)
+    else:
+        lines = message.split("\n", 1)
+        _lcd_string(bus, addr, lines[0], LCD_LINE_1)
+        if len(lines) > 1:
+            _lcd_string(bus, addr, lines[1], LCD_LINE_2)

--- a/tests/test_lcd.py
+++ b/tests/test_lcd.py
@@ -1,0 +1,64 @@
+import sys
+import unittest
+import types
+from gway import gw
+
+
+class LCDTests(unittest.TestCase):
+    def test_show_writes_to_i2c_bus(self):
+        writes = []
+        buses = []
+
+        class FakeSMBus:
+            def __init__(self, bus_no):
+                buses.append(bus_no)
+            def write_byte(self, addr, value):
+                writes.append((addr, value))
+
+        fake_mod = types.SimpleNamespace(SMBus=FakeSMBus)
+        with unittest.mock.patch.dict("sys.modules", {"smbus": fake_mod}):
+            gw.lcd.show("Hi")
+
+        self.assertEqual(buses, [1])
+        self.assertGreater(len(writes), 0)
+        self.assertTrue(all(addr == 0x27 for addr, _ in writes))
+
+    def test_scroll_flag_scrolls_message(self):
+        class FakeSMBus:
+            def __init__(self, bus_no):
+                pass
+
+            def write_byte(self, addr, value):
+                pass
+
+        fake_mod = types.SimpleNamespace(SMBus=FakeSMBus)
+        lcd_mod = sys.modules[gw.lcd.show.__module__]
+        with unittest.mock.patch.dict("sys.modules", {"smbus": fake_mod}), \
+             unittest.mock.patch.object(lcd_mod, "_lcd_string") as lcd_str, \
+             unittest.mock.patch.object(lcd_mod.time, "sleep") as sleep:
+            gw.lcd.show("Scrolling", scroll=True, ms=100)
+
+        self.assertGreater(lcd_str.call_count, 1)
+        delays = [call.args[0] for call in sleep.call_args_list]
+        self.assertTrue(any(abs(d - 0.1) < 1e-6 for d in delays))
+
+    def test_show_resolves_sigils(self):
+        class FakeSMBus:
+            def __init__(self, bus_no):
+                pass
+
+            def write_byte(self, addr, value):
+                pass
+
+        fake_mod = types.SimpleNamespace(SMBus=FakeSMBus)
+        lcd_mod = sys.modules[gw.lcd.show.__module__]
+        gw.context["LCD_MSG"] = "World"
+        try:
+            with unittest.mock.patch.dict("sys.modules", {"smbus": fake_mod}), \
+                 unittest.mock.patch.object(lcd_mod, "_lcd_string") as lcd_str:
+                gw.lcd.show("Hello [LCD_MSG]")
+        finally:
+            gw.context.pop("LCD_MSG", None)
+
+        msg = lcd_str.call_args_list[0].args[2]
+        self.assertEqual(msg.strip(), "Hello World")


### PR DESCRIPTION
## Summary
- add `--scroll` flag with configurable delay for LCD messages
- document scrolling usage and timing options
- test LCD scrolling via mocked bus and timing
- resolve `[sigils]` before displaying text on LCD

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pip install fastapi`
- `gway test --coverage` *(fails: FileNotFoundError, assertion errors in resource tests, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c0f27992108326be582ac16c4ea3f7