### PR TITLE
Resolve CLI sigils automatically

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -339,5 +339,17 @@ class TestProcessChaining(unittest.TestCase):
         self.assertEqual(last, "foo.wav")
 
 
+class TestProcessSigilResolution(unittest.TestCase):
+    def setUp(self):
+        console.gw.context.clear()
+        console.gw.results.clear()
+
+    def test_process_resolves_sigils(self):
+        console.gw.context['P'] = 'val'
+        cmds = [['hello-world', '[P]']]
+        _, last = console.process(cmds)
+        self.assertEqual(last['name'], 'val')
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- auto-resolve bare `[sigil]` tokens passed via the CLI by resolving them before function calls
- add regression test for CLI sigil resolution

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c6194c37688326b79263a5069d02b7