### PR TITLE
Stabilize LCD tests against smbus2 availability

### DIFF
--- a/tests/test_lcd.py
+++ b/tests/test_lcd.py
@@ -2,6 +2,7 @@ import sys
 import tempfile
 import types
 import unittest
+import unittest.mock
 from pathlib import Path
 from gway import gw
 
@@ -98,7 +99,7 @@ class LCDTests(unittest.TestCase):
         real_import = builtins.__import__
 
         def fake_import(name, *args, **kwargs):
-            if name == "smbus":
+            if name in {"smbus", "smbus2"}:
                 raise ModuleNotFoundError
             return real_import(name, *args, **kwargs)
 


### PR DESCRIPTION
## Summary
- import `unittest.mock` explicitly in LCD tests
- ensure `test_show_handles_missing_smbus_gracefully` simulates missing `smbus` and `smbus2`

## Testing
- `gway test`

------
https://chatgpt.com/codex/tasks/task_e_68c79cb659ec83269d06db79c2218a86