### PR TITLE
Fix CLI upgrade argument handling

### DIFF
--- a/tests/test_upgrade_builtin.py
+++ b/tests/test_upgrade_builtin.py
@@ -28,9 +28,24 @@ class UpgradeBuiltinTests(unittest.TestCase):
             os.chmod(script, 0o755)
             import pathlib
             with patch.object(gw, "resource", return_value=pathlib.Path(script)):
-                rc = gw.upgrade("--force", "--no-test")
+                rc = gw.upgrade("--force", "--latest", "--no-test")
         self.assertEqual(rc, 0)
-        self.assertIn("called with: --force --no-test", self.stdout.getvalue())
+        self.assertIn(
+            "called with: --force --latest --no-test",
+            self.stdout.getvalue(),
+        )
+
+    def test_upgrade_rejects_conflicting_test_flags(self):
+        with patch.object(gw, "resource") as mock_resource:
+            with self.assertRaises(ValueError):
+                gw.upgrade("--test", "--no-test")
+        mock_resource.assert_not_called()
+
+    def test_upgrade_rejects_unknown_option(self):
+        with patch.object(gw, "resource") as mock_resource:
+            with self.assertRaises(ValueError):
+                gw.upgrade("--invalid")
+        mock_resource.assert_not_called()
 
     def test_upgrade_streams_output(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- allow CLI functions with variadic positional arguments to keep unparsed flags so `gway upgrade` can pass `upgrade.sh` options through
- validate the set of supported upgrade flags and skip the safe pre-check when help is requested
- extend the upgrade builtin tests to cover the new flags and validation paths

## Testing
- python -m pytest tests/test_upgrade_builtin.py
- gway test --filter upgrade_builtin

------
https://chatgpt.com/codex/tasks/task_e_68cb0c7c44708326bb7bf2588a41ad88