### PR TITLE
Support forwarding recipe flags via install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -143,7 +143,14 @@ if $REPAIR_FLAG; then
 import shlex
 import sys
 
-for part in shlex.split(sys.argv[1]):
+argv = sys.argv[1:]
+if argv and argv[0] == "--":
+    argv = argv[1:]
+
+if len(argv) != 1:
+    raise SystemExit("unexpected ExecStart argv shape")
+
+for part in shlex.split(argv[0]):
     print(part)
 PY
     ) || {


### PR DESCRIPTION
## Summary
- allow `gw.install` to forward extra CLI arguments to install.sh and reject extra flags without a recipe
- update install.sh to keep recipe arguments when invoking services and during repairs, and to quote ExecStart safely
- extend install builtin tests to cover forwarded flags and missing recipe validation
- fix install.sh repair ExecStart parsing to skip the sentinel `--` argument so recipes reinstall correctly

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68cb592162bc8326a28e4eddf2266308