### PR TITLE
Default audio recordings to work directory

### DIFF
--- a/data/static/audio/README.rst
+++ b/data/static/audio/README.rst
@@ -9,7 +9,7 @@ Functions
 
 ``record``
   Capture audio from the default input device. The recording is saved to a
-  ``.wav`` file in the working directory. You may customise the duration,
+  ``.wav`` file in the ``work/`` directory by default. You may customise the duration,
   format (currently ``wav`` only) and target filename.
 
 ``playback``

--- a/gway/builtins/testing.py
+++ b/gway/builtins/testing.py
@@ -116,14 +116,16 @@ def test(
             test_suite = test_loader.discover(root, pattern=pattern)
 
             orig_resource = gw.resource
+            orig_abort = gw.abort
 
             class TimedResult(unittest.TextTestResult):
                 def startTest(self, test):
                     gw.resource = orig_resource
+                    gw.abort = orig_abort
                     super().startTest(test)
                     if getattr(gw, "timed_enabled", False):
                         self._start_time = time.perf_counter()
-
+                
                 def stopTest(self, test):
                     gw.resource = orig_resource
                     if getattr(gw, "timed_enabled", False) and hasattr(self, "_start_time"):

--- a/tests/test_audio_record.py
+++ b/tests/test_audio_record.py
@@ -1,0 +1,45 @@
+import unittest
+import importlib.util
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest.mock import patch, MagicMock
+import types
+import sys
+
+import numpy as np
+
+from gway import gw
+
+
+class AudioRecordTests(unittest.TestCase):
+    @staticmethod
+    def _load_audio():
+        audio_path = Path(__file__).resolve().parents[1] / "projects" / "audio.py"
+        spec = importlib.util.spec_from_file_location("audio", audio_path)
+        module = importlib.util.module_from_spec(spec)
+        with patch.dict(sys.modules, {"sounddevice": types.SimpleNamespace()}):
+            spec.loader.exec_module(module)
+        return module
+
+    def test_record_defaults_to_work_directory(self):
+        audio = self._load_audio()
+        fake_data = np.zeros((1, 1), dtype="int16")
+        with TemporaryDirectory() as tmpdir:
+            def fake_resource(*parts, **kwargs):
+                return Path(tmpdir).joinpath(*parts)
+
+            fake_wave = MagicMock()
+            fake_wave.__enter__.return_value = MagicMock()
+
+            fake_sd = types.SimpleNamespace(rec=MagicMock(return_value=fake_data), wait=MagicMock())
+            with patch.object(gw, 'resource', fake_resource), \
+                 patch.object(audio, 'sd', fake_sd), \
+                 patch.object(audio, 'wave') as wave_mod:
+                wave_mod.open.return_value = fake_wave
+                result = audio.record(duration=1)
+
+        self.assertTrue(result.startswith(tmpdir))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Save audio project recordings under work/ by default
- Document default work directory for audio recordings
- Add test ensuring audio recordings target work directory
- Restore original `gw.abort` in test harness to avoid NameError
- Stub `sounddevice` in audio test to remove external dependency

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c1e423e9dc8326b811b522b39de4fc