### PR TITLE
Add temp_env helper for canary auto-upgrade

### DIFF
--- a/recipes/auto_upgrade.gwr
+++ b/recipes/auto_upgrade.gwr
@@ -8,5 +8,9 @@
 # a new release is published. The service manager can then restart the
 # recipe, triggering another upgrade cycle.
 
+# Canary check: install the candidate release in an isolated environment and
+# run a smoke test before touching the live installation.  temp_env removes the
+# temporary directory automatically when the test succeeds.
+temp_env --pip-args=--quiet gway test --on-failure abort
 shell pip install --quiet --upgrade gway
 until --abort --pypi

--- a/tests/test_temp_env_builtin.py
+++ b/tests/test_temp_env_builtin.py
@@ -1,0 +1,35 @@
+import pathlib
+import shutil
+import unittest
+
+from gway import gw
+
+
+class TempEnvBuiltinTests(unittest.TestCase):
+    def test_runs_command_and_cleans_up(self):
+        code = "import sys; print(sys.prefix)"
+        result = gw.temp_env("python", "-c", code, packages="", capture_output=True)
+        prefix = pathlib.Path(result["stdout"].strip())
+        self.assertEqual(result["returncode"], 0)
+        self.assertEqual(prefix.parent, pathlib.Path(result["env"]))
+        self.assertFalse(pathlib.Path(result["env"]).exists())
+
+    def test_keep_true_preserves_environment(self):
+        result = gw.temp_env(
+            "python",
+            "-c",
+            "print('ok')",
+            packages="",
+            capture_output=True,
+            keep=True,
+        )
+        env_root = pathlib.Path(result["env"])
+        try:
+            self.assertTrue(env_root.exists())
+            self.assertEqual(result["stdout"].strip(), "ok")
+        finally:
+            shutil.rmtree(env_root, ignore_errors=True)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a temp_env builtin that provisions an isolated virtual environment and runs arbitrary commands or recipes
- gate the auto_upgrade recipe behind a canary install that runs gway test before upgrading the live environment
- cover the new helper with unit tests exercising cleanup and keep behaviour

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68c89a57cbd883269343fd7561e45989