### PR TITLE
Add automatic model fallback during sigil resolution

### DIFF
--- a/gway/console.py
+++ b/gway/console.py
@@ -167,7 +167,11 @@ def cli_main():
 
     # Resolve expression if requested
     if args.expression:
-        output = Gateway(**last_result).resolve(args.expression)
+        if isinstance(last_result, dict):
+            expr_gateway = Gateway(expression_mode=True, **last_result)
+        else:
+            expr_gateway = Gateway(expression_mode=True)
+        output = expr_gateway.resolve(args.expression)
     else:
         output = last_result
 


### PR DESCRIPTION
## Summary
- extend the gateway resolver to fall back to the loaded model namespace when standard sources miss, defaulting colon lookups to `objects.filter` outside expression mode
- construct expression-evaluation gateways with an explicit expression flag so the fallback stays disabled for `-e`
- cover the new behaviour with sigil resolution tests exercising filter and expression-mode scenarios

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68cb299eb9ac8326ba9686505870f409