### PR TITLE
Allow removing global symlink during uninstall

### DIFF
--- a/gway/builtins/core.py
+++ b/gway/builtins/core.py
@@ -357,7 +357,8 @@ def install(
     The helper mirrors the behavior of invoking ``install.sh`` from the
     repository root.  Pass a ``recipe`` name (or path) to install or upgrade
     its systemd service.  Use ``--remove`` to disable a previously installed
-    service, ``--repair`` to reinstall all known services, ``--bin`` to
+    service (combine it with ``--bin`` to uninstall the global ``gway``
+    command), ``--repair`` to reinstall all known services, ``--bin`` to
     register the ``gway`` CLI globally, and ``--shell`` to configure the
     ``gway shell`` wrapper as the login shell.  Additional flags are forwarded
     directly to the script.
@@ -380,17 +381,19 @@ def install(
     }
     enabled_actions = [name for name, enabled in action_flags.items() if enabled]
     if len(enabled_actions) > 1:
-        raise ValueError(
-            "Options --repair, --remove, --bin and --shell are mutually exclusive."
-        )
+        if set(enabled_actions) != {"remove", "bin"}:
+            raise ValueError(
+                "Options --repair, --remove, --bin and --shell are mutually exclusive. "
+                "Combine --bin with --remove to uninstall the global command."
+            )
 
     if repair and recipe:
         raise ValueError("--repair cannot be combined with a recipe argument")
-    if bin and recipe:
+    if bin and recipe and not remove:
         raise ValueError("--bin cannot be combined with a recipe argument")
     if shell and recipe:
         raise ValueError("--shell cannot be combined with a recipe argument")
-    if remove and not recipe:
+    if remove and not recipe and not bin:
         raise ValueError("--remove requires a recipe name or path")
     if root and (remove or repair or bin or shell or not recipe):
         raise ValueError("--root can only be used when installing a recipe service")
@@ -400,9 +403,9 @@ def install(
     cmd = ["bash", os.fspath(script)]
     if repair:
         cmd.append("--repair")
-    elif bin:
+    if bin:
         cmd.append("--bin")
-    elif shell:
+    if shell:
         cmd.append("--shell")
     if remove:
         cmd.append("--remove")

--- a/tests/test_install_builtin.py
+++ b/tests/test_install_builtin.py
@@ -73,6 +73,31 @@ class InstallBuiltinTests(unittest.TestCase):
         output = self.stdout.getvalue()
         self.assertIn("args: --remove auto_upgrade", output)
 
+    def test_install_allows_bin_with_remove(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install("auto_upgrade", remove=True, bin=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --bin --remove auto_upgrade", output)
+
+    def test_install_remove_bin_without_recipe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install(remove=True, bin=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --bin --remove", output)
+        self.assertNotIn("auto_upgrade", output)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- restructure `install.sh` flag handling so `--bin` can be combined with `--remove` to delete the global symlink and update usage help
- update `gw.install` validation/documentation to forward the new combination
- extend the install builtin tests to cover removing the global `gway` command

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68c9d55a63d883269fdad4501d16aeb9