### PR TITLE
Add automatic model fallback during sigil resolution

### DIFF
--- a/gway/gateway.py
+++ b/gway/gateway.py
@@ -141,6 +141,17 @@ class Gateway(Resolver, Runner):
                 namespace = self.__dict__[candidate]
                 if namespace is not None:
                     return namespace
+            if candidate in self._cache:
+                namespace = self._cache[candidate]
+                if namespace is not None:
+                    return namespace
+            try:
+                namespace = getattr(self, candidate)
+            except AttributeError:
+                continue
+            else:
+                if namespace is not None:
+                    return namespace
         return None
 
     def _find_model_value(self, key: str, *, exec: bool = False):


### PR DESCRIPTION
## Summary
- extend the gateway resolver to fall back to the loaded model namespace when standard sources miss, defaulting colon lookups to `objects.filter` outside expression mode
- construct expression-evaluation gateways with an explicit expression flag so the fallback stays disabled for `-e`
- cover the new behaviour with sigil resolution tests exercising filter and expression-mode scenarios
- ensure the model fallback inspects cached namespaces and triggers lazy loading so standard `gw.model` usage works without manual assignment

## Testing
- gway test --coverage *(fails: test_parse_log_default_mask)*

------
https://chatgpt.com/codex/tasks/task_e_68cb321f68d483268697b3fa5ae1aa17