### PR TITLE
Improve RFID scan dependency guidance

### DIFF
--- a/projects/rfid.py
+++ b/projects/rfid.py
@@ -1,25 +1,78 @@
 """RFID scanning utilities."""
 
+import select
 import sys
 import time
-import select
+from typing import Optional, Tuple, Type
+
+
+def _load_rfid_dependencies() -> Optional[Tuple[Type[object], object]]:
+    """Return the ``SimpleMFRC522`` class and ``RPi.GPIO`` module if available."""
+
+    try:
+        from mfrc522 import SimpleMFRC522  # type: ignore
+    except ModuleNotFoundError as exc:  # pragma: no cover - hardware dependent
+        print(
+            "RFID support requires the 'mfrc522' package.\n"
+            "Install it with: sudo pip install mfrc522"
+        )
+        print(f"Original error: {exc}")
+        return None
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        print(f"RFID libraries not available: {exc}")
+        return None
+
+    try:
+        import RPi.GPIO as GPIO  # type: ignore
+    except ModuleNotFoundError as exc:  # pragma: no cover - hardware dependent
+        print(
+            "RFID support requires the 'RPi.GPIO' package.\n"
+            "Install it with: sudo apt-get install python3-rpi.gpio"
+        )
+        print(f"Original error: {exc}")
+        return None
+    except RuntimeError as exc:  # pragma: no cover - hardware dependent
+        message = str(exc)
+        if "sudo" in message.lower() or "root" in message.lower():
+            print(
+                "Access to GPIO requires elevated privileges.\n"
+                "Rerun the command with: sudo gway rfid scan"
+            )
+        else:
+            print(f"RFID libraries not available: {exc}")
+        return None
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        print(f"RFID libraries not available: {exc}")
+        return None
+
+    return SimpleMFRC522, GPIO
 
 
 def scan():
-    """Wait for a card and print its data until a key is pressed.
+    """Wait for a card and print its data until a key is pressed."""
 
-    The function attempts to use a ``SimpleMFRC522`` reader. If the required
-    libraries are not available, an informative message is printed and the
-    function exits.
-    """
-    try:
-        from mfrc522 import SimpleMFRC522  # type: ignore
-        import RPi.GPIO as GPIO  # type: ignore
-    except Exception as exc:  # pragma: no cover - hardware dependent
-        print(f"RFID libraries not available: {exc}")
+    dependencies = _load_rfid_dependencies()
+    if not dependencies:
         return
 
-    reader = SimpleMFRC522()
+    SimpleMFRC522, GPIO = dependencies
+
+    try:
+        reader = SimpleMFRC522()
+    except RuntimeError as exc:  # pragma: no cover - hardware dependent
+        message = str(exc)
+        if "sudo" in message.lower() or "root" in message.lower():
+            print(
+                "RFID reader access was denied.\n"
+                "Rerun the command with elevated privileges: sudo gway rfid scan"
+            )
+        else:
+            print(f"Unable to initialize RFID reader: {exc}")
+        return
+    except Exception as exc:  # pragma: no cover - hardware dependent
+        print(f"Unable to initialize RFID reader: {exc}")
+        return
+
     print("Scanning for RFID cards. Press any key to stop.")
     try:
         while True:


### PR DESCRIPTION
## Summary
- add a helper to load RFID dependencies and give installation hints when missing
- provide sudo guidance when GPIO access or reader initialization requires elevated privileges
- keep the scanner loop unchanged while ensuring cleanup still runs

## Testing
- `pytest` *(fails: GatewayBuiltinsTests.test_help_list_flags expects only the `failure` flag but more hardware flags are returned)*

------
https://chatgpt.com/codex/tasks/task_e_68cab2b87a548326b00414f2a00e83c9