### PR TITLE
Ensure Django settings import searches work directory

### DIFF
--- a/projects/model.py
+++ b/projects/model.py
@@ -58,8 +58,10 @@ def _ensure_setup() -> None:
             importlib.import_module(settings_mod)
         except ModuleNotFoundError:
             root = Path(__file__).resolve().parents[1]
-            if str(root) not in sys.path:
-                sys.path.insert(0, str(root))
+            cwd = Path.cwd()
+            for path in (root, cwd):
+                if str(path) not in sys.path:
+                    sys.path.insert(0, str(path))
             importlib.import_module(settings_mod)
     if not apps.ready:
         if not hasattr(apps.get_models, "cache_clear"):


### PR DESCRIPTION
## Summary
- expand model project Django settings lookup to check the working directory when module import fails

## Testing
- `gway test`


------
https://chatgpt.com/codex/tasks/task_e_68c4400147188326b534700279462695