### PR TITLE
Fix shell uninstall cleanup when using sudo

### DIFF
--- a/tests/test_install_builtin.py
+++ b/tests/test_install_builtin.py
@@ -54,6 +54,10 @@ class InstallBuiltinTests(unittest.TestCase):
             gw.install("auto", shell=True)
         with self.assertRaises(ValueError):
             gw.install(repair=True, bin=True)
+        with self.assertRaises(ValueError):
+            gw.install(repair=True, shell=True)
+        with self.assertRaises(ValueError):
+            gw.install(bin=True, shell=True)
 
     def test_install_root_requires_recipe(self):
         with self.assertRaises(ValueError):
@@ -72,6 +76,68 @@ class InstallBuiltinTests(unittest.TestCase):
         self.assertEqual(rc, 0)
         output = self.stdout.getvalue()
         self.assertIn("args: --remove auto_upgrade", output)
+
+    def test_install_allows_bin_with_remove(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install("auto_upgrade", remove=True, bin=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --bin --remove auto_upgrade", output)
+
+    def test_install_allows_shell_with_remove(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install("auto_upgrade", remove=True, shell=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --shell --remove auto_upgrade", output)
+
+    def test_install_remove_bin_without_recipe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install(remove=True, bin=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --bin --remove", output)
+        self.assertNotIn("auto_upgrade", output)
+
+    def test_install_remove_shell_without_recipe(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install(remove=True, shell=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --shell --remove", output)
+        self.assertNotIn("auto_upgrade", output)
+
+    def test_install_remove_bin_and_shell(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            script = os.path.join(tmp, "install.sh")
+            self._write_script(script, "echo \"args: $@\"")
+
+            with patch.object(gw, "resource", return_value=pathlib.Path(script)):
+                rc = gw.install("auto_upgrade", remove=True, bin=True, shell=True)
+
+        self.assertEqual(rc, 0)
+        output = self.stdout.getvalue()
+        self.assertIn("args: --bin --shell --remove auto_upgrade", output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure the shell uninstall path escapes the sed pattern so gway-shell is removed from `/etc/shells`
- run wrapper and state-file removals through sudo when required so uninstall succeeds for root-owned installs

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68c9d55a63d883269fdad4501d16aeb9