### PR TITLE
Handle dynamic Django model loading and warnings

### DIFF
--- a/projects/mod.py
+++ b/projects/mod.py
@@ -1,6 +1,11 @@
 # file: projects/mod.py
 """Alias to the :mod:`projects.model` project."""
 
-from .model import list_models, __getattr__
+# Load directly from the ``projects`` package so the module can be executed
+# standalone without package context.
+from projects import model as _model
+
+list_models = _model.list_models
+__getattr__ = _model.__getattr__
 
 __all__ = ["list_models", "__getattr__"]


### PR DESCRIPTION
## Summary
- ensure Django settings modules are importable and support patched `apps.get_models`
- delegate project attribute lookups to module-level handlers and detect duplicate model names
- load `mod` alias using absolute import to avoid package context issues

## Testing
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_68c43961b5ac83269a9b99f908330009