### PR TITLE
fix: expose projects package

### DIFF
--- a/gway/__init__.py
+++ b/gway/__init__.py
@@ -8,3 +8,19 @@ from .sigils import Sigil, Resolver, Spool, __
 from .structs import Results
 from .logging import setup_logging
 from .envs import load_env
+
+# Expose the standalone ``projects`` package under ``gway.projects`` so
+# callers can import project modules via ``gway.projects.<name>``.
+import sys
+from pathlib import Path
+
+try:  # pragma: no cover - depends on installation layout
+    import projects as _projects
+except ModuleNotFoundError:  # pragma: no cover - ensure direct repo use works
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.append(str(root))
+    import projects as _projects
+
+sys.modules[__name__ + ".projects"] = _projects
+


### PR DESCRIPTION
## Summary
- expose top-level `projects` package as `gway.projects`

## Testing
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_68c4375fc2848326a851e99f2171f45d