### PR TITLE
Add repeat builtin for re-running command sequences

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -413,5 +413,30 @@ class TestProcessSigilResolution(unittest.TestCase):
         self.assertEqual(last['name'], 'val')
 
 
+class TestRepeatBuiltin(unittest.TestCase):
+    def test_repeat_replays_previous_commands(self):
+        commands = [["hello-world", "Agent"], ["repeat", "--times", "2", "--rest", "0"]]
+        results, last = console.process(commands)
+
+        self.assertEqual(len(results), 3)
+        self.assertTrue(all(result["name"] == "Agent" for result in results))
+        self.assertEqual(last["name"], "Agent")
+
+    def test_repeat_in_recipe_replays_all_steps(self):
+        commands = [
+            ["hello-world", "Alpha"],
+            ["hello-world", "Beta"],
+            ["repeat", "--times", "1", "--rest", "0"],
+        ]
+        results, last = console.process(commands, origin="recipe")
+
+        self.assertEqual([r["name"] for r in results], ["Alpha", "Beta", "Alpha", "Beta"])
+        self.assertEqual(last["name"], "Beta")
+
+    def test_repeat_requires_previous_commands(self):
+        with self.assertRaises(SystemExit):
+            console.process([["repeat", "--times", "1", "--rest", "0"]])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add a repeat builtin that emits an internal directive carrying rest and times options
- extend command processing to honour repeat directives for both CLI lines and recipes
- cover the new behaviour with console tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb1d966c5c83269b396fec42e72773