### PR TITLE
Default install scripts to global bin

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -4,6 +4,13 @@ setlocal
 rem Ensure the script runs from its own directory
 cd /d "%~dp0"
 
+rem Default to installing the gway command
+set INSTALL_BIN=1
+for %%I in (%*) do (
+    if "%%I"=="--no-bin" set INSTALL_BIN=0
+    if "%%I"=="--bin" set INSTALL_BIN=1
+)
+
 rem Create .venv and install package if not present
 if not exist ".venv" (
     echo Creating virtual environment...
@@ -13,6 +20,11 @@ if not exist ".venv" (
     python -m pip install --upgrade pip
     python -m pip install -e .
     deactivate
+)
+
+if "%INSTALL_BIN%"=="1" (
+    echo Installing gway.bat to %SystemRoot%\gway.bat...
+    copy /Y "%~dp0gway.bat" "%SystemRoot%\gway.bat" >nul
 )
 
 endlocal


### PR DESCRIPTION
## Summary
- Default install.sh to create /usr/bin/gway and add --no-bin flag
- install.bat now installs gway.bat globally unless --no-bin is specified

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c7162f29d48326bd2d207478a19573