### PR TITLE
Include builtins package in distribution

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 Unreleased
 ----------
 
+- ensure ``gway.builtins`` package is included in distribution
+
 0.4.59 [build 27aace]
 ---------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,5 +30,7 @@ Homepage = "https://arthexis.com"
 Sponsor = "https://www.gelectriic.com/"
 
 [tool.setuptools]
-packages = [ "gway", "projects" ]
 include-package-data = true
+
+[tool.setuptools.packages.find]
+include = ["gway*", "projects*"]


### PR DESCRIPTION
## Summary
- ensure the `gway.builtins` module is part of the distributed package by using automatic package discovery
- note this fix in the changelog

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test`


------
https://chatgpt.com/codex/tasks/task_e_68c379449b248326936587f5fc95656f