### PR TITLE
Add --when guard to side builtin

### DIFF
--- a/gway/builtins/side.py
+++ b/gway/builtins/side.py
@@ -240,7 +240,7 @@ def _launch_command(command: _SideCommand) -> None:
     thread.start()
 
 
-def side(*args: str, when: object | None = None) -> dict:
+def side(*args: str, when: str | None = None) -> dict:
     """Schedule ``args`` to run in the background, optionally on named queues."""
 
     from gway import gw


### PR DESCRIPTION
## Summary
- allow the `side` builtin to accept an optional `--when` expression
- skip queue initialization and background command execution when the expression resolves false and log the skip
- extend the side unit tests to cover the new conditional behavior
- annotate the `--when` parameter as text so CLI invocations parse successfully

## Testing
- pytest tests/test_side.py

------
https://chatgpt.com/codex/tasks/task_e_68cb2c21b894832686d4db20083c5506