### PR TITLE
Install hardware dependencies during upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ selenium
 webdriver-manager
 bs4
 markdown
+mfrc522; platform_system == "Linux"
 pandas
 openpyxl
 coverage

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -67,8 +67,7 @@ class GatewayBuiltinsTests(unittest.TestCase):
 
     def test_help_list_flags(self):
         flags = gw.help(list_flags=True)["Test Flags"]
-        expected = {"failure"}
-        self.assertEqual(set(flags.keys()), expected)
+        self.assertIn("failure", flags)
         for tests in flags.values():
             self.assertIsInstance(tests, list)
 

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -149,6 +149,13 @@ fi
 echo "[5.3] Upgrading pip to latest version in venv..."
 python -m pip install --upgrade pip || log_action "pip upgrade failed"
 
+echo "[5.4] Installing Python requirements..."
+if ! pip install -r requirements.txt; then
+    echo "Warning: requirements installation failed, continuing"
+    log_action "requirements install failed"
+fi
+
+echo "[5.5] Installing gway in editable mode..."
 if ! pip install -e .; then
     echo "Warning: package installation failed, continuing"
     log_action "pip install failed"


### PR DESCRIPTION
## Summary
- add the MFRC522 helper package to the Linux requirements list so RFID scans work by default
- run `pip install -r requirements.txt` from the upgrade script before reinstalling the package to pull in optional hardware libraries
- relax the help flag test to accommodate additional feature flags when optional modules are available

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68cb0637fea08326824d9583da828309