### PR TITLE
feat: add upgrade builtin

### DIFF
--- a/gway/builtins/core.py
+++ b/gway/builtins/core.py
@@ -6,6 +6,7 @@ __all__ = [
     "envs",
     "version",
     "shell",
+    "upgrade",
 ]
 
 def hello_world(name: str = "World", *, greeting: str = "Hello", **kwargs):
@@ -87,5 +88,29 @@ def shell():
     local_vars = {"gw": gw, "__": __}
     banner = "GWAY interactive shell.\nfrom gway import gw  # Python 3.13 compatible"
     code.interact(banner=banner, local=local_vars)
+
+
+def upgrade(*args):
+    """Run ``upgrade.sh`` with the given parameters.
+
+    This mirrors executing the ``upgrade.sh`` script located in the
+    installation directory, passing through all provided arguments and
+    printing the script's output.
+    """
+    from gway import gw
+    import os
+    import subprocess
+    import sys
+
+    script = gw.resource("upgrade.sh", check=True)
+    cmd = ["bash", os.fspath(script), *args]
+    result = subprocess.run(
+        cmd, cwd=script.parent, capture_output=True, text=True
+    )
+    if result.stdout:
+        print(result.stdout, end="")
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+    return result.returncode
 
 

--- a/tests/test_upgrade_builtin.py
+++ b/tests/test_upgrade_builtin.py
@@ -1,0 +1,34 @@
+import unittest
+import tempfile
+import os
+import sys
+from io import StringIO
+from unittest.mock import patch
+from gway import gw
+
+
+class UpgradeBuiltinTests(unittest.TestCase):
+    def setUp(self):
+        self.stdout = StringIO()
+        self.orig_stdout = sys.stdout
+        sys.stdout = self.stdout
+
+    def tearDown(self):
+        sys.stdout = self.orig_stdout
+
+    def test_upgrade_passes_args_and_prints_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "upgrade.sh")
+            with open(script, "w", encoding="utf-8") as f:
+                f.write("#!/usr/bin/env bash\n")
+                f.write("echo \"called with: $@\"\n")
+            os.chmod(script, 0o755)
+            import pathlib
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.upgrade("--force", "--no-test")
+        self.assertEqual(rc, 0)
+        self.assertIn("called with: --force --no-test", self.stdout.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add upgrade builtin that runs upgrade.sh with provided args
- test upgrade builtin argument passing and output

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c61a461598832689040e5780491125