### PR TITLE
feat: stream upgrade output

### DIFF
--- a/tests/test_upgrade_builtin.py
+++ b/tests/test_upgrade_builtin.py
@@ -2,6 +2,8 @@ import unittest
 import tempfile
 import os
 import sys
+import threading
+import time
 from io import StringIO
 from unittest.mock import patch
 from gway import gw
@@ -28,6 +30,24 @@ class UpgradeBuiltinTests(unittest.TestCase):
                 rc = gw.upgrade("--force", "--no-test")
         self.assertEqual(rc, 0)
         self.assertIn("called with: --force --no-test", self.stdout.getvalue())
+
+    def test_upgrade_streams_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "upgrade.sh")
+            with open(script, "w", encoding="utf-8") as f:
+                f.write("#!/usr/bin/env bash\n")
+                f.write("echo start\n")
+                f.write("sleep 1\n")
+                f.write("echo end\n")
+            os.chmod(script, 0o755)
+            import pathlib
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                t = threading.Thread(target=gw.upgrade)
+                t.start()
+                time.sleep(0.2)
+                self.assertIn("start", self.stdout.getvalue())
+                t.join()
+        self.assertIn("end", self.stdout.getvalue())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- stream `upgrade.sh` output in real time
- verify upgrade builtin streams output as it happens

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_68c63b08ec4c8326b0e75471e1d61e8a