### PR TITLE
Ensure install shell uses explicit target user

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -251,7 +251,7 @@ if $SHELL_FLAG; then
 
     if [[ -n "$CURRENT_SHELL" && "$CURRENT_SHELL" == "$SHELL_WRAPPER" ]]; then
       CHSH_CMD=("chsh" "-s" "$FALLBACK_SHELL")
-      if [[ "$TARGET_USER" != "$CURRENT_USER" ]]; then
+      if [[ -n "$TARGET_USER" ]]; then
         CHSH_CMD+=("$TARGET_USER")
       fi
       if [[ -n "$SUDO" ]]; then
@@ -345,7 +345,7 @@ EOF
   fi
 
   CHSH_CMD=("chsh" "-s" "$SHELL_WRAPPER")
-  if [[ "$TARGET_USER" != "$CURRENT_USER" ]]; then
+  if [[ -n "$TARGET_USER" ]]; then
     CHSH_CMD+=("$TARGET_USER")
   fi
   if [[ -n "$SUDO" ]]; then


### PR DESCRIPTION
## Summary
- ensure the shell installation/removal commands always pass the intended username to `chsh` so sudo executions change the correct account

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68ca02ed12f083268f68fa366975fdcf