### PR TITLE
Add side builtin for parallel recipe commands

### DIFF
--- a/gway/builtins/side.py
+++ b/gway/builtins/side.py
@@ -1,0 +1,266 @@
+"""Background command execution helper for recipes."""
+
+from __future__ import annotations
+
+import itertools
+import threading
+from collections import deque
+from dataclasses import dataclass, field
+from typing import Deque, Iterable, List, Tuple
+
+__all__ = ["side"]
+
+
+@dataclass
+class _SideCommand:
+    tokens: List[str]
+    queues: Tuple[str, ...]
+    id: int
+    thread: threading.Thread | None = None
+
+
+@dataclass
+class _QueueState:
+    name: str
+    pending: Deque[_SideCommand] = field(default_factory=deque)
+    current: _SideCommand | None = None
+
+
+_DEFAULT_QUEUE = "__side_default__"
+_SIDE_LOCK = threading.Lock()
+_SIDE_QUEUES: dict[str, _QueueState] = {}
+_PENDING_COMMANDS: list[_SideCommand] = []
+_COMMAND_COUNTER = itertools.count(1)
+_CONSOLE_TOOLS: dict[str, object] | None = None
+
+
+def _get_console_tools() -> dict[str, object]:
+    """Load helpers from :mod:`gway.console` lazily to avoid import cycles."""
+
+    global _CONSOLE_TOOLS
+    if _CONSOLE_TOOLS is None:
+        from gway.console import join_unquoted_kwargs, load_recipe, normalize_token, process
+
+        _CONSOLE_TOOLS = {
+            "join_unquoted_kwargs": join_unquoted_kwargs,
+            "load_recipe": load_recipe,
+            "normalize_token": normalize_token,
+            "process": process,
+        }
+    return _CONSOLE_TOOLS
+
+
+def _ensure_queue(name: str) -> _QueueState:
+    state = _SIDE_QUEUES.get(name)
+    if state is None:
+        state = _QueueState(name)
+        _SIDE_QUEUES[name] = state
+    return state
+
+
+def _normalize_queue_names(tokens: Iterable[str]) -> list[str]:
+    names: list[str] = []
+    seen: set[str] = set()
+    for token in tokens:
+        name = token.rstrip(":")
+        if not name or name in seen:
+            continue
+        names.append(name)
+        seen.add(name)
+    return names
+
+
+def _looks_like_command(tokens: List[str]) -> bool:
+    if not tokens:
+        return False
+
+    tools = _get_console_tools()
+    join = tools["join_unquoted_kwargs"]
+    normalize = tools["normalize_token"]
+    load_recipe = tools["load_recipe"]
+
+    chunk = join(tokens)
+    if not chunk:
+        return False
+
+    from gway import gw
+
+    obj = gw
+    remaining = list(chunk)
+    path: list[str] = []
+
+    while remaining:
+        token = remaining[0]
+        normalized = normalize(token)
+        try:
+            obj = getattr(obj, normalized)
+            path.append(remaining.pop(0))
+            continue
+        except AttributeError:
+            matched = False
+            for size in range(len(remaining), 0, -1):
+                joined = "_".join(normalize(part) for part in remaining[:size])
+                try:
+                    obj = getattr(obj, joined)
+                    path.extend(remaining[:size])
+                    remaining = remaining[size:]
+                    matched = True
+                    break
+                except AttributeError:
+                    continue
+            if not matched:
+                break
+
+    if callable(obj) and path:
+        return True
+
+    try:
+        load_recipe(chunk[0], strict=False)
+        return True
+    except FileNotFoundError:
+        return False
+
+
+def _find_command_start(tokens: List[str]) -> int | None:
+    if not tokens:
+        return None
+    for index in range(len(tokens)):
+        if _looks_like_command(tokens[index:]):
+            return index
+    return None
+
+
+def _split_args(args: Tuple[str, ...]) -> tuple[list[str], list[str]]:
+    tokens = list(args)
+    if not tokens:
+        return [], []
+
+    queue_tokens: list[str] = []
+    idx = 0
+    while idx < len(tokens) and tokens[idx].endswith(":"):
+        queue_tokens.append(tokens[idx][:-1])
+        idx += 1
+
+    remaining = tokens[idx:]
+    start = _find_command_start(remaining)
+    if start is None:
+        queue_tokens.extend(remaining)
+        return queue_tokens, []
+
+    queue_tokens.extend(remaining[:start])
+    command_tokens = remaining[start:]
+    return queue_tokens, command_tokens
+
+
+def _command_ready_locked(command: _SideCommand) -> bool:
+    for name in command.queues:
+        state = _SIDE_QUEUES[name]
+        if state.current is not None:
+            return False
+        if not state.pending or state.pending[0] is not command:
+            return False
+    return True
+
+
+def _collect_ready_locked() -> list[_SideCommand]:
+    ready: list[_SideCommand] = []
+    for command in list(_PENDING_COMMANDS):
+        if _command_ready_locked(command):
+            for name in command.queues:
+                state = _SIDE_QUEUES[name]
+                if state.pending and state.pending[0] is command:
+                    state.pending.popleft()
+                state.current = command
+            _PENDING_COMMANDS.remove(command)
+            ready.append(command)
+    return ready
+
+
+def _launch_command(command: _SideCommand) -> None:
+    from gway import gw
+
+    def runner() -> None:
+        process = _get_console_tools()["process"]
+        try:
+            process([command.tokens])
+        except SystemExit:
+            pass
+        except Exception as exc:  # pragma: no cover - defensive logging
+            gw.exception(exc)
+        finally:
+            with _SIDE_LOCK:
+                for name in command.queues:
+                    state = _SIDE_QUEUES.get(name)
+                    if state and state.current is command:
+                        state.current = None
+                ready_commands = _collect_ready_locked()
+            for next_command in ready_commands:
+                _launch_command(next_command)
+
+    thread = threading.Thread(
+        target=runner,
+        name=f"gway-side-{command.id}",
+        daemon=True,
+    )
+    command.thread = thread
+    gw.debug(
+        f"[side] starting command {command.id} -> {' '.join(command.tokens)} on {command.queues}"
+    )
+    gw._async_threads.append(thread)
+    thread.start()
+
+
+def side(*args: str) -> dict:
+    """Schedule ``args`` to run in the background, optionally on named queues."""
+
+    from gway import gw
+
+    queue_tokens, command_tokens = _split_args(args)
+    queue_names = _normalize_queue_names(queue_tokens)
+
+    if not queue_names:
+        queue_names = [_DEFAULT_QUEUE]
+
+    with _SIDE_LOCK:
+        for name in queue_names:
+            _ensure_queue(name)
+
+    if not command_tokens:
+        gw.debug(f"[side] initialized queue(s): {queue_names}")
+        return {"queues": queue_names, "status": "ready"}
+
+    command = _SideCommand(list(command_tokens), tuple(queue_names), next(_COMMAND_COUNTER))
+
+    with _SIDE_LOCK:
+        for name in queue_names:
+            _SIDE_QUEUES[name].pending.append(command)
+        _PENDING_COMMANDS.append(command)
+        ready_commands = _collect_ready_locked()
+        started_now = command in ready_commands
+
+    for ready in ready_commands:
+        _launch_command(ready)
+
+    status = "started" if started_now else "queued"
+    command_text = " ".join(command_tokens)
+    gw.debug(
+        f"[side] {status} command {command.id} on queues {queue_names}: {command_text}"
+    )
+
+    return {
+        "id": command.id,
+        "queues": queue_names,
+        "command": command_text,
+        "status": status,
+    }
+
+
+def _reset_side_state_for_tests() -> None:
+    """Reset internal queues (intended for unit tests)."""
+
+    global _COMMAND_COUNTER, _CONSOLE_TOOLS
+    with _SIDE_LOCK:
+        _PENDING_COMMANDS.clear()
+        _SIDE_QUEUES.clear()
+    _COMMAND_COUNTER = itertools.count(1)
+    _CONSOLE_TOOLS = None

--- a/tests/test_side.py
+++ b/tests/test_side.py
@@ -1,0 +1,134 @@
+import threading
+import time
+import importlib
+
+import pytest
+
+from gway import gw
+
+
+@pytest.fixture
+def side_module():
+    module = importlib.import_module("gway.builtins.side")
+    module._reset_side_state_for_tests()
+    original_threads = list(gw._async_threads)
+    yield module
+    new_threads = [t for t in gw._async_threads if t not in original_threads]
+    for thread in new_threads:
+        thread.join(timeout=1)
+    module._reset_side_state_for_tests()
+    gw._async_threads.clear()
+    gw._async_threads.extend(original_threads)
+
+
+def test_side_default_queue_serializes_commands(side_module, monkeypatch):
+    start_events: list[tuple[list[str], threading.Event]] = []
+    release_events: list[threading.Event] = []
+    threads_seen: list[threading.Thread] = []
+
+    def fake_process(chunks, **kwargs):
+        command = list(chunks[0])
+        start_evt = threading.Event()
+        release_evt = threading.Event()
+        start_events.append((command, start_evt))
+        release_events.append(release_evt)
+        threads_seen.append(threading.current_thread())
+        start_evt.set()
+        release_evt.wait(timeout=1)
+        return ([], None)
+
+    monkeypatch.setattr("gway.console.process", fake_process)
+
+    result_first = side_module.side("hello-world")
+    assert result_first["status"] == "started"
+    assert start_events[0][0] == ["hello-world"]
+    assert start_events[0][1].wait(timeout=1)
+
+    result_second = side_module.side("hello-world")
+    assert result_second["status"] == "queued"
+    time.sleep(0.05)
+    assert len(start_events) == 1
+
+    release_events[0].set()
+    for _ in range(20):
+        if len(start_events) >= 2:
+            break
+        time.sleep(0.05)
+    assert len(start_events) == 2
+    assert start_events[1][0] == ["hello-world"]
+    release_events[1].set()
+
+    for thread in list(threads_seen):
+        thread.join(timeout=1)
+
+
+def test_side_named_queues_and_multiplex(side_module, monkeypatch):
+    start_records: list[tuple[list[str], threading.Event]] = []
+    release_events: list[threading.Event] = []
+    threads_seen: list[threading.Thread] = []
+
+    def fake_process(chunks, **kwargs):
+        command = list(chunks[0])
+        start_evt = threading.Event()
+        release_evt = threading.Event()
+        start_records.append((command, start_evt))
+        release_events.append(release_evt)
+        threads_seen.append(threading.current_thread())
+        start_evt.set()
+        release_evt.wait(timeout=1)
+        return ([], None)
+
+    monkeypatch.setattr("gway.console.process", fake_process)
+
+    ready_alpha = side_module.side("alpha")
+    assert ready_alpha["status"] == "ready"
+
+    first = side_module.side("alpha", "beta:", "hello-world", "--id", "A")
+    assert first["status"] == "started"
+    assert start_records[0][0] == ["hello-world", "--id", "A"]
+    assert start_records[0][1].wait(timeout=1)
+
+    second = side_module.side("alpha", "hello-world", "--id", "B")
+    third = side_module.side("beta", "hello-world", "--id", "C")
+    assert second["status"] == "queued"
+    assert third["status"] == "queued"
+    time.sleep(0.05)
+    assert len(start_records) == 1
+
+    release_events[0].set()
+    for _ in range(20):
+        if len(start_records) >= 3:
+            break
+        time.sleep(0.05)
+    assert len(start_records) == 3
+
+    seen_ids = {tuple(record[0]) for record in start_records}
+    assert ("hello-world", "--id", "A") in seen_ids
+    assert ("hello-world", "--id", "B") in seen_ids
+    assert ("hello-world", "--id", "C") in seen_ids
+
+    release_events[1].set()
+    release_events[2].set()
+
+    for thread in list(threads_seen):
+        thread.join(timeout=1)
+
+
+def test_side_supports_colon_queue_names(side_module, monkeypatch):
+    commands_seen: list[list[str]] = []
+
+    def quick_process(chunks, **kwargs):
+        commands_seen.append(list(chunks[0]))
+        return ([], None)
+
+    monkeypatch.setattr("gway.console.process", quick_process)
+
+    result = side_module.side("watcher:", "hello-world")
+    assert result["status"] == "started"
+
+    for _ in range(20):
+        if commands_seen:
+            break
+        time.sleep(0.05)
+    assert commands_seen[0] == ["hello-world"]
+    assert "watcher" in side_module._SIDE_QUEUES


### PR DESCRIPTION
## Summary
- add a `side` builtin that schedules recipe commands on background queues and runs them in worker threads
- rely on the existing recipe parser without special-case handling for `side` prefixes
- cover the new behaviour with unit tests for default and named queues as well as colon-prefixed syntax

## Testing
- pytest tests/test_side.py

------
https://chatgpt.com/codex/tasks/task_e_68c9fa43a0648326b40c94a7a7f1aeb1