### PR TITLE
Add auto-upgrade recipe

### DIFF
--- a/recipes/auto_upgrade.gwr
+++ b/recipes/auto_upgrade.gwr
@@ -1,0 +1,12 @@
+# file: recipes/auto_upgrade.gwr
+#
+# Auto-upgrade service recipe
+#
+# This recipe ensures the local gway installation is always kept up to
+# date. When run under a service manager like systemd, the `until` runner
+# monitors the gway package on PyPI and exits with a non-zero status when
+# a new release is published. The service manager can then restart the
+# recipe, triggering another upgrade cycle.
+
+shell pip install --quiet --upgrade gway
+until --abort --pypi


### PR DESCRIPTION
## Summary
- add recipe to auto-upgrade gway via PyPI watcher
- allow passing extra context with `gway -r file.gwr --key value`

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: failures=7, errors=7)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e71358ac8326b489e4d047ab4af5