### PR TITLE
Use requirements hash to skip unnecessary installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ work/
 .work/
 products/
 .products/
+requirements.md5
 
 # Node dependencies
 node_modules/

--- a/gway.bat
+++ b/gway.bat
@@ -1,6 +1,9 @@
 @echo off
 setlocal
 
+set "REQ_FILE=requirements.txt"
+set "REQ_HASH_FILE=requirements.md5"
+
 :: Change to the directory containing this script
 cd /d "%~dp0"
 
@@ -9,8 +12,14 @@ if not exist ".venv" (
     echo Creating virtual environment...
     python -m venv .venv
     call .venv\Scripts\activate.bat
-    echo Installing gway in editable mode...
+    echo Installing dependencies...
     python -m pip install --upgrade pip
+    call :EnsureRequirements force
+    if errorlevel 1 (
+        echo Failed to install requirements.>&2
+        deactivate
+        goto :END
+    )
     python -m pip install -e .
 
     deactivate
@@ -19,10 +28,64 @@ if not exist ".venv" (
 :: Activate the virtual environment
 call .venv\Scripts\activate.bat
 
+call :EnsureRequirements
+if errorlevel 1 (
+    echo Failed to install requirements.>&2
+    goto :DEACTIVATE
+)
+
 :: Run the Python module
 python -m gway %*
 
+:DEACTIVATE
 :: Deactivate the virtual environment
 deactivate
 
+:END
 endlocal
+goto :EOF
+
+:EnsureRequirements
+set "REQUIREMENTS_UPDATED=false"
+set "CURRENT_REQ_HASH="
+if not exist "%REQ_FILE%" (
+    if exist "%REQ_HASH_FILE%" del "%REQ_HASH_FILE%"
+    exit /b 0
+)
+
+for /f "usebackq delims=" %%H in (`python -c "import hashlib, pathlib, sys;print(hashlib.md5(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())" "%REQ_FILE%"`) do set "CURRENT_REQ_HASH=%%H"
+
+if not defined CURRENT_REQ_HASH (
+    echo Failed to compute requirements hash.>&2
+    exit /b 1
+)
+
+set "STORED_REQ_HASH="
+if exist "%REQ_HASH_FILE%" (
+    set /p "STORED_REQ_HASH="<"%REQ_HASH_FILE%"
+)
+
+set "NEED_INSTALL=0"
+if /I "%~1"=="force" (
+    set "NEED_INSTALL=1"
+) else (
+    if "%STORED_REQ_HASH%"=="" (
+        set "NEED_INSTALL=1"
+    ) else (
+        if /I not "%CURRENT_REQ_HASH%"=="%STORED_REQ_HASH%" (
+            set "NEED_INSTALL=1"
+        )
+    )
+)
+
+if "%NEED_INSTALL%"=="1" (
+    echo Installing requirements...
+    python -m pip install -r "%REQ_FILE%"
+    if errorlevel 1 (
+        exit /b 1
+    )
+    >"%REQ_HASH_FILE%" (echo %CURRENT_REQ_HASH%)
+    set "REQUIREMENTS_UPDATED=true"
+)
+
+exit /b 0

--- a/gway.sh
+++ b/gway.sh
@@ -1,6 +1,61 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+REQ_FILE="requirements.txt"
+REQ_HASH_FILE="requirements.md5"
+REQUIREMENTS_UPDATED=false
+
+compute_requirements_hash() {
+  python3 - "$1" <<'PY'
+import hashlib
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+print(hashlib.md5(path.read_bytes()).hexdigest())
+PY
+}
+
+sync_requirements() {
+  local force="${1-}"
+  REQUIREMENTS_UPDATED=false
+
+  if [ ! -f "$REQ_FILE" ]; then
+    if [ -f "$REQ_HASH_FILE" ]; then
+      rm -f "$REQ_HASH_FILE"
+    fi
+    return 0
+  fi
+
+  local current_hash
+  current_hash="$(compute_requirements_hash "$REQ_FILE")"
+
+  local stored_hash=""
+  if [ -f "$REQ_HASH_FILE" ]; then
+    stored_hash="$(<"$REQ_HASH_FILE")"
+  fi
+
+  local reinstall="false"
+  if [ "$force" = "--force" ]; then
+    reinstall="true"
+  elif [ -z "$stored_hash" ] || [ "$current_hash" != "$stored_hash" ]; then
+    reinstall="true"
+  fi
+
+  if [ "$reinstall" = "true" ]; then
+    echo "Installing requirements..."
+    if pip install -r "$REQ_FILE"; then
+      printf '%s\n' "$current_hash" > "$REQ_HASH_FILE"
+      REQUIREMENTS_UPDATED=true
+    else
+      echo "ERROR: Failed to install requirements." >&2
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
 # Resolve the real directory of this script, even if it’s symlinked
 SCRIPT_PATH="$(readlink -f "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
@@ -13,7 +68,10 @@ if [ ! -d ".venv" ]; then
   source .venv/bin/activate
   echo "Installing dependencies..."
   pip install --upgrade pip
-  pip install -r requirements.txt
+  if ! sync_requirements "--force"; then
+    deactivate
+    exit 1
+  fi
   pip install -e .
 
   deactivate
@@ -22,14 +80,30 @@ fi
 # Activate the virtual environment
 source .venv/bin/activate
 
+if ! sync_requirements; then
+  deactivate
+  exit 1
+fi
+
 # Run the Python module; if a dependency is missing, install requirements and retry
 if ! python3 -m gway "$@" 2> >(tee /tmp/gway_err.log >&2); then
   if grep -q "ModuleNotFoundError" /tmp/gway_err.log; then
-    echo "Missing dependency detected. Installing requirements..."
-    pip install -r requirements.txt
-    pip install -e .
-    python3 -m gway "$@"
+    echo "Missing dependency detected. Checking requirements..."
+    if sync_requirements; then
+      if [ "$REQUIREMENTS_UPDATED" = true ]; then
+        pip install -e .
+        python3 -m gway "$@"
+      else
+        echo "requirements.txt is unchanged; skipping reinstall." >&2
+        deactivate
+        exit 1
+      fi
+    else
+      deactivate
+      exit 1
+    fi
   else
+    deactivate
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary
- compute and store an md5 hash for requirements.txt in gway.sh so dependency installs only run when the file changes
- apply the same requirements hash guard to gway.bat, including error handling when the hash cannot be computed
- ignore the generated requirements.md5 file so the cache is not committed

## Testing
- python -m pip install -r requirements.txt
- python -m pip install -e .
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68c9ef0a4da08326b0735696ae3f4160