### PR TITLE
feat(lcd): add boot message service

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 - ensure ``gway.builtins`` package is included in distribution
+- add boot service to show LCD message at startup
 
 0.4.59 [build 27aace]
 ---------------------

--- a/data/static/lcd/README.rst
+++ b/data/static/lcd/README.rst
@@ -41,6 +41,14 @@ From the command line::
     gway lcd show "Scrolling text" --scroll
     gway lcd show "Fast" --scroll --ms 500
 
+Install a boot message shown once at startup::
+
+    gway lcd boot "Welcome"
+
+Remove the boot message::
+
+    gway lcd boot --remove
+
 ``--scroll`` moves the message across the first line of the display.
 The ``--ms`` option changes the speed (milliseconds per character, default
 2000).  Message text may include ``[sigils]`` that are resolved before
@@ -52,3 +60,5 @@ Programmatically::
     gw.context["USER"] = "world"
     gw.lcd.show("Hello [USER]\nWorld")
     gw.lcd.show("Scrolling", scroll=True, ms=500)
+    gw.lcd.boot("Hello")
+    gw.lcd.boot(remove=True)


### PR DESCRIPTION
## Summary
- add `lcd.boot` to create or remove a systemd service that shows a message on boot
- document boot service usage
- test service installation and removal

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c70dd862c48326b329ee1e7ae04920