### PR TITLE
docs: remove web project references

### DIFF
--- a/data/static/awg/README.rst
+++ b/data/static/awg/README.rst
@@ -2,9 +2,9 @@ AWG Cable Calculator
 --------------------
 
 The ``awg`` project provides helpers for selecting electrical cable sizes using
-American Wire Gauge tables.  It exposes a ``find_awg`` function and a small web
-form so you can determine the required cable, voltage drop and conduit size
-straight from the command line or a browser.
+American Wire Gauge tables.  It exposes a ``find_awg`` function so you can
+determine the required cable, voltage drop and conduit size straight from the
+command line or your own scripts.
 
 Usage
 =====
@@ -58,9 +58,6 @@ Additional Tools
 
 ``find_conduit``
   Utility to calculate conduit diameter for a given AWG and number of cables.
-``view_awg_calculator``
-  Renders ``/awg/awg-calculator`` – an HTML form backed by ``find_awg`` for quick
-  calculations in the browser.
 
 Data Files
 ==========

--- a/data/static/monitor/README.rst
+++ b/data/static/monitor/README.rst
@@ -8,5 +8,3 @@ It does not alter any connections automatically. Start the watcher from a recipe
 
     monitor start-watch nmcli
 
-Use the ``run`` page in the web interface to execute arbitrary ``nmcli`` commands when needed.
-

--- a/data/static/monitor/rpi/README.rst
+++ b/data/static/monitor/rpi/README.rst
@@ -20,10 +20,3 @@ Programmatically::
 Ensure the destination device refers to the USB microSD writer
 connected to the Pi.  The entire device will be overwritten and
 requires ``sudo`` permissions.  Cloning may take several minutes.
-
-Web Interface
-=============
-
-Launch the web application and open ``/monitor/rpi/pi-remote`` to use a simple
-interface for selecting the target device and starting the copy.  The
-progress bar updates automatically while the clone runs.

--- a/data/static/rpi/README.rst
+++ b/data/static/rpi/README.rst
@@ -20,10 +20,3 @@ Programmatically::
 Ensure the destination device refers to the USB microSD writer
 connected to the Pi.  The entire device will be overwritten and
 requires ``sudo`` permissions.  Cloning may take several minutes.
-
-Web Interface
-=============
-
-Launch the web application and open ``/rpi/pi-remote`` to use a simple
-interface for selecting the target device and starting the copy.  The
-progress bar updates automatically while the clone runs.


### PR DESCRIPTION
## Summary
- remove web form and interface references from AWG and Raspberry Pi docs
- clean network monitor doc of obsolete web UI note

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c37c64a18083269f3e97d4ccb1c63e