### PR TITLE
Allow hyphen recipe names

### DIFF
--- a/gway/console.py
+++ b/gway/console.py
@@ -873,10 +873,31 @@ def load_recipe(recipe_filename, *, strict=True):
     # --- Recipe file resolution (unchanged) ---
     if not os.path.isabs(recipe_filename):
         candidate_names = []
-        base_names = [recipe_filename]
-        if "." in recipe_filename:
-            base_names.append(recipe_filename.replace(".", "_"))
-            base_names.append(recipe_filename.replace(".", os.sep))
+        base_names: list[str] = []
+        seen_bases = set()
+        queue = [recipe_filename]
+
+        while queue:
+            base = queue.pop(0)
+            if base in seen_bases:
+                continue
+            seen_bases.add(base)
+            base_names.append(base)
+
+            dot_variants = []
+            if "." in base:
+                dot_variants.append(base.replace(".", "_"))
+                dot_variants.append(base.replace(".", os.sep))
+
+            dash_variants = []
+            if "-" in base:
+                dash_variants.append(base.replace("-", "_"))
+            if "_" in base:
+                dash_variants.append(base.replace("_", "-"))
+
+            for variant in (*dot_variants, *dash_variants):
+                if variant not in seen_bases:
+                    queue.append(variant)
 
         seen = set()
         for base in base_names:

--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -95,6 +95,7 @@ app start --port 8000
         # Write without extension and with .gwr extension
         (self.recipes_dir / 'sample').write_text(content)
         (self.recipes_dir / 'sample.gwr').write_text(content)
+        (self.recipes_dir / 'sample_script.gwr').write_text('cmd hyphen')
         # Monkey-patch gw.resource to point to our fake recipes directory
         self.original_resource = console.gw.resource
         console.gw.resource = lambda category, name: str(self.recipes_dir / name)
@@ -126,6 +127,10 @@ app start --port 8000
         (self.recipes_dir / 'foo' / 'bar.gwr').write_text('cmd go')
         commands, _ = console.load_recipe('foo.bar')
         self.assertEqual(commands, [['cmd', 'go']])
+
+    def test_load_recipe_accepts_hyphenated_name(self):
+        commands, _ = console.load_recipe('sample-script')
+        self.assertEqual(commands, [['cmd', 'hyphen']])
 
 
 class TestLoadRecipeColonSyntax(unittest.TestCase):


### PR DESCRIPTION
## Summary
- expand recipe resolution to consider hyphen and underscore variants alongside dotted aliases
- add console recipe-loading test case covering hyphenated recipe requests

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68cb25f2fd6883268750dcd8921eaa94