### PR TITLE
Move video and QR helpers into standalone projects

### DIFF
--- a/projects/qr.py
+++ b/projects/qr.py
@@ -1,11 +1,12 @@
-
-# file: projects/qr.py
+"""QR code generation and scanning helpers."""
 
 import os
 import uuid
 import base64
 from io import BytesIO
+
 import qrcode
+
 from gway import gw
 
 
@@ -46,9 +47,9 @@ def generate_b64data(value):
     return base64.b64encode(buffer.getvalue()).decode("ascii")
 
 
-def scan_img(source):
+def scan(source):
     """
-    Scan the given image (file‑path or PIL.Image) for QR codes and return
+    Scan the given image (file-path or PIL.Image) for QR codes and return
     a list of decoded string values. Returns [] if nothing’s found.
     """
     import cv2

--- a/projects/video.py
+++ b/projects/video.py
@@ -1,4 +1,4 @@
-"""Video stream helpers for studio project."""
+"""Video stream helpers for the standalone video project."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ from typing import Iterator, Iterable
 from gway import gw
 
 
-def capture_camera(*, source: int = 0) -> Iterator:
+def capture(*, source: int = 0) -> Iterator:
     """Capture frames from a camera device.
 
     Parameters
@@ -41,7 +41,7 @@ def capture_camera(*, source: int = 0) -> Iterator:
     return _generator()
 
 
-def display_video(stream: Iterable, *, screen: int = 0) -> bool:
+def display(stream: Iterable, *, screen: int = 0) -> bool:
     """Display frames from ``stream`` using pygame.
 
     Parameters

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -48,7 +48,7 @@ class GatewayBuiltinsTests(unittest.TestCase):
     def test_load_qr_code_project(self):
         # Normally qr is autoloaded when accessed, but this test ensures we can
         # also manually load projects and use the objects directly if we need to.
-        project = gw.load_project("studio.qr")
+        project = gw.load_project("qr")
         test_url = project.generate_url("test")
         self.assertTrue(test_url.endswith(".png"))
 

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -99,7 +99,7 @@ class GatewayTests(unittest.TestCase):
             return Path().joinpath(*parts)
 
         with patch.object(gw, "resource", fake_resource):
-            project = gw.find_project("does.not.exist", "studio.qr")
+            project = gw.find_project("does.not.exist", "qr")
             self.assertIsNotNone(project)
             self.assertTrue(hasattr(project, "generate_url"))
             none_proj = gw.find_project("nope1", "nope2")

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -9,7 +9,7 @@ from gway import gw
 
 
 def _load_video():
-    video_path = Path(__file__).resolve().parents[1] / "projects" / "studio" / "video.py"
+    video_path = Path(__file__).resolve().parents[1] / "projects" / "video.py"
     spec = importlib.util.spec_from_file_location("video", video_path)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -17,7 +17,7 @@ def _load_video():
 
 
 class CaptureCameraTests(unittest.TestCase):
-    def test_capture_camera_yields_frames_and_releases(self):
+    def test_capture_yields_frames_and_releases(self):
         video = _load_video()
         frame = np.zeros((10, 10, 3), dtype="uint8")
 
@@ -27,7 +27,7 @@ class CaptureCameraTests(unittest.TestCase):
         fake_cv2 = types.SimpleNamespace(VideoCapture=MagicMock(return_value=fake_cap))
 
         with unittest.mock.patch.dict('sys.modules', {'cv2': fake_cv2}):
-            gen = video.capture_camera(source=0)
+            gen = video.capture(source=0)
             frames = list(gen)
 
         self.assertEqual(len(frames), 1)
@@ -35,12 +35,12 @@ class CaptureCameraTests(unittest.TestCase):
 
 
 class DisplayVideoTests(unittest.TestCase):
-    def test_display_video_rejects_non_iterable(self):
+    def test_display_rejects_non_iterable(self):
         video = _load_video()
         with self.assertRaises(ValueError):
-            video.display_video(123)
+            video.display(123)
 
-    def test_display_video_consumes_stream(self):
+    def test_display_consumes_stream(self):
         video = _load_video()
         frames = [np.zeros((5, 5, 3), dtype="uint8") for _ in range(2)]
         stream = (f for f in frames)
@@ -58,7 +58,7 @@ class DisplayVideoTests(unittest.TestCase):
         fake_cv2 = types.SimpleNamespace(colorConverter=MagicMock(), COLOR_BGR2RGB=0, cvtColor=lambda f, code: f)
 
         with unittest.mock.patch.dict('sys.modules', {'pygame': fake_pygame, 'cv2': fake_cv2}):
-            result = video.display_video(stream)
+            result = video.display(stream)
 
         self.assertTrue(result)
         fake_display.set_mode.assert_called_once()


### PR DESCRIPTION
## Summary
- move the studio video helpers to a standalone `projects/video.py` module and rename the public APIs to `capture` and `display`
- relocate the QR utilities into `projects/qr.py`, renaming `scan_img` to `scan`
- update the existing tests to reference the new project locations and function names

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68c9defcc2a883268fa1b953d2cd348d