### PR TITLE
Document RFID wiring and expose pinout helper

### DIFF
--- a/data/static/rfid/README.rst
+++ b/data/static/rfid/README.rst
@@ -5,3 +5,34 @@ RFID Utilities
 
 ``scan`` – wait for a card to be scanned and print its information. Press any
 key to stop scanning.
+
+``pinout`` – return the expected wiring between the MFRC522 board and a
+Raspberry Pi.
+
+Wiring reference
+~~~~~~~~~~~~~~~~
+
+The RFID helpers expect the reader to be connected following the default
+``SimpleMFRC522`` pinout:
+
+.. list-table::
+   :header-rows: 1
+
+   * - RFID pin
+     - Raspberry Pi connection
+   * - SDA
+     - CE0 (GPIO8, physical pin 24)
+   * - SCK
+     - SCLK (GPIO11, physical pin 23)
+   * - MOSI
+     - MOSI (GPIO10, physical pin 19)
+   * - MISO
+     - MISO (GPIO9, physical pin 21)
+   * - IRQ
+     - GPIO4 (physical pin 7)
+   * - GND
+     - GND (physical pin 6)
+   * - RST
+     - GPIO25 (physical pin 22)
+   * - 3v3
+     - 3V3 (physical pin 1)

--- a/projects/rfid.py
+++ b/projects/rfid.py
@@ -1,8 +1,39 @@
-"""RFID scanning utilities."""
+"""RFID scanning utilities.
+
+The helpers in this module rely on the default wiring expected by the
+``mfrc522`` package's :class:`~mfrc522.SimpleMFRC522` reader. The pinout is
+documented via :func:`pinout` so future integrations can double-check the
+hardware connections without digging through the third-party library.
+"""
 
 import sys
 import time
 import select
+
+
+PINOUT = {
+    "SDA": "CE0 (GPIO8, physical pin 24)",
+    "SCK": "SCLK (GPIO11, physical pin 23)",
+    "MOSI": "MOSI (GPIO10, physical pin 19)",
+    "MISO": "MISO (GPIO9, physical pin 21)",
+    "IRQ": "GPIO4 (physical pin 7)",
+    "GND": "GND (physical pin 6)",
+    "RST": "GPIO25 (physical pin 22)",
+    "3v3": "3V3 (physical pin 1)",
+}
+
+
+def pinout():
+    """Return the expected wiring map between the RFID reader and the Pi.
+
+    ``SimpleMFRC522`` defaults to ``spidev`` on ``/dev/spidev0.0`` (CE0) and
+    pulls its reset pin high using ``GPIO.BOARD`` numbering, which maps to
+    ``GPIO25`` on physical pin 22. The remaining connections align with the
+    Raspberry Pi's SPI interface. Returning the mapping makes it easy to assert
+    the wiring in tests or display it from the CLI.
+    """
+
+    return PINOUT.copy()
 
 
 def scan():

--- a/tests/test_rfid.py
+++ b/tests/test_rfid.py
@@ -1,0 +1,29 @@
+"""Tests for RFID helpers."""
+
+from projects import rfid
+
+
+EXPECTED_PINOUT = {
+    "SDA": "CE0 (GPIO8, physical pin 24)",
+    "SCK": "SCLK (GPIO11, physical pin 23)",
+    "MOSI": "MOSI (GPIO10, physical pin 19)",
+    "MISO": "MISO (GPIO9, physical pin 21)",
+    "IRQ": "GPIO4 (physical pin 7)",
+    "GND": "GND (physical pin 6)",
+    "RST": "GPIO25 (physical pin 22)",
+    "3v3": "3V3 (physical pin 1)",
+}
+
+
+def test_pinout_matches_expected_mapping():
+    """Ensure the exposed pinout documents the expected wiring."""
+
+    assert rfid.pinout() == EXPECTED_PINOUT
+
+
+def test_pinout_returns_copy():
+    """The wiring map should be copy-on-return to prevent accidental edits."""
+
+    mapping = rfid.pinout()
+    mapping["SDA"] = "modified"
+    assert rfid.pinout()["SDA"] == EXPECTED_PINOUT["SDA"]


### PR DESCRIPTION
## Summary
- expose the MFRC522 wiring map via a new `rfid.pinout()` helper
- document the Raspberry Pi pinout expected by the RFID utilities
- add unit coverage to keep the wiring reference in sync

## Testing
- pytest tests/test_rfid.py

------
https://chatgpt.com/codex/tasks/task_e_68cad5b1b75c8326be2e19434a26de09