### PR TITLE
Allow chained commands to reuse project name

### DIFF
--- a/data/static/audio/README.rst
+++ b/data/static/audio/README.rst
@@ -24,6 +24,10 @@ Record five seconds of audio and play it back::
     gway audio record --duration 5
     gway audio playback --audio "$(gw results audio.record)"
 
+Or chain the commands, omitting the project name on the second call::
+
+    gway audio record --duration 5 - playback --audio "$(gw results audio.record)"
+
 To keep a file playing in the background::
 
     gway audio playback --audio song.wav --loop

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -284,5 +284,14 @@ class TestRecipeCliContext(unittest.TestCase):
             sys.argv = original_argv
 
 
+class TestProcessChaining(unittest.TestCase):
+    def test_reuses_project_for_chained_calls(self):
+        commands = [["dummy", "setup-home"], ["setup-links"]]
+        results, last = console.process(commands)
+        self.assertEqual(results[0], "index")
+        self.assertEqual(results[1], ["about", "more"])
+        self.assertEqual(last, ["about", "more"])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- permit successive chained commands to omit the project name, resolving against the previously used project
- document chaining in audio project README
- add regression test for implicit project reuse

## Testing
- `gway test --coverage` *(fails: Unhandled NameError in test -> name 'orig_abort' is not defined)*
- `pytest tests/test_console.py::TestProcessChaining::test_reuses_project_for_chained_calls -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1a3597bc48326a138c5c79a360256