### PR TITLE
Add redacted builtin for masking sigils

### DIFF
--- a/gway/builtins/utils.py
+++ b/gway/builtins/utils.py
@@ -7,6 +7,7 @@ __all__ = [
     "try_cast",
     "random_id",
     "notify",
+    "redacted",
 ]
 
 _EZ_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXY3456789"
@@ -51,3 +52,19 @@ def notify(message: str, *, title: str = "GWAY Notice", timeout: int = 10):
     print(message)
     gw.info(f"Console notify: {message}")
     return "console"
+
+
+def redacted(text: str | None = None) -> str:
+    """Replace sigils in ``text`` with ``"[REDACTED]"``.
+
+    If ``text`` is empty or contains no sigils, return a single ``"[REDACTED]"``.
+    """
+
+    if text is None:
+        return "[REDACTED]"
+
+    value = str(text)
+    redacted_value, count = Sigil._pattern.subn("[REDACTED]", value)
+    if count == 0:
+        return "[REDACTED]"
+    return redacted_value

--- a/tests/test_redacted_builtin.py
+++ b/tests/test_redacted_builtin.py
@@ -1,0 +1,16 @@
+"""Tests for the redacted builtin."""
+
+from gway.gateway import gw
+
+
+def test_redacted_replaces_sigils():
+    text = "Hello [name] and [other]!"
+    assert gw.redacted(text) == "Hello [REDACTED] and [REDACTED]!"
+
+
+def test_redacted_without_sigils_returns_placeholder():
+    assert gw.redacted("No placeholders here") == "[REDACTED]"
+
+
+def test_redacted_without_arguments():
+    assert gw.redacted() == "[REDACTED]"


### PR DESCRIPTION
## Summary
- add a redacted builtin that replaces any sigils in provided text with "[REDACTED]"
- return a default "[REDACTED]" placeholder when no text or sigils are present
- cover the new builtin with unit tests verifying sigil masking and fallback behaviour

## Testing
- pytest tests/test_redacted_builtin.py
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68c8b158c6348326801cf78e05e4df76