### PR TITLE
Handle optional unions in CLI parser

### DIFF
--- a/gway/console.py
+++ b/gway/console.py
@@ -10,6 +10,7 @@ import argcomplete
 import csv
 import difflib
 from typing import get_origin, get_args, Literal, Union, get_type_hints
+from types import UnionType
 
 from . import units
 
@@ -615,7 +616,7 @@ def get_arg_opts(arg_name, param, gw=None):
     if origin == Literal:
         opts["choices"] = args
         inferred_type = type(args[0]) if args else str
-    elif origin == Union:
+    elif origin in (Union, UnionType):
         non_none = [a for a in args if a is not type(None)]
         if len(non_none) == 1:
             inner_param = type("param", (), {"annotation": non_none[0], "default": default})

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -257,6 +257,23 @@ class TestPrepareKwargParsing(unittest.TestCase):
         self.assertEqual(kw["title"], "My Great App")
 
 
+class TestUnionAnnotations(unittest.TestCase):
+    def test_add_func_args_handles_pep604_optional(self):
+        import argparse
+
+        def dummy(*, count: int | None = None):
+            return count
+
+        parser = argparse.ArgumentParser()
+        console.add_func_args(parser, dummy)
+
+        parsed = parser.parse_args([])
+        self.assertIsNone(parsed.count)
+
+        parsed = parser.parse_args(["--count", "5"])
+        self.assertEqual(parsed.count, 5)
+
+
 class TestRecipeCliContext(unittest.TestCase):
     def test_extra_cli_args_as_context(self):
         fake_commands = [['noop']]


### PR DESCRIPTION
## Summary
- handle PEP 604 style optional unions in CLI parsing
- add regression test covering optional PEP 604 union annotations

## Testing
- `gway sensor proximity`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c5ffa30ca88326a4d0c49ccbe69821