### PR TITLE
Create PIR project with sense_motion helper

### DIFF
--- a/projects/pir.py
+++ b/projects/pir.py
@@ -1,0 +1,60 @@
+"""Prototype helpers for passive infrared (PIR) sensors."""
+
+from __future__ import annotations
+
+import time
+
+from gway.projects.sensor import _resolve_gpio
+
+
+def sense_motion(
+    *,
+    pin: int = 17,
+    gpio_module=None,
+    settle_time: float = 2.0,
+    interval: float = 0.5,
+    max_checks: int | None = None,
+) -> None:
+    """Run a simple console prototype for a PIR motion sensor.
+
+    Parameters
+    ----------
+    pin:
+        BCM pin number connected to the sensor's digital output. Defaults to
+        ``17`` (``IO17``).
+    gpio_module:
+        Optional GPIO-like module providing ``setmode``, ``setup``, ``input``
+        and ``cleanup``. Defaults to :mod:`RPi.GPIO` (or :mod:`RPIO`) when
+        available.
+    settle_time:
+        Seconds to wait after setting up the GPIO pin before polling. Defaults
+        to ``2`` seconds to match common PIR warm-up requirements.
+    interval:
+        Seconds to wait between polls. Defaults to half a second.
+    max_checks:
+        Maximum number of polls to perform before returning. ``None`` means run
+        indefinitely. This is primarily intended for testing.
+    """
+
+    GPIO = _resolve_gpio(gpio_module)
+    if GPIO is None:
+        return
+    GPIO.setmode(getattr(GPIO, "BCM", GPIO.BOARD))
+    GPIO.setup(pin, getattr(GPIO, "IN"))
+    print("PIR Sensor Test (CTRL+C to exit)")
+    if settle_time > 0:
+        time.sleep(settle_time)
+    checks = 0
+    try:
+        while max_checks is None or checks < max_checks:
+            message = "⚡ Motion detected!" if GPIO.input(pin) else "... no motion"
+            print(message)
+            checks += 1
+            if max_checks is not None and checks >= max_checks:
+                break
+            if interval > 0:
+                time.sleep(interval)
+    except KeyboardInterrupt:  # pragma: no cover - user interrupt
+        print("Exiting...")
+    finally:
+        GPIO.cleanup(pin)

--- a/projects/sensor.py
+++ b/projects/sensor.py
@@ -112,3 +112,5 @@ def proximity(
         print("\nStopping proximity polling")
     finally:
         GPIO.cleanup(pin)
+
+

--- a/tests/test_pir_sense_motion.py
+++ b/tests/test_pir_sense_motion.py
@@ -1,0 +1,90 @@
+import io
+from contextlib import redirect_stdout
+
+from gway import gw
+
+
+def test_sense_motion_reports_sequence():
+    class FakeGPIO:
+        BCM = "BCM"
+        IN = "IN"
+
+        def __init__(self, readings):
+            self.readings = readings
+            self.cleaned = []
+
+        def setmode(self, mode):
+            self.mode = mode
+
+        def setup(self, pin, mode):
+            self.pin = pin
+            self.mode_set = mode
+
+        def input(self, pin):
+            return self.readings.pop(0)
+
+        def cleanup(self, pin):
+            self.cleaned.append(pin)
+
+    gpio = FakeGPIO([0, 1, 0])
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        gw.pir.sense_motion(
+            gpio_module=gpio,
+            settle_time=0.0,
+            interval=0.0,
+            max_checks=3,
+        )
+
+    lines = buf.getvalue().splitlines()
+    assert lines == [
+        "PIR Sensor Test (CTRL+C to exit)",
+        "... no motion",
+        "⚡ Motion detected!",
+        "... no motion",
+    ]
+    assert gpio.cleaned == [17]
+
+
+def test_sense_motion_handles_keyboard_interrupt(monkeypatch):
+    class FakeGPIO:
+        BCM = "BCM"
+        IN = "IN"
+
+        def __init__(self):
+            self.cleaned = []
+
+        def setmode(self, mode):
+            self.mode = mode
+
+        def setup(self, pin, mode):
+            self.pin = pin
+            self.mode_set = mode
+
+        def input(self, pin):
+            return 0
+
+        def cleanup(self, pin):
+            self.cleaned.append(pin)
+
+    def raising_sleep(seconds):
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr("gway.projects.pir.time.sleep", raising_sleep)
+
+    gpio = FakeGPIO()
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        gw.pir.sense_motion(
+            gpio_module=gpio,
+            settle_time=0.0,
+            interval=1.0,
+        )
+
+    lines = buf.getvalue().splitlines()
+    assert lines == [
+        "PIR Sensor Test (CTRL+C to exit)",
+        "... no motion",
+        "Exiting...",
+    ]
+    assert gpio.cleaned == [17]


### PR DESCRIPTION
## Summary
- create a dedicated `pir` project with a `sense_motion` helper using the PIR console prototype logic so it can be invoked separately from other sensors
- expose configuration for warm-up, poll interval, and max checks so it can be tested
- cover the helper with unit tests for normal operation and keyboard interrupts updated to target the new project

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68c9a003dbf083269ade5bfcf78aa985