### PR TITLE
Improve RFID SPI diagnostics

### DIFF
--- a/data/static/rfid/README.rst
+++ b/data/static/rfid/README.rst
@@ -36,3 +36,22 @@ The RFID helpers expect the reader to be connected following the default
      - GPIO25 (physical pin 22)
    * - 3v3
      - 3V3 (physical pin 1)
+
+Bringing the reader online
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The MFRC522 driver expects the Raspberry Pi's first SPI controller (``bus 0``)
+to be enabled and exposed as ``/dev/spidev0.0``. If ``gway rfid scan`` reports
+that the SPI device is missing:
+
+* enable SPI via ``sudo raspi-config nonint do_spi 0`` (or through
+  ``raspi-config`` → *Interface Options* → *SPI*)
+* confirm ``dtparam=spi=on`` exists in ``/boot/config.txt`` and reboot
+* ensure the ``spi_bcm2835`` kernel module is loaded (``lsmod | grep spi``)
+* add your user to the ``spi`` group or run the command with ``sudo`` if
+  permissions are denied
+
+Other single-board computers may expose the device under a different
+``/dev/spidevX.Y`` path. Move the reader to the chip select that maps to
+``spidev0.0`` or extend ``projects/rfid.scan`` to pass a custom bus/device pair
+to the MFRC522 driver.

--- a/projects/rfid.py
+++ b/projects/rfid.py
@@ -4,11 +4,21 @@ The helpers in this module rely on the default wiring expected by the
 ``mfrc522`` package's :class:`~mfrc522.SimpleMFRC522` reader. The pinout is
 documented via :func:`pinout` so future integrations can double-check the
 hardware connections without digging through the third-party library.
+
+The :func:`scan` helper now performs pre-flight checks for the Linux SPI
+device node that backs the MFRC522 driver. A missing ``/dev/spidev0.0`` is the
+root cause behind the ``FileNotFoundError`` seen when SPI is disabled or wired
+to a different chip select. Surfacing a helpful explanation makes the CLI
+usable during bring-up on fresh Raspberry Pi OS images or on alternate
+single-board computers where the kernel modules need to be enabled first.
 """
 
 import sys
 import time
 import select
+import glob
+import os
+from typing import Iterable
 
 
 PINOUT = {
@@ -21,6 +31,21 @@ PINOUT = {
     "RST": "GPIO25 (physical pin 22)",
     "3v3": "3V3 (physical pin 1)",
 }
+
+DEFAULT_SPI_DEVICE = "/dev/spidev0.0"
+SPI_DEVICE_GLOB = "/dev/spidev*"
+
+
+def _list_spi_devices() -> list[str]:
+    """Return the available ``spidev`` device nodes in ``/dev``."""
+
+    return sorted(glob.glob(SPI_DEVICE_GLOB))
+
+
+def _format_device_list(devices: Iterable[str]) -> str:
+    """Return a comma-separated list for displaying SPI candidates."""
+
+    return ", ".join(sorted(devices))
 
 
 def pinout():
@@ -57,6 +82,10 @@ def scan():
             advice.append(
                 "Install the Raspberry Pi GPIO bindings with `pip install RPi.GPIO` on a Pi."
             )
+        if missing == "spidev":
+            advice.append(
+                "Install the SPI bindings with `sudo apt install python3-spidev` or `pip install spidev`."
+            )
         if not advice:
             advice.append("Install the missing Python module and try again.")
         print(
@@ -66,11 +95,56 @@ def scan():
             )
         )
         return
+    except RuntimeError as exc:  # pragma: no cover - hardware dependent
+        print(
+            "RFID libraries could not initialize: {exc}. "
+            "Run on a Raspberry Pi or install GPIO bindings that expose the same API.".format(
+                exc=exc
+            )
+        )
+        return
     except Exception as exc:  # pragma: no cover - hardware dependent
         print(f"RFID libraries not available: {exc}")
         return
 
-    reader = SimpleMFRC522()
+    if not os.path.exists(DEFAULT_SPI_DEVICE):
+        candidates = [
+            device for device in _list_spi_devices() if device != DEFAULT_SPI_DEVICE
+        ]
+        if candidates:
+            print(
+                "RFID SPI device {device} not found. Detected SPI interfaces: {candidates}. "
+                "Move the reader to CE0 or extend the tool to target the desired bus/device.".format(
+                    device=DEFAULT_SPI_DEVICE,
+                    candidates=_format_device_list(candidates),
+                )
+            )
+        else:
+            print(
+                "RFID SPI device {device} not found and no /dev/spidev* nodes are present. "
+                "Enable SPI with `sudo raspi-config nonint do_spi 0`, confirm `dtparam=spi=on` in /boot/config.txt, "
+                "and reboot so the kernel exposes the SPI device. On other boards load the appropriate SPI driver.".format(
+                    device=DEFAULT_SPI_DEVICE
+                )
+            )
+        return
+
+    try:
+        reader = SimpleMFRC522()
+    except FileNotFoundError as exc:  # pragma: no cover - hardware dependent
+        print(
+            "RFID hardware interface not found: {exc}. "
+            "Ensure the SPI device is available and enabled.".format(exc=exc)
+        )
+        return
+    except PermissionError as exc:  # pragma: no cover - hardware dependent
+        print(
+            "RFID hardware interface permission denied: {exc}. "
+            "Run the command with elevated privileges or add your user to the `spi` group.".format(
+                exc=exc
+            )
+        )
+        return
     print("Scanning for RFID cards. Press any key to stop.")
     try:
         while True:

--- a/tests/test_rfid.py
+++ b/tests/test_rfid.py
@@ -1,5 +1,8 @@
 """Tests for RFID helpers."""
 
+import sys
+import types
+
 from projects import rfid
 
 
@@ -27,3 +30,86 @@ def test_pinout_returns_copy():
     mapping = rfid.pinout()
     mapping["SDA"] = "modified"
     assert rfid.pinout()["SDA"] == EXPECTED_PINOUT["SDA"]
+
+
+def test_scan_handles_missing_spi_interface(monkeypatch, capsys):
+    """A missing SPI device should not raise and should explain the issue."""
+
+    class FakeReader:
+        def __init__(self):
+            raise FileNotFoundError("/dev/spidev0.0")
+
+    _install_fake_rfid_dependencies(monkeypatch, FakeReader)
+    monkeypatch.setattr(rfid.os.path, "exists", lambda path: True)
+
+    rfid.scan()
+    captured = capsys.readouterr()
+    assert "RFID hardware interface not found" in captured.out
+
+
+def test_scan_explains_when_no_spi_nodes_exist(monkeypatch, capsys):
+    """If no ``/dev/spidev*`` nodes exist the CLI should explain how to enable SPI."""
+
+    class FakeReader:
+        def __init__(self):  # pragma: no cover - should not run
+            raise AssertionError("reader should not be constructed when SPI is missing")
+
+    _install_fake_rfid_dependencies(monkeypatch, FakeReader)
+    monkeypatch.setattr(rfid.os.path, "exists", lambda path: False)
+    monkeypatch.setattr(rfid.glob, "glob", lambda pattern: [])
+
+    rfid.scan()
+    captured = capsys.readouterr()
+    assert "no /dev/spidev* nodes" in captured.out
+    assert "Enable SPI" in captured.out
+
+
+def test_scan_lists_available_spi_candidates(monkeypatch, capsys):
+    """Surface alternative SPI nodes so users can rewire or extend the helper."""
+
+    class FakeReader:
+        def __init__(self):  # pragma: no cover - should not run
+            raise AssertionError("reader should not be constructed when SPI is missing")
+
+    _install_fake_rfid_dependencies(monkeypatch, FakeReader)
+    monkeypatch.setattr(rfid.os.path, "exists", lambda path: False)
+    monkeypatch.setattr(
+        rfid.glob,
+        "glob",
+        lambda pattern: ["/dev/spidev0.1", "/dev/spidev1.0", "/dev/spidev0.0"],
+    )
+
+    rfid.scan()
+    captured = capsys.readouterr()
+    assert "Detected SPI interfaces" in captured.out
+    assert "/dev/spidev0.1" in captured.out
+
+
+def test_scan_reports_permission_errors(monkeypatch, capsys):
+    """Permission issues should hint at running with sudo or joining the SPI group."""
+
+    class FakeReader:
+        def __init__(self):
+            raise PermissionError("[Errno 13] Permission denied: '/dev/spidev0.0'")
+
+    _install_fake_rfid_dependencies(monkeypatch, FakeReader)
+    monkeypatch.setattr(rfid.os.path, "exists", lambda path: True)
+
+    rfid.scan()
+    captured = capsys.readouterr()
+    assert "permission denied" in captured.out.lower()
+    assert "spi` group" in captured.out
+
+
+def _install_fake_rfid_dependencies(monkeypatch, reader_cls):
+    """Install stub modules so ``rfid.scan`` can be exercised without hardware."""
+
+    fake_mfrc522 = types.SimpleNamespace(SimpleMFRC522=reader_cls)
+    fake_rpi = types.ModuleType("RPi")
+    fake_gpio = types.ModuleType("RPi.GPIO")
+    fake_gpio.cleanup = lambda: None
+    fake_rpi.GPIO = fake_gpio
+
+    monkeypatch.setitem(sys.modules, "mfrc522", fake_mfrc522)
+    monkeypatch.setitem(sys.modules, "RPi", fake_rpi)
+    monkeypatch.setitem(sys.modules, "RPi.GPIO", fake_gpio)


### PR DESCRIPTION
## Summary
- add SPI device discovery and targeted error handling to `rfid.scan`
- extend the RFID tests to cover missing devices, alternative buses, and permission errors
- document the steps required to enable `/dev/spidev0.0` for the MFRC522 reader

## Testing
- pytest tests/test_rfid.py
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68cb11da076c832697d99a64bef986c3