### PR TITLE
Avoid title-casing hello_world inputs

### DIFF
--- a/gway/builtins/core.py
+++ b/gway/builtins/core.py
@@ -13,7 +13,11 @@ def hello_world(name: str = "World", *, greeting: str = "Hello", **kwargs):
     """Smoke test function."""
     from gway import gw
     version = gw.version()
-    message = f"{greeting.title()}, {name.title()}!"
+    # Preserve the caller's capitalization.  Using ``str.title`` on the
+    # arguments caused paths or other case-sensitive values to be modified
+    # unexpectedly (e.g. `/home/user/file.py` becoming `/Home/User/File.Py`).
+    # Generate the greeting without altering the original casing.
+    message = f"{greeting}, {name}!"
     if hasattr(gw, "hello_world"):
         if not gw.silent:
             print(message)


### PR DESCRIPTION
## Summary
- Preserve caller capitalization in hello_world output

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c647534efc832683277ba61b0662a3