### PR TITLE
Add interactive CLI mode and release build wizard enhancements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Existing utilities (``gw.awg`` etc.) are loaded lazily and should be reused via
 4. Treat every public function (those not starting with ``_``) as CLI-ready: accept primitive arguments directly while still supporting richer objects when passed, as the mail helpers do with simple subject/body strings plus optional async behavior (see ``projects/mail.py``).
 5. Design outputs so multiple commands can chain together. Gateway stores each result under its detected ``subject`` and merges dictionaries into the shared context, so returning named fields makes recipe injection effortless (see ``gway/gateway.py``).
 6. Always reach helpers through the shared ``gw`` instance (``from gway import gw``) instead of importing project modules manually; the ``gw`` singleton exposes utilities like ``gw.resource`` and ``gw.mail`` for reuse (see ``projects/help_db.py`` and ``gway/gateway.py``).
+7. When adding behavior that prompts users for input, only trigger those questions while running in interactive mode (``-i`` / ``gw.interactive_enabled``). Wizard mode may layer on extra, optional questions, but only after the user explicitly requests it with ``-w``.
 
 ## Testing
 - Install requirements and the package in editable mode before running tests:

--- a/gway/console.py
+++ b/gway/console.py
@@ -59,6 +59,7 @@ def cli_main():
     add("-d", dest="debug", action="store_true", help="Enable debug logging")
     add("-e", dest="expression", type=str, help="Return resolved sigil at the end")
     add("-j", dest="json", nargs="?", const=True, default=False, help="Output result(s) as JSON")
+    add("-i", dest="interactive", action="store_true", help="Interactive mode (prompt for required parameters)")
     add("-o", dest="outfile", type=str, help="Write text output(s) to this file")
     add("-p", dest="projects", type=str, help="Root project path for custom functions.")
     add(
@@ -107,6 +108,7 @@ def cli_main():
         project_path=args.projects,
         debug=args.debug,
         wizard=args.wizard,
+        interactive=args.interactive,
         timed=args.timed
     )
 
@@ -125,6 +127,10 @@ def cli_main():
         run_kwargs['client'] = args.client
     if args.server:
         run_kwargs['server'] = args.server
+    if args.interactive:
+        run_kwargs['interactive'] = True
+    if args.wizard:
+        run_kwargs['wizard'] = True
     if args.timed:
         run_kwargs['timed'] = True
     run_kwargs.update(extra_context)
@@ -212,6 +218,8 @@ def process(command_sources, callback=None, **context):
 
     gw = Gateway(**context) if context else _global_gw
     wizard_enabled = getattr(gw, "wizard_enabled", False)
+    interactive_enabled = getattr(gw, "interactive_enabled", False)
+    wizard_prompts = wizard_enabled and interactive_enabled
     call_specs = []
     last_project = None
     last_project_name = None
@@ -238,7 +246,7 @@ def process(command_sources, callback=None, **context):
             except AttributeError as e:
                 last_error = e
 
-                if wizard_enabled:
+                if wizard_prompts:
                     candidates = [a for a in dir(obj) if not a.startswith("_")]
                     guess = difflib.get_close_matches(normalized, candidates, n=1)
                     if guess:
@@ -344,7 +352,12 @@ def process(command_sources, callback=None, **context):
 
         # Parse function arguments, using parse_known_args if **kwargs present
         func_parser = argparse.ArgumentParser(prog=".".join(path))
-        add_func_args(func_parser, resolved_obj, wizard=wizard_enabled)
+        add_func_args(
+            func_parser,
+            resolved_obj,
+            interactive=interactive_enabled,
+            wizard=wizard_prompts,
+        )
 
         var_kw_name = getattr(resolved_obj, "__var_keyword_name__", None)
         if var_kw_name:
@@ -354,29 +367,35 @@ def process(command_sources, callback=None, **context):
         else:
             parsed_args = func_parser.parse_args(func_args)
 
-        if wizard_enabled:
-            parsed_args = prompt_for_missing(parsed_args, resolved_obj)
+        if interactive_enabled:
+            parsed_args = prompt_for_missing(
+                parsed_args,
+                resolved_obj,
+                required_only=not wizard_prompts,
+            )
             final_args, final_kwargs = prepare(parsed_args, resolved_obj)
-            call_specs.append((resolved_obj, final_args, final_kwargs, path))
+            if wizard_prompts:
+                call_specs.append((resolved_obj, final_args, final_kwargs, path))
+                continue
         else:
-            # Prepare and invoke
             final_args, final_kwargs = prepare(parsed_args, resolved_obj)
-            try:
-                result = resolved_obj(*final_args, **final_kwargs)
-                last_result = result
-                all_results.append(result)
-                if path:
-                    last_project_name = path[0]
-                    try:
-                        last_project = getattr(gw, normalize_token(last_project_name))
-                    except AttributeError:
-                        last_project = None
-            except Exception as e:
-                gw.exception(e)
-                name = getattr(resolved_obj, "__name__", str(resolved_obj))
-                abort(f"Unhandled {type(e).__name__} in {name} -> {str(e)} @ {str(resolved_obj.__module__)}.py")
 
-    if wizard_enabled:
+        try:
+            result = resolved_obj(*final_args, **final_kwargs)
+            last_result = result
+            all_results.append(result)
+            if path:
+                last_project_name = path[0]
+                try:
+                    last_project = getattr(gw, normalize_token(last_project_name))
+                except AttributeError:
+                    last_project = None
+        except Exception as e:
+            gw.exception(e)
+            name = getattr(resolved_obj, "__name__", str(resolved_obj))
+            abort(f"Unhandled {type(e).__name__} in {name} -> {str(e)} @ {str(resolved_obj.__module__)}.py")
+
+    if wizard_prompts:
         for func, f_args, f_kwargs, call_path in call_specs:
             try:
                 result = func(*f_args, **f_kwargs)
@@ -459,11 +478,11 @@ def prepare(parsed_args, func_obj):
     return func_args, {**func_kwargs, **extra_kwargs}
 
 
-def prompt_for_missing(parsed_args, func_obj):
-    """Prompt user for any parameters missing from *parsed_args*.
+def prompt_for_missing(parsed_args, func_obj, *, required_only=False):
+    """Prompt user for parameters missing from *parsed_args*.
 
-    Displays default values for optional parameters and returns the updated
-    namespace."""
+    When ``required_only`` is True, optional parameters that already have
+    defaults are skipped."""
     sig = inspect.signature(func_obj, eval_str=True)
 
     for name, param in sig.parameters.items():
@@ -473,6 +492,10 @@ def prompt_for_missing(parsed_args, func_obj):
 
         current = getattr(parsed_args, name, inspect._empty)
         if current is not inspect._empty and current is not None:
+            continue
+
+        is_required = param.default is inspect._empty
+        if required_only and not is_required:
             continue
 
         default = None if param.default is inspect.Parameter.empty else param.default
@@ -571,11 +594,12 @@ def show_functions(functions: dict):
         if doc:
             print(f"      {doc}")
 
-def add_func_args(subparser, func_obj, *, wizard=False):
+def add_func_args(subparser, func_obj, *, interactive=False, wizard=False):
     """Add the function's arguments to the CLI subparser.
 
-    When ``wizard`` is True, required arguments are marked optional so they can
-    be filled interactively later."""
+    ``interactive`` relaxes required parameters so they can be asked for later.
+    When ``wizard`` is also True, optional parameters are treated the same way
+    so the wizard can prompt for extra details."""
     sig = inspect.signature(func_obj, eval_str=True)
     try:
         hints = get_type_hints(func_obj)
@@ -611,16 +635,21 @@ def add_func_args(subparser, func_obj, *, wizard=False):
             if auto_inject:
                 opts.pop('required', None)
 
+            is_required = param.default is inspect._empty
+
             # before the first kw-only marker (*) → positional
             if is_positional:
                 # argparse forbids 'required' on positionals:
                 opts.pop('required', None)
 
-                if wizard:
+                if interactive:
                     opts['nargs'] = '?'
-                    opts['default'] = inspect._empty
+                    if is_required or wizard:
+                        opts['default'] = inspect._empty
+                    elif 'default' not in opts and param.default is not inspect._empty:
+                        opts['default'] = param.default
                     subparser.add_argument(arg_name, **opts)
-                elif param.default is not inspect.Parameter.empty or auto_inject:
+                elif param.default is not inspect._empty or auto_inject:
                     subparser.add_argument(arg_name, nargs='?', **opts)
                 else:
                     subparser.add_argument(arg_name, **opts)
@@ -629,7 +658,8 @@ def add_func_args(subparser, func_obj, *, wizard=False):
             else:
                 seen_kw_only = True
                 cli_name = f"--{arg_name.replace('_', '-')}"
-                if param.annotation is bool or isinstance(param.default, bool):
+                is_bool = param.annotation is bool or isinstance(param.default, bool)
+                if is_bool:
                     grp = subparser.add_mutually_exclusive_group(required=False)
                     grp.add_argument(
                         cli_name,
@@ -643,14 +673,20 @@ def add_func_args(subparser, func_obj, *, wizard=False):
                         action="store_false",
                         help=f"Disable {arg_name}"
                     )
-                    if wizard:
-                        subparser.set_defaults(**{arg_name: inspect._empty})
+                    if interactive:
+                        if is_required or wizard:
+                            subparser.set_defaults(**{arg_name: inspect._empty})
+                        else:
+                            subparser.set_defaults(**{arg_name: param.default})
                     else:
                         subparser.set_defaults(**{arg_name: param.default})
                 else:
-                    if wizard:
+                    if interactive:
                         opts['required'] = False
-                        opts['default'] = inspect._empty
+                        if is_required or wizard:
+                            opts['default'] = inspect._empty
+                        elif 'default' not in opts and param.default is not inspect._empty:
+                            opts['default'] = param.default
                     subparser.add_argument(cli_name, **opts)
 
                     # Add unit conversion flags if available
@@ -671,8 +707,13 @@ def add_func_args(subparser, func_obj, *, wizard=False):
                                     if k not in {"required", "default"}}
                         alt_opts["dest"] = arg_name
                         alt_opts["type"] = _wrapper
-                        if wizard:
-                            alt_opts["default"] = inspect._empty
+                        if interactive:
+                            if is_required or wizard:
+                                alt_opts["default"] = inspect._empty
+                            else:
+                                default_value = opts.get('default', param.default)
+                                if default_value is not inspect._empty:
+                                    alt_opts["default"] = default_value
                         alt_opts.setdefault(
                             "help",
                             f"Alias for --{arg_name} in {alt_name} units")

--- a/gway/gateway.py
+++ b/gway/gateway.py
@@ -39,11 +39,13 @@ class Gateway(Resolver, Runner):
     silent = False
     verbose = False
     wizard = False
+    interactive = False
     timed = False
 
     def __init__(self, *,
                 client=None, server=None, name="gw", base_path=None, project_path=None,
-                verbose=None, silent=None, debug=None, wizard=None, timed=None, quantity=1, **kwargs
+                verbose=None, silent=None, debug=None, wizard=None, interactive=None,
+                timed=None, quantity=1, **kwargs
             ):
         self._cache = {}
         self._async_threads = []
@@ -57,7 +59,7 @@ class Gateway(Resolver, Runner):
 
         # --- Mode propagation logic: Set global flags via classmethod ---
         explicit_modes = {}
-        for flag in ('debug', 'silent', 'verbose', 'wizard', 'timed'):
+        for flag in ('debug', 'silent', 'verbose', 'wizard', 'interactive', 'timed'):
             val = locals()[flag]
             if val is not None:
                 explicit_modes[flag] = val
@@ -65,7 +67,7 @@ class Gateway(Resolver, Runner):
             type(self).update_modes(**explicit_modes)
 
         # Set instance mode flags to match class-level (which may have just changed)
-        for flag in ('debug', 'silent', 'verbose', 'wizard'):
+        for flag in ('debug', 'silent', 'verbose', 'wizard', 'interactive'):
             setattr(self, f"{flag}_enabled", getattr(type(self), flag))
         self.timed_enabled = timed if timed is not None else getattr(type(self), 'timed', False)
 
@@ -110,10 +112,17 @@ class Gateway(Resolver, Runner):
                     Gateway._builtins[name] = obj
 
     @classmethod
-    def update_modes(cls, *, debug=None, silent=None, verbose=None, wizard=None, timed=None):
+    def update_modes(cls, *, debug=None, silent=None, verbose=None, wizard=None, interactive=None, timed=None):
         """Set global mode flags at the class level and on the global 'gw' instance, if present."""
         updated = {}
-        for flag, value in [('debug', debug), ('silent', silent), ('verbose', verbose), ('wizard', wizard), ('timed', timed)]:
+        for flag, value in [
+            ('debug', debug),
+            ('silent', silent),
+            ('verbose', verbose),
+            ('wizard', wizard),
+            ('interactive', interactive),
+            ('timed', timed),
+        ]:
             if value is not None:
                 setattr(cls, flag, value)
                 updated[flag] = value

--- a/tests/test_release_notify.py
+++ b/tests/test_release_notify.py
@@ -4,6 +4,9 @@ import os
 from pathlib import Path
 from unittest.mock import patch
 import subprocess
+import builtins
+import getpass
+
 from gway import gw
 
 class ReleaseBuildNotifyTests(unittest.TestCase):
@@ -43,6 +46,85 @@ class ReleaseBuildNotifyTests(unittest.TestCase):
              patch.object(gw, "notify") as mock_notify:
             gw.release.build(all=True)
             mock_notify.assert_called_once()
+
+    def test_interactive_prompts_for_token(self):
+        cp = subprocess.CompletedProcess([], 0, "", "")
+
+        def fake_resolve(key, *args, **kwargs):
+            default = kwargs.get("default", None)
+            if args:
+                default = args[0]
+            if key == "[PYPI_API_TOKEN]":
+                return default if default is not None else ""
+            if key in ("[PYPI_USERNAME]", "[PYPI_PASSWORD]"):
+                if default is not None:
+                    return default
+                raise KeyError(key)
+            return ""
+
+        prompts = []
+        inputs = iter(["token-value"])
+
+        def fake_input(prompt):
+            prompts.append(prompt)
+            return next(inputs)
+
+        original_interactive = gw.interactive_enabled
+        gw.interactive_enabled = True
+        try:
+            with patch.object(gw, "test", return_value=True), \
+                 patch.object(gw, "resolve", side_effect=fake_resolve), \
+                 patch.object(gw.hub, "commit", return_value="abc"), \
+                 patch.object(gw.release, "update_changelog"), \
+                 patch("requests.get") as mock_get, \
+                 patch("subprocess.run", return_value=cp), \
+                 patch.object(builtins, "input", side_effect=fake_input), \
+                 patch.object(getpass, "getpass") as mock_getpass:
+                mock_get.return_value.ok = True
+                mock_get.return_value.json.return_value = {"releases": {}}
+                gw.release.build(dist=True, twine=True)
+            mock_getpass.assert_not_called()
+            assert prompts == ["PyPI API token (leave blank to provide username/password): "]
+        finally:
+            gw.interactive_enabled = original_interactive
+
+    def test_wizard_failure_offers_clipboard(self):
+        cp = subprocess.CompletedProcess([], 0, "", "")
+        original_interactive = gw.interactive_enabled
+        original_wizard = gw.wizard_enabled
+        gw.interactive_enabled = True
+        gw.wizard_enabled = True
+        try:
+            with patch.object(gw, "test", return_value=False), \
+                 patch("subprocess.run", return_value=cp), \
+                 patch.object(gw.studio.clip, "copy") as mock_copy, \
+                 patch.object(builtins, "input", return_value="y") as mock_input:
+                with self.assertRaises(SystemExit):
+                    gw.release.build(all=True)
+            mock_input.assert_called_once()
+            mock_copy.assert_called_once()
+        finally:
+            gw.interactive_enabled = original_interactive
+            gw.wizard_enabled = original_wizard
+
+    def test_wizard_failure_auto_copy_without_interactive(self):
+        cp = subprocess.CompletedProcess([], 0, "", "")
+        original_interactive = gw.interactive_enabled
+        original_wizard = gw.wizard_enabled
+        gw.interactive_enabled = False
+        gw.wizard_enabled = True
+        try:
+            with patch.object(gw, "test", return_value=False), \
+                 patch("subprocess.run", return_value=cp), \
+                 patch.object(gw.studio.clip, "copy") as mock_copy, \
+                 patch.object(builtins, "input") as mock_input:
+                with self.assertRaises(SystemExit):
+                    gw.release.build(all=True)
+            mock_input.assert_not_called()
+            mock_copy.assert_called_once()
+        finally:
+            gw.interactive_enabled = original_interactive
+            gw.wizard_enabled = original_wizard
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_wizard_mode.py
+++ b/tests/test_wizard_mode.py
@@ -10,6 +10,7 @@ def test_wizard_prompts_for_missing():
 
     setattr(console.gw, "dummy", dummy)
     console.gw.wizard_enabled = True
+    console.gw.interactive_enabled = True
 
     inputs = iter(["3", ""])  # a, b (accept default)
     with patch.object(builtins, "input", side_effect=lambda _: next(inputs)):
@@ -20,6 +21,7 @@ def test_wizard_prompts_for_missing():
 
     delattr(console.gw, "dummy")
     console.gw.wizard_enabled = False
+    console.gw.interactive_enabled = False
 
 
 def test_wizard_collects_before_run():
@@ -36,6 +38,7 @@ def test_wizard_collects_before_run():
     setattr(console.gw, "first", first)
     setattr(console.gw, "second", second)
     console.gw.wizard_enabled = True
+    console.gw.interactive_enabled = True
 
     inputs = iter(["1", "2"])
 
@@ -53,6 +56,7 @@ def test_wizard_collects_before_run():
     delattr(console.gw, "first")
     delattr(console.gw, "second")
     console.gw.wizard_enabled = False
+    console.gw.interactive_enabled = False
 
 
 def test_wizard_guesses_names():
@@ -61,6 +65,7 @@ def test_wizard_guesses_names():
 
     setattr(console.gw, "dummy", dummy)
     console.gw.wizard_enabled = True
+    console.gw.interactive_enabled = True
 
     inputs = iter(["", "5"])  # accept guess, provide param
 
@@ -72,3 +77,30 @@ def test_wizard_guesses_names():
 
     delattr(console.gw, "dummy")
     console.gw.wizard_enabled = False
+    console.gw.interactive_enabled = False
+
+
+def test_interactive_prompts_required_only():
+    calls = []
+
+    def dummy(a: int, b: int = 2):
+        return a + b
+
+    setattr(console.gw, "dummy", dummy)
+    console.gw.interactive_enabled = True
+
+    inputs = iter(["3"])
+
+    def fake_input(prompt):
+        calls.append(prompt)
+        return next(inputs)
+
+    with patch.object(builtins, "input", side_effect=fake_input):
+        results, last = console.process([["dummy"]])
+
+    assert results == [5]
+    assert last == 5
+    assert len(calls) == 1
+
+    delattr(console.gw, "dummy")
+    console.gw.interactive_enabled = False


### PR DESCRIPTION
## Summary
- add a global interactive flag to the CLI/gateway so required parameters are only prompted when -i is supplied
- update release.build to gather credentials interactively and surface clipboard failure reports when wizard mode is active
- expand wizard/release tests to cover the new prompting rules and clipboard behaviour

## Testing
- pytest tests/test_wizard_mode.py tests/test_release_notify.py

------
https://chatgpt.com/codex/tasks/task_e_68ca011105a483269043737db1f0b8d1