### PR TITLE
feat: trigger release via labeled PR

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,32 @@
+name: Auto Release
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'release')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Configure git
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+      - name: Build release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gway release build --bump --git --tag

--- a/data/static/release/README.rst
+++ b/data/static/release/README.rst
@@ -14,3 +14,12 @@ to PyPI::
 
 GitHub will run the ``test-release`` workflow on every pushed tag and mark a
 successful run as ready for release to PyPI.
+
+Marking PRs for Release
+=======================
+
+Instead of running the release command locally, a pull request labeled
+``release`` can generate a new version. When such a PR is merged the
+``auto-release`` workflow runs ``gw.release.build --bump --git --tag`` on the
+main branch. The workflow commits the version bump, tags it (``vX.Y.Z``) and
+pushes the result, which in turn triggers the ``test-release`` workflow above.


### PR DESCRIPTION
## Summary
- add auto-release workflow to run `gw.release.build --bump --git --tag` when a PR labeled `release` is merged
- document PR-based release triggering

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c21cfb48e08326a00d16d4aaa36693