### PR TITLE
Log CLI commands to work history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,8 @@ temp/
 tmp/
 .temp/
 .tmp/
-work/
+work/*
+!work/.gitignore
 .work/
 products/
 .products/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Unreleased
 - add boot service to show LCD message at startup
 - drop RFID helpers from ``auth_db`` and add ``rfid.scan`` utility
 - allow ``lcd show --scroll`` and ``--wrap`` to snake text together
+- log every CLI invocation to ``work/history.txt``
 
 0.4.59 [build 27aace]
 ---------------------

--- a/gway/__main__.py
+++ b/gway/__main__.py
@@ -1,23 +1,42 @@
+from pathlib import Path
+import shlex
+import sys
+
 from .console import cli_main
 
 r"""
-  __                                 .___        .__                        .___                
-_/  |_   ____    _____    ____     __| _/  ____  |  |   ______    ____    __| _/  ____  _______ 
+  __                                 .___        .__                        .___
+_/  |_   ____    _____    ____     __| _/  ____  |  |   ______    ____    __| _/  ____  _______
 \   __\ /  _ \  /     \  /  _ \   / __ | _/ __ \ |  |   \____ \  /  _ \  / __ | _/ __ \ \_  __ \
  |  |  (  <_> )|  Y Y  \(  <_> ) / /_/ | \  ___/ |  |__ |  |_> >(  <.> )/ /_/ | \  ___/  |  | \/
- |__|   \____/ |__|_|  / \____/  \____ |  \___  >|____/ |   __/  \____/ \____ |  \___  > |__|   
-                     \/               \/      \/        |__|                 \/      \/         
+ |__|   \____/ |__|_|  / \____/  \____ |  \___  >|____/ |   __/  \____/ \____ |  \___  > |__|
+                     \/               \/      \/        |__|                 \/      \/
 
 [ Venimos de la Tribu. ] [ A la Tribu volveremos. ]
 
 -- El siguiente [texto] es un poema que se cuenta a si mismo. --
 
-Python/HTML/CSS/SQL code by Rafael Jesús Guillén Osorio (https://arthexis.com) 
+Python/HTML/CSS/SQL code by Rafael Jesús Guillén Osorio (https://arthexis.com)
 Comments, reviews and support by Avon[ ]Ross, Keats, INTERCAL and Aristóteles Palimpsesto, III.
 Testing, QA Acceptance and mischief instigation by Dr. A. Lince (and His team.)
 
 """
 
-if __name__ == "__main__":
+
+def _append_history() -> None:
+    """Log executed CLI commands to work/history.txt."""
+    try:
+        cmd = shlex.join(sys.argv[1:])
+        path = Path.cwd() / "work" / "history.txt"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(cmd + "\n")
+    except Exception:
+        # Logging should never block CLI execution
+        pass
+
+
+if __name__ == "__main__":  # pragma: no cover - handled by invocation
+    _append_history()
     cli_main()
-    
+

--- a/tests/test_history_logging.py
+++ b/tests/test_history_logging.py
@@ -1,0 +1,13 @@
+import subprocess
+from pathlib import Path
+
+
+def test_cli_logs_to_history(tmp_path):
+    history = tmp_path / "work" / "history.txt"
+
+    result = subprocess.run(["gway", "-h"], cwd=tmp_path)
+
+    assert result.returncode == 0
+    assert history.exists()
+    assert history.read_text(encoding="utf-8").strip() == "-h"
+

--- a/work/.gitignore
+++ b/work/.gitignore
@@ -1,0 +1,5 @@
+# Ignore all command history logs
+
+*
+!.gitignore
+


### PR DESCRIPTION
## Summary
- log every `gway` CLI invocation to `work/history.txt`
- ignore generated history logs from version control
- test command logging

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68c830ab628c832693d35de048e9a2b6