### PR TITLE
Add RFID write helper with auto-increment support

### DIFF
--- a/projects/rfid.py
+++ b/projects/rfid.py
@@ -18,7 +18,7 @@ import time
 import select
 import glob
 import os
-from typing import Iterable
+from typing import Iterable, Tuple, Optional
 
 
 PINOUT = {
@@ -48,26 +48,15 @@ def _format_device_list(devices: Iterable[str]) -> str:
     return ", ".join(sorted(devices))
 
 
-def pinout():
-    """Return the expected wiring map between the RFID reader and the Pi.
+def _initialize_reader() -> Tuple[Optional[object], Optional[object]]:
+    """Return an initialized ``SimpleMFRC522`` reader and GPIO module.
 
-    ``SimpleMFRC522`` defaults to ``spidev`` on ``/dev/spidev0.0`` (CE0) and
-    pulls its reset pin high using ``GPIO.BOARD`` numbering, which maps to
-    ``GPIO25`` on physical pin 22. The remaining connections align with the
-    Raspberry Pi's SPI interface. Returning the mapping makes it easy to assert
-    the wiring in tests or display it from the CLI.
+    The helper centralizes the import and hardware validation logic used by
+    both :func:`scan` and :func:`write`. Returning ``(None, None)`` indicates
+    that the reader could not be constructed and the caller should abort.
     """
 
-    return PINOUT.copy()
-
-
-def scan():
-    """Wait for a card and print its data until a key is pressed.
-
-    The function attempts to use a ``SimpleMFRC522`` reader. If the required
-    libraries are not available, an informative message is printed and the
-    function exits.
-    """
+    GPIO = None  # type: ignore[assignment]
     try:
         from mfrc522 import SimpleMFRC522  # type: ignore
         import RPi.GPIO as GPIO  # type: ignore
@@ -94,7 +83,7 @@ def scan():
                 advice=" ".join(advice),
             )
         )
-        return
+        return None, None
     except RuntimeError as exc:  # pragma: no cover - hardware dependent
         print(
             "RFID libraries could not initialize: {exc}. "
@@ -102,10 +91,10 @@ def scan():
                 exc=exc
             )
         )
-        return
+        return None, None
     except Exception as exc:  # pragma: no cover - hardware dependent
         print(f"RFID libraries not available: {exc}")
-        return
+        return None, None
 
     if not os.path.exists(DEFAULT_SPI_DEVICE):
         candidates = [
@@ -127,7 +116,7 @@ def scan():
                     device=DEFAULT_SPI_DEVICE
                 )
             )
-        return
+        return None, GPIO
 
     try:
         reader = SimpleMFRC522()
@@ -136,7 +125,7 @@ def scan():
             "RFID hardware interface not found: {exc}. "
             "Ensure the SPI device is available and enabled.".format(exc=exc)
         )
-        return
+        return None, GPIO
     except PermissionError as exc:  # pragma: no cover - hardware dependent
         print(
             "RFID hardware interface permission denied: {exc}. "
@@ -144,6 +133,33 @@ def scan():
                 exc=exc
             )
         )
+        return None, GPIO
+
+    return reader, GPIO
+
+
+def pinout():
+    """Return the expected wiring map between the RFID reader and the Pi.
+
+    ``SimpleMFRC522`` defaults to ``spidev`` on ``/dev/spidev0.0`` (CE0) and
+    pulls its reset pin high using ``GPIO.BOARD`` numbering, which maps to
+    ``GPIO25`` on physical pin 22. The remaining connections align with the
+    Raspberry Pi's SPI interface. Returning the mapping makes it easy to assert
+    the wiring in tests or display it from the CLI.
+    """
+
+    return PINOUT.copy()
+
+
+def scan():
+    """Wait for a card and print its data until a key is pressed.
+
+    The function attempts to use a ``SimpleMFRC522`` reader. If the required
+    libraries are not available, an informative message is printed and the
+    function exits.
+    """
+    reader, GPIO = _initialize_reader()
+    if reader is None:
         return
     print("Scanning for RFID cards. Press any key to stop.")
     try:
@@ -156,7 +172,117 @@ def scan():
                 print(f"Card ID: {card_id} Text: {text}")
             time.sleep(0.1)
     finally:  # pragma: no cover - hardware cleanup
+        if GPIO is not None:
+            try:
+                GPIO.cleanup()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+
+
+def _coerce_uid(uid) -> int:
+    """Normalize the provided UID into an integer."""
+
+    if isinstance(uid, bool):
+        raise TypeError("uid must be an integer, not a boolean")
+    if isinstance(uid, (int,)):
+        return int(uid)
+    if isinstance(uid, float):
+        if not uid.is_integer():
+            raise ValueError("uid must be an integer value")
+        return int(uid)
+    if isinstance(uid, str):
+        stripped = uid.strip()
+        if not stripped:
+            raise ValueError("uid must not be empty")
         try:
-            GPIO.cleanup()  # type: ignore
-        except Exception:
-            pass
+            return int(stripped, 10)
+        except ValueError as exc:
+            raise ValueError("uid must be a base-10 integer string") from exc
+    raise TypeError("uid must be an integer or base-10 string")
+
+
+def _coerce_auto_increment(value) -> int:
+    """Return the increment to apply when auto-incrementing the UID."""
+
+    if value is None:
+        return 0
+    if isinstance(value, bool):
+        return 1 if value else 0
+    if isinstance(value, (int,)):
+        return int(value)
+    if isinstance(value, float):
+        if not value.is_integer():
+            raise ValueError("auto_increment must be an integer value")
+        return int(value)
+    if isinstance(value, str):
+        stripped = value.strip()
+        if not stripped:
+            return 0
+        lowered = stripped.lower()
+        if lowered in {"false", "no", "off"}:
+            return 0
+        if lowered in {"true", "yes", "on"}:
+            return 1
+        try:
+            return int(stripped, 10)
+        except ValueError as exc:
+            raise ValueError(
+                "auto_increment must be a boolean or integer value"
+            ) from exc
+    raise TypeError("auto_increment must be a boolean, string, or integer value")
+
+
+def write(*, uid, auto_increment=False, poll_interval=0.1):
+    """Program an RFID card with a UID and report the written value.
+
+    Args:
+        uid: The base UID to write. When ``auto_increment`` is non-zero the
+            provided UID is increased before being written to the card.
+        auto_increment: When ``True`` increments the UID by ``1`` before
+            writing. Providing an integer (or integer-like string) increments
+            the UID by that value. ``False`` or ``0`` disables incrementing.
+        poll_interval: Delay between polling attempts in seconds. Exposed for
+            tests so they can advance immediately.
+
+    Returns:
+        A mapping describing the card that was programmed along with the
+        written UID. When ``auto_increment`` is enabled the next UID in the
+        sequence is returned under ``next_uid`` for convenience.
+    """
+
+    base_uid = _coerce_uid(uid)
+    increment = _coerce_auto_increment(auto_increment)
+    target_uid = base_uid + increment
+
+    reader, GPIO = _initialize_reader()
+    if reader is None:
+        return None
+
+    print(
+        "Ready to write UID {uid}. Present an RFID card to the reader.".format(
+            uid=target_uid
+        )
+    )
+
+    card_id = None
+    try:
+        while True:
+            card_id, _ = reader.read_no_block()
+            if card_id is not None:
+                reader.write(str(target_uid))
+                print(f"Wrote UID {target_uid} to card {card_id}.")
+                break
+            time.sleep(poll_interval)
+    finally:  # pragma: no cover - hardware cleanup
+        if GPIO is not None:
+            try:
+                GPIO.cleanup()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+
+    result = {"card_id": card_id, "written_uid": target_uid}
+    if increment:
+        next_uid = target_uid + increment
+        result["next_uid"] = next_uid
+        print(f"Next UID: {next_uid}")
+    return result


### PR DESCRIPTION
## Summary
- add a shared reader initialization helper used by RFID scan/write utilities
- implement `rfid.write` with optional auto-increment handling and result reporting
- expand unit tests to cover the writer workflow and input validation

## Testing
- pytest tests/test_rfid.py

------
https://chatgpt.com/codex/tasks/task_e_68cb3ac89e408326b3398db5e11e5403