### PR TITLE
Add Base64 encode/decode project

### DIFF
--- a/data/static/b64/README.rst
+++ b/data/static/b64/README.rst
@@ -1,0 +1,11 @@
+B64 Project
+===========
+
+Utilities for Base64 encoding and decoding.
+
+Examples::
+
+    gway b64 encode "hello world"
+    gway b64 decode data.txt --content --out image.png
+
+These commands can also operate on URLs when ``--content`` is supplied.

--- a/gway/builtins/testing.py
+++ b/gway/builtins/testing.py
@@ -115,13 +115,17 @@ def test(
 
             test_suite = test_loader.discover(root, pattern=pattern)
 
+            orig_resource = gw.resource
+
             class TimedResult(unittest.TextTestResult):
                 def startTest(self, test):
+                    gw.resource = orig_resource
                     super().startTest(test)
                     if getattr(gw, "timed_enabled", False):
                         self._start_time = time.perf_counter()
 
                 def stopTest(self, test):
+                    gw.resource = orig_resource
                     if getattr(gw, "timed_enabled", False) and hasattr(self, "_start_time"):
                         elapsed = time.perf_counter() - self._start_time
                         gw.log(f"[test] {test} took {elapsed:.3f}s")

--- a/gway/console.py
+++ b/gway/console.py
@@ -472,6 +472,10 @@ def add_func_args(subparser, func_obj, *, wizard=False):
     When ``wizard`` is True, required arguments are marked optional so they can
     be filled interactively later."""
     sig = inspect.signature(func_obj, eval_str=True)
+    try:
+        hints = get_type_hints(func_obj)
+    except Exception:
+        hints = {}
     seen_kw_only = False
 
     for arg_name, param in sig.parameters.items():

--- a/projects/b64.py
+++ b/projects/b64.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import base64
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+
+def _load_bytes(value: str, content: bool) -> bytes:
+    """Return bytes from ``value``.
+
+    If ``content`` is False, ``value`` is treated as plain text.
+    Otherwise ``value`` is interpreted as a filename or URL and its
+    contents are loaded as bytes.
+    """
+    if content:
+        parsed = urlparse(value)
+        if parsed.scheme in ("http", "https"):
+            with urlopen(value) as resp:
+                return resp.read()
+        return Path(value).read_bytes()
+    return value.encode()
+
+
+def _load_text(value: str, content: bool) -> str:
+    """Return text from ``value``.
+
+    When ``content`` is True the value is read from a file or URL.
+    """
+    if content:
+        parsed = urlparse(value)
+        if parsed.scheme in ("http", "https"):
+            with urlopen(value) as resp:
+                return resp.read().decode()
+        return Path(value).read_text()
+    return value
+
+
+def _default_out(ext: str) -> Path:
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return Path(f"b64_{ts}{ext}")
+
+
+def encode(value: str, content: bool = False, out: Optional[str] = None) -> str:
+    """Base64 encode ``value`` or the contents of a file/URL.
+
+    Args:
+        value: Text to encode or path/URL when ``content`` is True.
+        content: Treat ``value`` as filename or URL.
+        out: Optional output file to store the encoded text.
+    Returns:
+        The Base64 encoded string or the output filename if ``out`` is provided.
+    """
+    data = _load_bytes(value, content)
+    encoded = base64.b64encode(data).decode()
+    if out:
+        outfile = Path(out)
+        outfile.write_text(encoded)
+        return str(outfile)
+    return encoded
+
+
+def decode(value: str, content: bool = False, out: Optional[str] = None) -> str:
+    """Decode Base64 ``value`` or a file/URL containing Base64 text.
+
+    Args:
+        value: Base64 string or path/URL when ``content`` is True.
+        content: Interpret ``value`` as filename or URL.
+        out: Optional output filename for binary data.
+    Returns:
+        Decoded text if it is UTF-8 printable, otherwise the path to the
+        output file where binary data was written.
+    """
+    source = _load_text(value, content)
+    decoded = base64.b64decode(source)
+    try:
+        text = decoded.decode()
+        if all(ch.isprintable() or ch in "\r\n\t" for ch in text):
+            if out:
+                outfile = Path(out)
+                outfile.write_text(text)
+                return str(outfile)
+            return text
+    except UnicodeDecodeError:
+        pass
+
+    outfile = Path(out) if out else _default_out(".bin")
+    outfile.write_bytes(decoded)
+    return str(outfile)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,18 +3,18 @@ setuptools
 twine
 build
 colorama
- requests
- dateparser
- docutils
- croniter
- qrcode[pil]
- cryptography
- jinja2
- pygame
- httpx
- pyperclip; platform_system == "Windows"
- plyer
- numpy
+requests
+dateparser
+docutils
+croniter
+qrcode[pil]
+cryptography
+jinja2
+pygame
+httpx
+pyperclip; platform_system == "Windows"
+plyer
+numpy
 pygetwindow; platform_system == "Windows"
 duckdb
 pywin32; platform_system == "Windows"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from gway import gw
+
+@pytest.fixture(autouse=True)
+def reset_gw_resource():
+    orig = gw.resource
+    yield
+    gw.resource = orig

--- a/tests/test_b64.py
+++ b/tests/test_b64.py
@@ -1,0 +1,30 @@
+import base64
+import tempfile
+from pathlib import Path
+import unittest
+
+from gway import gw
+
+
+class B64Tests(unittest.TestCase):
+    def test_encode_string(self):
+        result = gw.b64.encode("hello")
+        self.assertEqual(result, base64.b64encode(b"hello").decode())
+
+    def test_decode_string(self):
+        b64val = base64.b64encode(b"hello world").decode()
+        result = gw.b64.decode(b64val)
+        self.assertEqual(result, "hello world")
+
+    def test_decode_to_file(self):
+        data = b"\x00\x01\x02"
+        b64val = base64.b64encode(data).decode()
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "data.bin"
+            path_str = gw.b64.decode(b64val, out=str(out))
+            self.assertEqual(path_str, str(out))
+            self.assertEqual(out.read_bytes(), data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `b64` project with `encode` and `decode` helpers
- document Base64 project and add tests
- include `requests` dependency in requirements
- fix CLI type hint handling and stabilize `gw.resource` for reliable tests

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1919c96cc83268d1d6ad895a93057