### PR TITLE
feat: add proximity sensor watcher

### DIFF
--- a/projects/sensor.py
+++ b/projects/sensor.py
@@ -1,0 +1,47 @@
+# file: projects/sensor.py
+"""Sensor utilities including proximity watcher."""
+
+from __future__ import annotations
+
+from gway import gw
+
+
+def watch_proximity(pin: int = 17, *, gpio_module=None, max_events: int | None = None) -> None:
+    """Block and report when a proximity sensor on ``pin`` is triggered.
+
+    Parameters
+    ----------
+    pin:
+        BCM pin number wired to the sensor's digital output. Defaults to ``17``
+        (``IO17``).
+    gpio_module:
+        Optional GPIO-like module providing ``setmode``, ``setup``, ``wait_for_edge``
+        and ``cleanup``.  Defaults to :mod:`RPi.GPIO` when available.
+    max_events:
+        Maximum number of events to report before returning.  ``None`` means run
+        indefinitely.  This is primarily intended for testing.
+    """
+    if gpio_module is None:
+        try:  # pragma: no cover - hardware import
+            import RPi.GPIO as GPIO  # type: ignore
+            gpio_module = GPIO
+        except Exception:  # pragma: no cover - hardware missing
+            gw.error("RPi.GPIO not available; install it on a Raspberry Pi")
+            print("Proximity sensor watch requires RPi.GPIO")
+            return
+
+    GPIO = gpio_module
+    GPIO.setmode(getattr(GPIO, "BCM", GPIO.BOARD))
+    GPIO.setup(pin, getattr(GPIO, "IN"))
+    print(f"Watching proximity sensor on pin {pin}...")
+    events = 0
+    try:
+        while max_events is None or events < max_events:
+            # Wait for any edge; sensors usually pull the line high when triggered.
+            GPIO.wait_for_edge(pin, getattr(GPIO, "BOTH", None))
+            events += 1
+            print("Proximity detected!")
+    except KeyboardInterrupt:  # pragma: no cover - user interrupt
+        print("Stopping proximity watch")
+    finally:
+        GPIO.cleanup(pin)

--- a/tests/test_sensor_proximity.py
+++ b/tests/test_sensor_proximity.py
@@ -1,0 +1,33 @@
+import io
+from contextlib import redirect_stdout
+from gway import gw
+
+
+def test_watch_proximity_reports_events():
+    class FakeGPIO:
+        BCM = "BCM"
+        IN = "IN"
+        BOTH = "BOTH"
+        def __init__(self):
+            self.cleaned = []
+            self.wait_calls = 0
+        def setmode(self, mode):
+            self.mode = mode
+        def setup(self, pin, mode):
+            self.pin = pin
+            self.mode_set = mode
+        def wait_for_edge(self, pin, edge):
+            self.wait_calls += 1
+            if self.wait_calls > 1:
+                raise AssertionError("should not block after max_events")
+        def cleanup(self, pin):
+            self.cleaned.append(pin)
+
+    gpio = FakeGPIO()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        gw.sensor.watch_proximity(gpio_module=gpio, max_events=1)
+
+    out = buf.getvalue()
+    assert "Proximity detected" in out
+    assert gpio.cleaned == [17]


### PR DESCRIPTION
## Summary
- add `sensor` project with `watch_proximity` helper for RPi.GPIO-based sensors
- default proximity pin to 17 (IO17)
- test proximity watcher with fake GPIO module

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c3cb9ab1bc8326bf2675b7ba4cb242