### PR TITLE
Add RPIO fallback for proximity sensor

### DIFF
--- a/tests/test_sensor_proximity.py
+++ b/tests/test_sensor_proximity.py
@@ -1,4 +1,6 @@
 import io
+import sys
+import types
 from contextlib import redirect_stdout
 from gway import gw
 
@@ -58,3 +60,47 @@ def test_proximity_polls_and_prints_symbols():
     out = buf.getvalue()
     assert out == ".!.\n"
     assert gpio.cleaned == [17]
+
+
+def test_proximity_uses_rpio_when_rpi_gpio_missing(monkeypatch):
+    class FakeGPIO:
+        BCM = "BCM"
+        IN = "IN"
+
+        def __init__(self):
+            self.cleaned = []
+            self.input_calls = 0
+
+        def setmode(self, mode):
+            self.mode = mode
+
+        def setup(self, pin, mode):
+            self.pin = pin
+            self.mode_set = mode
+
+        def input(self, pin):
+            self.input_calls += 1
+            return 0
+
+        def cleanup(self, pin):
+            self.cleaned.append(pin)
+
+    fake = FakeGPIO()
+    module = types.ModuleType("RPIO")
+    module.BCM = fake.BCM
+    module.IN = fake.IN
+    module.setmode = fake.setmode
+    module.setup = fake.setup
+    module.input = fake.input
+    module.cleanup = fake.cleanup
+
+    monkeypatch.setitem(sys.modules, "RPIO", module)
+    monkeypatch.delitem(sys.modules, "RPi", raising=False)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        gw.sensor.proximity(interval=0.0, max_checks=1)
+
+    out = buf.getvalue()
+    assert out == ".\n"
+    assert fake.cleaned == [17]


### PR DESCRIPTION
## Summary
- allow sensor utilities to use either RPi.GPIO or RPIO
- add test covering RPIO fallback

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c60730a2fc8326b741f07331b25831