### PR TITLE
Enhance auto-upgrade logging and notifications

### DIFF
--- a/projects/auto_upgrade.py
+++ b/projects/auto_upgrade.py
@@ -1,0 +1,201 @@
+"""Utilities supporting the auto-upgrade recipe.
+
+The helpers in this module are invoked from ``recipes/auto_upgrade.gwr``
+to coordinate logging, upgrades and system notifications.  They centralise
+all stateful behaviour so the recipe itself can stay declarative and easy
+to audit.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+import os
+import shlex
+import subprocess
+import sys
+from importlib import metadata
+from pathlib import Path
+
+from gway import gw
+
+
+LOG_NAME = "auto_upgrade.log"
+
+
+def _bool_from(value) -> bool:
+    """Return ``True`` when *value* represents an affirmative flag."""
+
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+
+    text = str(value).strip().lower()
+    if not text:
+        return False
+    return text in {"1", "true", "yes", "on", "force"}
+
+
+def _latest_requested(explicit: bool | str | None = None) -> bool:
+    """Determine whether the caller requested a ``--latest`` upgrade."""
+
+    if explicit is not None:
+        return _bool_from(explicit)
+
+    for key in ("auto_upgrade_latest", "latest", "LATEST"):
+        if key in gw.context:
+            return _bool_from(gw.context[key])
+
+    env_flag = os.environ.get("AUTO_UPGRADE_LATEST")
+    if env_flag is not None:
+        return _bool_from(env_flag)
+
+    return "--latest" in sys.argv
+
+
+def _log_path(log_name: str = LOG_NAME) -> Path:
+    """Return the canonical path for the auto-upgrade log file."""
+
+    return Path(gw.resource("logs", log_name, touch=True))
+
+
+def _append_log(message: str, *, log_name: str = LOG_NAME) -> Path:
+    """Append *message* to the auto-upgrade log and return the log path."""
+
+    path = _log_path(log_name)
+    timestamp = datetime.now().isoformat(timespec="seconds")
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(f"{timestamp} | {message}\n")
+    return path
+
+
+def _installed_version() -> str | None:
+    """Return the currently installed ``gway`` version, if available."""
+
+    try:
+        return metadata.version("gway")
+    except metadata.PackageNotFoundError:  # pragma: no cover - defensive
+        return None
+    except Exception as exc:  # pragma: no cover - defensive logging
+        gw.warning(f"Unable to determine installed gway version: {exc}")
+        return None
+
+
+def _broadcast(message: str) -> None:
+    """Send *message* to logged-in users via ``wall`` when available."""
+
+    try:
+        subprocess.run(["wall", message], check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except FileNotFoundError:
+        gw.debug("wall binary not available; skipping broadcast")
+    except Exception as exc:  # pragma: no cover - best effort notification
+        gw.debug(f"Failed to broadcast upgrade message: {exc}")
+
+
+@dataclass(slots=True)
+class CycleState:
+    log_path: Path
+    latest: bool
+    previous_version: str | None
+
+
+def log_cycle(*, latest: bool | str | None = None, log_name: str = LOG_NAME) -> CycleState:
+    """Record a log entry for the start of a new upgrade check.
+
+    The helper captures the currently installed version, records the check in
+    ``logs/auto_upgrade.log`` and stores the details in ``gw.context`` for later
+    recipe steps.
+    """
+
+    latest_requested = _latest_requested(latest)
+    previous_version = _installed_version()
+
+    log_message = "CHECK"
+    details: list[str] = []
+    if previous_version:
+        details.append(f"installed={previous_version}")
+    if latest_requested:
+        details.append("latest=true")
+    if details:
+        log_message = f"{log_message} | {' '.join(details)}"
+
+    log_path = _append_log(log_message, log_name=log_name)
+
+    gw.context.update(
+        {
+            "auto_upgrade_latest": latest_requested,
+            "auto_upgrade_previous_version": previous_version,
+            "auto_upgrade_log": str(log_path),
+        }
+    )
+
+    gw.info(f"[auto-upgrade] Logged check (latest={latest_requested}, version={previous_version})")
+    return CycleState(log_path=log_path, latest=latest_requested, previous_version=previous_version)
+
+
+def install(*, latest: bool | str | None = None) -> int:
+    """Install or upgrade ``gway`` using pip.
+
+    When *latest* (or the ``--latest`` CLI flag) is truthy the installation is
+    forced even if the version has not changed.
+    """
+
+    latest_requested = _latest_requested(latest)
+    python_exec = sys.executable or "python3"
+    cmd = [python_exec, "-m", "pip", "install", "--quiet", "--upgrade", "gway"]
+    if latest_requested:
+        cmd.insert(-1, "--force-reinstall")
+
+    gw.info(f"[auto-upgrade] Running {' '.join(shlex.quote(part) for part in cmd)}")
+    process = subprocess.run(cmd, check=False)
+    if process.returncode != 0:
+        gw.error(f"gway installation failed with exit code {process.returncode}")
+        raise subprocess.CalledProcessError(process.returncode, cmd)
+
+    return process.returncode
+
+
+def log_upgrade(
+    *,
+    version: str | None = None,
+    latest: bool | str | None = None,
+    log_name: str = LOG_NAME,
+    notify: bool = True,
+) -> dict:
+    """Record the outcome of an applied upgrade and optionally notify users."""
+
+    latest_requested = _latest_requested(latest)
+    previous_version = gw.context.get("auto_upgrade_previous_version")
+    current_version = version or _installed_version()
+
+    if not current_version:
+        log_message = "UPGRADE | version=unknown"
+    else:
+        log_message = f"UPGRADE | version={current_version}"
+        if previous_version and previous_version != current_version:
+            log_message += f" from={previous_version}"
+        elif previous_version and previous_version == current_version and not latest_requested:
+            log_message = f"UPGRADE-SKIPPED | version={current_version}"
+
+    log_path = _append_log(log_message, log_name=log_name)
+
+    gw.context.update(
+        {
+            "auto_upgrade_log": str(log_path),
+            "auto_upgrade_current_version": current_version,
+        }
+    )
+
+    gw.info(f"[auto-upgrade] Logged upgrade result: {log_message}")
+
+    if notify and current_version and (latest_requested or previous_version != current_version):
+        _broadcast(f"gway upgraded to {current_version}")
+
+    return {
+        "log": str(log_path),
+        "version": current_version,
+    }
+

--- a/recipes/auto_upgrade.gwr
+++ b/recipes/auto_upgrade.gwr
@@ -11,6 +11,8 @@
 # Canary check: install the candidate release in an isolated environment and
 # run a smoke test before touching the live installation.  temp_env removes the
 # temporary directory automatically when the test succeeds.
+auto-upgrade log-cycle
 temp_env --pip-args=--quiet gway test --on-failure abort
-shell pip install --quiet --upgrade gway
+auto-upgrade install
+auto-upgrade log-upgrade
 until --abort --pypi

--- a/tests/test_auto_upgrade_project.py
+++ b/tests/test_auto_upgrade_project.py
@@ -1,0 +1,77 @@
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from gway import gw
+from gway.projects import auto_upgrade
+
+
+class AutoUpgradeProjectTests(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.addCleanup(gw.context.clear)
+        self._env_patch = mock.patch.dict(os.environ, {"GWAY_ROOT": self.tempdir.name}, clear=False)
+        self._env_patch.start()
+        self.addCleanup(self._env_patch.stop)
+
+    def _read_log(self, path):
+        with open(path, "r", encoding="utf-8") as handle:
+            return handle.read()
+
+    def test_log_cycle_creates_log_and_updates_context(self):
+        state = auto_upgrade.log_cycle(latest=True, log_name="test.log")
+        self.addCleanup(lambda: state.log_path.unlink(missing_ok=True))
+        self.assertTrue(state.latest)
+        self.assertIn("auto_upgrade_previous_version", gw.context)
+        contents = self._read_log(state.log_path)
+        self.assertIn("CHECK", contents)
+        self.assertIn("latest=true", contents)
+
+    def test_install_honours_latest_flag(self):
+        result = mock.Mock(returncode=0)
+        with mock.patch.object(auto_upgrade.subprocess, "run", return_value=result) as run_mock:
+            auto_upgrade.install(latest=True)
+
+        called_args = run_mock.call_args[0][0]
+        self.assertIn("--force-reinstall", called_args)
+
+        with mock.patch.object(auto_upgrade.subprocess, "run", return_value=result) as run_mock:
+            auto_upgrade.install(latest=False)
+
+        called_args = run_mock.call_args[0][0]
+        self.assertNotIn("--force-reinstall", called_args)
+
+    def test_log_upgrade_records_change_and_notifies(self):
+        gw.context["auto_upgrade_previous_version"] = "1.0.0"
+
+        with mock.patch.object(auto_upgrade, "_installed_version", return_value="1.1.0"), mock.patch.object(
+            auto_upgrade, "_broadcast"
+        ) as broadcast_mock:
+            result = auto_upgrade.log_upgrade(log_name="change.log")
+
+        contents = self._read_log(result["log"])
+        self.addCleanup(lambda: Path(result["log"]).unlink(missing_ok=True))
+        self.assertIn("UPGRADE | version=1.1.0 from=1.0.0", contents)
+        broadcast_mock.assert_called_once_with("gway upgraded to 1.1.0")
+
+    def test_log_upgrade_skips_notification_when_version_unchanged(self):
+        gw.context["auto_upgrade_previous_version"] = "2.0.0"
+
+        with mock.patch.object(auto_upgrade, "_installed_version", return_value="2.0.0"), mock.patch.object(
+            auto_upgrade, "_broadcast"
+        ) as broadcast_mock:
+            result = auto_upgrade.log_upgrade(log_name="skip.log")
+
+        contents = self._read_log(result["log"])
+        self.addCleanup(lambda: Path(result["log"]).unlink(missing_ok=True))
+        self.assertIn("UPGRADE-SKIPPED | version=2.0.0", contents)
+        broadcast_mock.assert_not_called()
+
+
+if __name__ == "__main__":  # pragma: no cover - direct execution support
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add an auto_upgrade helper module that logs checks/upgrades, supports --latest installs and sends wall notifications
- update the auto_upgrade recipe to rely on the helper so each run records the check and upgrade results
- cover the new behaviour with unit tests for logging, upgrade decisions and forced reinstalls

## Testing
- PYTHONPATH=/workspace/gway python -m pytest tests/test_auto_upgrade_project.py

------
https://chatgpt.com/codex/tasks/task_e_68cb4324161c8326bb882b45b054ac34