### PR TITLE
Enable audio record prompt and playback chaining

### DIFF
--- a/data/static/audio/README.rst
+++ b/data/static/audio/README.rst
@@ -10,7 +10,9 @@ Functions
 ``record``
   Capture audio from the default input device. The recording is saved to a
   ``.wav`` file in the ``work/`` directory by default. You may customise the duration,
-  format (currently ``wav`` only) and target filename.
+  format (currently ``wav`` only) and target filename. By default the user is
+  prompted to press Enter before recording starts; use ``--immediate`` to begin
+  right away.
 
 ``playback``
   Play a ``.wav`` file. When invoked with ``--loop`` it keeps the audio
@@ -21,12 +23,13 @@ Usage
 
 Record five seconds of audio and play it back::
 
-    gway audio record --duration 5
+    gway audio record --duration 5 --immediate
     gway audio playback --audio "$(gw results audio.record)"
 
-Or chain the commands, omitting the project name on the second call::
+Or chain the commands, omitting the project name and relying on auto
+injection::
 
-    gway audio record --duration 5 - playback --audio "$(gw results audio.record)"
+    gway audio record --duration 5 --immediate - playback
 
 To keep a file playing in the background::
 

--- a/projects/audio.py
+++ b/projects/audio.py
@@ -21,6 +21,7 @@ def record(
     channels: int = 1,
     format: str = "wav",
     file: Optional[str] = None,
+    immediate: bool = False,
 ):
     """Record audio from the default input device.
 
@@ -32,6 +33,8 @@ def record(
         file: Target filename. If ``None``, a name like
             ``"recording_<timestamp>.wav"`` is saved to the ``work``
             directory.
+        immediate: Start recording immediately without waiting for
+            user input.
 
     Returns:
         Absolute path to the recorded audio file.
@@ -48,6 +51,9 @@ def record(
             path = Path.cwd() / path
     path = path.resolve()
     gw.info(f"Recording audio to {path}")
+    if not immediate:
+        gw.info("Press Enter to start recording")
+        input()
 
     frames = int(duration * samplerate)
     data = sd.rec(frames, samplerate=samplerate, channels=channels)

--- a/tests/test_audio_record.py
+++ b/tests/test_audio_record.py
@@ -36,7 +36,7 @@ class AudioRecordTests(unittest.TestCase):
                  patch.object(audio, 'sd', fake_sd), \
                  patch.object(audio, 'wave') as wave_mod:
                 wave_mod.open.return_value = fake_wave
-                result = audio.record(duration=1)
+                result = audio.record(duration=1, immediate=True)
 
         self.assertTrue(result.startswith(tmpdir))
 
@@ -59,7 +59,7 @@ class AudioRecordTests(unittest.TestCase):
                 record_wrapped = gw.wrap_callable("audio.record", audio.record)
                 playback_wrapped = gw.wrap_callable("audio.playback", lambda *, audio: audio)
                 gw.results.clear()
-                path = record_wrapped(duration=1)
+                path = record_wrapped(duration=1, immediate=True)
                 self.assertEqual(gw.results.get('audio'), path)
                 result = playback_wrapped()
                 self.assertEqual(result, path)


### PR DESCRIPTION
## Summary
- Prompt before recording audio unless `--immediate` is used
- Allow CLI to auto-inject recorded audio into playback
- Document new audio workflow and cover with tests

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c36b1f1b5083268742ef19ee2881f2