### PR TITLE
Add RFID scan-to-LCD loop recipe

### DIFF
--- a/recipes/rfid_lcd_loop.gwr
+++ b/recipes/rfid_lcd_loop.gwr
@@ -1,0 +1,9 @@
+# file: recipes/rfid_lcd_loop.gwr
+#
+# Continuously scan RFID cards and show the UID with the timestamp on the LCD.
+
+rfid scan --once
+clock timestamp
+hello-world --greeting Card [rfid] @ [clock]
+lcd show %[greeting] --wrap
+repeat --rest=0.1


### PR DESCRIPTION
## Summary
- add a recipe that waits for RFID cards, records the timestamp, and updates the LCD with the card/time details

## Testing
- gway test --coverage *(fails: test_interval_alias_seconds_and_minutes expects slightly different timestamp)*

------
https://chatgpt.com/codex/tasks/task_e_68cb4ff3676c83268eaa824bb9345771