### PR TITLE
Support uninstalling shell wrapper during remove

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,24 +25,27 @@ fi
 source .venv/bin/activate
 
 # Parse arguments
-ACTION="install"
 DEBUG_FLAG=""
 RECIPE=""
 FORCE_FLAG=""
 ROOT_FLAG=""
+REPAIR_FLAG=false
+REMOVE_FLAG=false
+BIN_FLAG=false
+SHELL_FLAG=false
 for arg in "$@"; do
   case "$arg" in
     --repair)
-      ACTION="repair"
+      REPAIR_FLAG=true
       ;;
     --remove)
-      ACTION="remove"
+      REMOVE_FLAG=true
       ;;
     --bin)
-      ACTION="bin"
+      BIN_FLAG=true
       ;;
     --shell)
-      ACTION="shell"
+      SHELL_FLAG=true
       ;;
     --force)
       FORCE_FLAG="--force"
@@ -67,9 +70,9 @@ done
 
 # Determine if this action requires root privileges
 ROOT_REQUIRED=false
-if [[ "$ACTION" == "remove" || "$ACTION" == "repair" || "$ACTION" == "bin" || "$ACTION" == "shell" ]]; then
+if $REPAIR_FLAG || $REMOVE_FLAG || $BIN_FLAG || $SHELL_FLAG; then
   ROOT_REQUIRED=true
-elif [[ "$ACTION" == "install" && -n "$RECIPE" ]]; then
+elif [[ -n "$RECIPE" ]]; then
   ROOT_REQUIRED=true
 fi
 
@@ -88,13 +91,44 @@ if $ROOT_REQUIRED; then
   fi
 fi
 
+if $REPAIR_FLAG && ($REMOVE_FLAG || $BIN_FLAG || $SHELL_FLAG); then
+  echo "ERROR: Options --repair, --remove, --bin and --shell are mutually exclusive. Combine --remove with --bin or --shell to uninstall those integrations." >&2
+  deactivate
+  exit 1
+fi
+
+if $BIN_FLAG && $SHELL_FLAG && ! $REMOVE_FLAG; then
+  echo "ERROR: Options --bin and --shell cannot be combined unless used with --remove." >&2
+  deactivate
+  exit 1
+fi
+
+if $REPAIR_FLAG && [[ -n "$RECIPE" ]]; then
+  echo "ERROR: --repair does not take a recipe argument" >&2
+  deactivate
+  exit 1
+fi
+
+if $SHELL_FLAG && [[ -n "$RECIPE" ]] && ! $REMOVE_FLAG; then
+  echo "ERROR: --shell does not take a recipe argument" >&2
+  deactivate
+  exit 1
+fi
+
+if $BIN_FLAG && ! $REMOVE_FLAG && [[ -n "$RECIPE" ]]; then
+  echo "ERROR: --bin does not take a recipe argument" >&2
+  deactivate
+  exit 1
+fi
+
+if $REMOVE_FLAG && [[ -z "$RECIPE" ]] && ! $BIN_FLAG && ! $SHELL_FLAG; then
+  echo "ERROR: --remove requires a recipe argument" >&2
+  deactivate
+  exit 1
+fi
+
 # Repair previously installed services
-if [[ "$ACTION" == "repair" ]]; then
-  if [[ -n "$RECIPE" ]]; then
-    echo "ERROR: --repair does not take a recipe argument" >&2
-    deactivate
-    exit 1
-  fi
+if $REPAIR_FLAG; then
   echo "Repairing installed gway services..."
   for unit in /etc/systemd/system/gway-*.service; do
     [[ -f "$unit" ]] || continue
@@ -110,43 +144,54 @@ if [[ "$ACTION" == "repair" ]]; then
 fi
 
 # Remove specified service
-if [[ "$ACTION" == "remove" ]]; then
-  if [[ -z "$RECIPE" ]]; then
-    echo "ERROR: --remove requires a recipe argument" >&2
-    deactivate
-    exit 1
+if $REMOVE_FLAG; then
+  if [[ -n "$RECIPE" ]]; then
+    SERVICE_SAFE_RECIPE="${RECIPE//\//-}"
+    SERVICE_SAFE_RECIPE="${SERVICE_SAFE_RECIPE//[^a-zA-Z0-9_-]/-}"
+    SERVICE_NAME="gway-${SERVICE_SAFE_RECIPE}.service"
+    SERVICE_PATH="/etc/systemd/system/$SERVICE_NAME"
+    echo "Removing systemd service '$SERVICE_NAME' for recipe '$RECIPE'..."
+    $SUDO systemctl stop "$SERVICE_NAME" 2>/dev/null || true
+    $SUDO systemctl disable "$SERVICE_NAME" 2>/dev/null || true
+    if [[ -f "$SERVICE_PATH" ]]; then
+      $SUDO rm -f "$SERVICE_PATH"
+    fi
+    $SUDO systemctl daemon-reload
   fi
-  SERVICE_SAFE_RECIPE="${RECIPE//\//-}"
-  SERVICE_SAFE_RECIPE="${SERVICE_SAFE_RECIPE//[^a-zA-Z0-9_-]/-}"
-  SERVICE_NAME="gway-${SERVICE_SAFE_RECIPE}.service"
-  SERVICE_PATH="/etc/systemd/system/$SERVICE_NAME"
-  echo "Removing systemd service '$SERVICE_NAME' for recipe '$RECIPE'..."
-  $SUDO systemctl stop "$SERVICE_NAME" 2>/dev/null || true
-  $SUDO systemctl disable "$SERVICE_NAME" 2>/dev/null || true
-  if [[ -f "$SERVICE_PATH" ]]; then
-    $SUDO rm -f "$SERVICE_PATH"
-  fi
-  $SUDO systemctl daemon-reload
-  deactivate
-  exit 0
 fi
 
-# Install global /usr/bin/gway symlink
-if [[ "$ACTION" == "bin" ]]; then
-  if [[ -n "$RECIPE" ]]; then
-    echo "ERROR: --bin does not take a recipe argument" >&2
-    deactivate
-    exit 1
+# Install or remove global /usr/bin/gway symlink
+if $BIN_FLAG; then
+  BIN_TARGET="/usr/bin/gway"
+  if $REMOVE_FLAG; then
+    echo "Removing gway from $BIN_TARGET..."
+    if [[ -L "$BIN_TARGET" ]]; then
+      TARGET_PATH="$(readlink -f "$BIN_TARGET")"
+      if [[ "$TARGET_PATH" == "$SCRIPT_DIR/gway.sh" ]]; then
+        $SUDO rm -f "$BIN_TARGET"
+        echo "  → Removed symlink to $TARGET_PATH."
+      else
+        echo "WARNING: $BIN_TARGET is not managed by this installer; skipping removal." >&2
+      fi
+    elif [[ -e "$BIN_TARGET" ]]; then
+      echo "WARNING: $BIN_TARGET exists but is not a symlink; skipping removal." >&2
+    else
+      echo "  → No $BIN_TARGET symlink found."
+    fi
+  else
+    echo "Installing gway to $BIN_TARGET..."
+    $SUDO ln -sf "$SCRIPT_DIR/gway.sh" "$BIN_TARGET"
+    $SUDO chmod +x "$SCRIPT_DIR/gway.sh"
   fi
-  echo "Installing gway to /usr/bin/gway..."
-  $SUDO ln -sf "$SCRIPT_DIR/gway.sh" /usr/bin/gway
-  $SUDO chmod +x "$SCRIPT_DIR/gway.sh"
+fi
+
+if ($REMOVE_FLAG || $BIN_FLAG) && ! $SHELL_FLAG; then
   deactivate
   exit 0
 fi
 
 # 2) No-arg case: notify installation and usage
-if [[ -z "$RECIPE" && "$ACTION" == "install" ]]; then
+if [[ -z "$RECIPE" ]] && ! $REPAIR_FLAG && ! $BIN_FLAG && ! $REMOVE_FLAG && ! $SHELL_FLAG; then
   echo "GWAY has been set up in .venv."
   echo "To install a systemd service for a recipe, run:"
   echo "  sudo ./install.sh <recipe-name> [--debug]"
@@ -156,19 +201,20 @@ if [[ -z "$RECIPE" && "$ACTION" == "install" ]]; then
   echo "  sudo ./install.sh --repair"
   echo "To install gway as a global command, run:"
   echo "  sudo ./install.sh --bin"
+  echo "To uninstall the global command, run:"
+  echo "  sudo ./install.sh --bin --remove"
   echo "To use 'gway shell' as your login shell, run:"
   echo "  sudo ./install.sh --shell"
+  echo "To restore your previous login shell, run:"
+  echo "  sudo ./install.sh --shell --remove"
   deactivate
   exit 0
 fi
 
+SHELL_STATE_FILE="$SCRIPT_DIR/.venv/.gway-shell-default"
+
 # Configure the GWAY login shell wrapper and set it as default
-if [[ "$ACTION" == "shell" ]]; then
-  if [[ -n "$RECIPE" ]]; then
-    echo "ERROR: --shell does not take a recipe argument" >&2
-    deactivate
-    exit 1
-  fi
+if $SHELL_FLAG; then
 
   if ! command -v chsh >/dev/null 2>&1; then
     echo "ERROR: 'chsh' command not found. Unable to change default shell." >&2
@@ -177,6 +223,86 @@ if [[ "$ACTION" == "shell" ]]; then
   fi
 
   SHELL_WRAPPER="$SCRIPT_DIR/.venv/bin/gway-shell"
+  TARGET_USER="${SUDO_USER-$(whoami)}"
+  CURRENT_USER="$(whoami)"
+  CURRENT_ENTRY="$(getent passwd "$TARGET_USER" || true)"
+  CURRENT_SHELL=""
+  if [[ -n "$CURRENT_ENTRY" ]]; then
+    IFS=':' read -r _ _ _ _ _ _ CURRENT_SHELL <<< "$CURRENT_ENTRY"
+  fi
+
+  if $REMOVE_FLAG; then
+    echo "Restoring login shell for $TARGET_USER..."
+    FALLBACK_SHELL=""
+    if [[ -f "$SHELL_STATE_FILE" ]]; then
+      FALLBACK_SHELL="$(cat "$SHELL_STATE_FILE")"
+    fi
+    if [[ -z "$FALLBACK_SHELL" ]]; then
+      if command -v bash >/dev/null 2>&1; then
+        FALLBACK_SHELL="$(command -v bash)"
+      elif [[ -x /bin/sh ]]; then
+        FALLBACK_SHELL="/bin/sh"
+      else
+        echo "ERROR: Unable to determine a fallback shell." >&2
+        deactivate
+        exit 1
+      fi
+    fi
+
+    if [[ -n "$CURRENT_SHELL" && "$CURRENT_SHELL" == "$SHELL_WRAPPER" ]]; then
+      CHSH_CMD=("chsh" "-s" "$FALLBACK_SHELL")
+      if [[ "$TARGET_USER" != "$CURRENT_USER" ]]; then
+        CHSH_CMD+=("$TARGET_USER")
+      fi
+      if [[ -n "$SUDO" ]]; then
+        CHSH_CMD=("$SUDO" "${CHSH_CMD[@]}")
+      fi
+      if ! "${CHSH_CMD[@]}"; then
+        echo "ERROR: Failed to restore default shell for $TARGET_USER." >&2
+        deactivate
+        exit 1
+      fi
+      echo "Default shell for $TARGET_USER restored to '$FALLBACK_SHELL'."
+    else
+      if [[ -n "$CURRENT_SHELL" ]]; then
+        echo "Current shell for $TARGET_USER is '$CURRENT_SHELL'; leaving unchanged."
+      else
+        echo "WARNING: Unable to determine current shell for $TARGET_USER." >&2
+      fi
+    fi
+
+    if [[ -f /etc/shells ]]; then
+      if grep -Fxq "$SHELL_WRAPPER" /etc/shells; then
+        echo "Removing $SHELL_WRAPPER from /etc/shells..."
+        if [[ -n "$SUDO" ]]; then
+          if ! $SUDO sed -i '#^'"$SHELL_WRAPPER"'$#d' /etc/shells; then
+            echo "WARNING: Failed to update /etc/shells. Please remove '$SHELL_WRAPPER' manually." >&2
+          fi
+        else
+          if ! sed -i '#^'"$SHELL_WRAPPER"'$#d' /etc/shells; then
+            echo "WARNING: Failed to update /etc/shells. Please remove '$SHELL_WRAPPER' manually." >&2
+          fi
+        fi
+      fi
+    fi
+
+    if [[ -e "$SHELL_WRAPPER" ]]; then
+      rm -f "$SHELL_WRAPPER"
+      echo "Removed shell wrapper at $SHELL_WRAPPER."
+    fi
+
+    if [[ -f "$SHELL_STATE_FILE" ]]; then
+      rm -f "$SHELL_STATE_FILE"
+    fi
+
+    deactivate
+    exit 0
+  fi
+
+  if [[ -n "$CURRENT_SHELL" && "$CURRENT_SHELL" != "$SHELL_WRAPPER" ]]; then
+    printf '%s\n' "$CURRENT_SHELL" > "$SHELL_STATE_FILE"
+  fi
+
   cat > "$SHELL_WRAPPER" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
@@ -210,8 +336,6 @@ EOF
     echo "WARNING: /etc/shells not found; skipping registration." >&2
   fi
 
-  TARGET_USER="${SUDO_USER-$(whoami)}"
-  CURRENT_USER="$(whoami)"
   CHSH_CMD=("chsh" "-s" "$SHELL_WRAPPER")
   if [[ "$TARGET_USER" != "$CURRENT_USER" ]]; then
     CHSH_CMD+=("$TARGET_USER")

--- a/tests/test_install_builtin.py
+++ b/tests/test_install_builtin.py
@@ -54,6 +54,10 @@ class InstallBuiltinTests(unittest.TestCase):
             gw.install("auto", shell=True)
         with self.assertRaises(ValueError):
             gw.install(repair=True, bin=True)
+        with self.assertRaises(ValueError):
+            gw.install(repair=True, shell=True)
+        with self.assertRaises(ValueError):
+            gw.install(bin=True, shell=True)
 
     def test_install_root_requires_recipe(self):
         with self.assertRaises(ValueError):
@@ -72,6 +76,68 @@ class InstallBuiltinTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         output = self.stdout.getvalue()
         self.assertIn("args: --remove auto_upgrade", output)
+
+    def test_install_allows_bin_with_remove(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install("auto_upgrade", remove=True, bin=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --bin --remove auto_upgrade", output)
+
+    def test_install_allows_shell_with_remove(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install("auto_upgrade", remove=True, shell=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --shell --remove auto_upgrade", output)
+
+    def test_install_remove_bin_without_recipe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install(remove=True, bin=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --bin --remove", output)
+        self.assertNotIn("auto_upgrade", output)
+
+    def test_install_remove_shell_without_recipe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install(remove=True, shell=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --shell --remove", output)
+        self.assertNotIn("auto_upgrade", output)
+
+    def test_install_remove_bin_and_shell(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install("auto_upgrade", remove=True, bin=True, shell=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --bin --shell --remove auto_upgrade", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- allow `install.sh` to pair `--remove` with `--shell`, restoring the prior login shell, unregistering the wrapper, and cleaning up state
- update install argument validation and help text so `--remove` may be combined with either `--bin` or `--shell`
- extend the install builtin tests to exercise shell removal flows and additional validation errors

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68c9d55a63d883269fdad4501d16aeb9