### PR TITLE
Include bundled projects when installing gway

### DIFF
--- a/projects/__init__.py
+++ b/projects/__init__.py
@@ -1,0 +1,5 @@
+"""Project modules shipped with gway.
+
+This file allows the ``projects`` directory to be installed as a Python package
+so bundled utilities remain accessible after installation.
+"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,4 +30,5 @@ Homepage = "https://arthexis.com"
 Sponsor = "https://www.gelectriic.com/"
 
 [tool.setuptools]
-packages = [ "gway",]
+packages = [ "gway", "projects" ]
+include-package-data = true


### PR DESCRIPTION
## Summary
- ensure `projects` modules are installed with the package so `gw` works in fresh environments like Google Colab
- make `projects` a package and include package data in `pyproject.toml`

## Testing
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c1f90bf6c4832683492bb515efa432