### PR TITLE
Add wait timeout to RFID scan command

### DIFF
--- a/data/static/rfid/README.rst
+++ b/data/static/rfid/README.rst
@@ -4,7 +4,8 @@ RFID Utilities
 ``projects/rfid`` offers helpers for working with RFID hardware.
 
 ``scan`` – wait for a card to be scanned and print its information. Press any
-key to stop scanning.
+key to stop scanning or pass ``--wait`` to exit automatically after the
+specified number of seconds.
 
 ``pinout`` – return the expected wiring between the MFRC522 board and a
 Raspberry Pi.


### PR DESCRIPTION
## Summary
- add an optional wait timeout to `rfid.scan` so the CLI stops automatically after the given seconds
- validate the new parameter, adjust the scan prompt, and document the option
- expand the RFID tests with coverage for the timeout logic

## Testing
- pytest tests/test_rfid.py

------
https://chatgpt.com/codex/tasks/task_e_68cb5b1ec83883268e1763254194ab36