### PR TITLE
Add RFID scan utility and clean legacy references

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,11 +6,12 @@ Unreleased
 
 - ensure ``gway.builtins`` package is included in distribution
 - add boot service to show LCD message at startup
+- drop RFID helpers from ``auth_db`` and add ``rfid.scan`` utility
 
 0.4.59 [build 27aace]
 ---------------------
 
-- 4fb1f00 Store VIN and validator; add weekly RFID report
+- 4fb1f00 Store VIN and validator
 
 0.4.58 [build f9604d]
 ---------------------

--- a/data/static/auth_db/README.rst
+++ b/data/static/auth_db/README.rst
@@ -2,9 +2,8 @@ Unified Authentication Database
 -------------------------------
 
 ``projects/auth_db`` provides a small helper that stores authentication
-information in a DuckDB database.  Multiple login methods can be linked
-via a shared ``identity_id`` so that a user authenticated by username
-and password can also be recognised via an RFID tag.
+information in a DuckDB database. Multiple login methods can be linked
+via a shared ``identity_id``.
 
 The tables are created automatically using ``gw.sql.model`` the first time
 any helper function is called.  By default the database is stored in
@@ -17,10 +16,4 @@ Available helpers include:
 
 ``set_basic_auth`` – store HTTP Basic credentials for an identity.
 
-``set_rfid`` – register an RFID token and optional balance.
-
 ``verify_basic`` – validate a username/password pair.
-
-``verify_rfid`` – validate an RFID and check its ``allowed`` flag.
-
-``adjust_balance`` – modify the stored balance for a tag.

--- a/data/static/rfid/README.rst
+++ b/data/static/rfid/README.rst
@@ -1,0 +1,7 @@
+RFID Utilities
+--------------
+
+``projects/rfid`` offers helpers for working with RFID hardware.
+
+``scan`` – wait for a card to be scanned and print its information. Press any
+key to stop scanning.

--- a/projects/rfid.py
+++ b/projects/rfid.py
@@ -1,0 +1,37 @@
+"""RFID scanning utilities."""
+
+import sys
+import time
+import select
+
+
+def scan():
+    """Wait for a card and print its data until a key is pressed.
+
+    The function attempts to use a ``SimpleMFRC522`` reader. If the required
+    libraries are not available, an informative message is printed and the
+    function exits.
+    """
+    try:
+        from mfrc522 import SimpleMFRC522  # type: ignore
+        import RPi.GPIO as GPIO  # type: ignore
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        print(f"RFID libraries not available: {exc}")
+        return
+
+    reader = SimpleMFRC522()
+    print("Scanning for RFID cards. Press any key to stop.")
+    try:
+        while True:
+            if select.select([sys.stdin], [], [], 0)[0]:
+                break
+            card_id, text = reader.read_no_block()
+            if card_id:
+                text = text.strip() if isinstance(text, str) else text
+                print(f"Card ID: {card_id} Text: {text}")
+            time.sleep(0.1)
+    finally:  # pragma: no cover - hardware cleanup
+        try:
+            GPIO.cleanup()  # type: ignore
+        except Exception:
+            pass

--- a/tests/test_auth_db.py
+++ b/tests/test_auth_db.py
@@ -16,23 +16,6 @@ class AuthDBTests(unittest.TestCase):
         if os.path.exists(path):
             os.remove(path)
 
-    def test_basic_rfid_flow(self):
-        uid = gw.auth_db.create_identity("Alice", dbfile=DB)
-        gw.auth_db.set_basic_auth("alice", "secret", identity_id=uid, dbfile=DB)
-        gw.auth_db.set_rfid("TAG1", identity_id=uid, balance=5, dbfile=DB)
-
-        ok, ident = gw.auth_db.verify_basic("alice", "secret", dbfile=DB)
-        self.assertTrue(ok)
-        self.assertEqual(ident, uid)
-
-        ok, ident2 = gw.auth_db.verify_rfid("TAG1", dbfile=DB)
-        self.assertTrue(ok)
-        self.assertEqual(ident2, uid)
-        self.assertEqual(gw.auth_db.get_balance("TAG1", dbfile=DB), 5)
-
-        gw.auth_db.adjust_balance("TAG1", 3, dbfile=DB)
-        self.assertEqual(gw.auth_db.get_balance("TAG1", dbfile=DB), 8)
-
     def test_sync_from_url(self):
         import tempfile
         import http.server


### PR DESCRIPTION
## Summary
- remove legacy RFID helpers from auth_db and tests
- introduce standalone rfid.scan function to read cards until a key is pressed
- document new RFID project and update changelog

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c79a6d10948326950afe3703e80aea