### PR TITLE
Add sampling limit and streaming support to audio record

### DIFF
--- a/data/static/audio/README.rst
+++ b/data/static/audio/README.rst
@@ -12,7 +12,10 @@ Functions
   ``.wav`` file in the ``work/`` directory by default. You may customise the duration,
   format (currently ``wav`` only) and target filename. By default the user is
   prompted to press Enter before recording starts; use ``--immediate`` to begin
-  right away.
+  right away. When you only need a short sample, ``--sample N`` caps the capture
+  to ``N`` seconds even if a longer duration was requested. Use ``--stream`` to
+  receive an in-memory handle that downstream helpers (such as ``audio.playback``)
+  can play without hitting the filesystem.
 
 ``playback``
   Play a ``.wav`` file. When invoked with ``--loop`` it keeps the audio

--- a/projects/audio.py
+++ b/projects/audio.py
@@ -6,12 +6,40 @@ import os
 import threading
 import time
 import wave
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Iterator, Optional
 
 import numpy as np
 import sounddevice as sd
 from gway import gw
+
+
+@dataclass
+class AudioStream:
+    """In-memory audio capture ready to be streamed or played back."""
+
+    data: np.ndarray
+    samplerate: int
+    channels: int
+    path: Path
+
+    def iter_chunks(self, *, frames: int = 1024) -> Iterator[np.ndarray]:
+        """Yield successive chunks of the captured audio.
+
+        Args:
+            frames: Number of frames to emit per chunk.
+
+        Yields:
+            ``numpy.ndarray`` slices containing ``frames`` worth of audio data.
+        """
+
+        if frames <= 0:
+            raise ValueError("frames must be a positive integer")
+
+        total_frames = self.data.shape[0]
+        for start in range(0, total_frames, frames):
+            yield self.data[start : start + frames]
 
 
 def record(
@@ -22,6 +50,8 @@ def record(
     format: str = "wav",
     file: Optional[str] = None,
     immediate: bool = False,
+    sample: Optional[float] = None,
+    stream: bool = False,
 ):
     """Record audio from the default input device.
 
@@ -35,12 +65,27 @@ def record(
             directory.
         immediate: Start recording immediately without waiting for
             user input.
+        sample: Maximum seconds to capture. When provided the effective
+            recording duration is ``min(duration, sample)``.
+        stream: When ``True`` return an :class:`AudioStream` with the
+            captured data for real-time streaming instead of a file path.
 
     Returns:
-        Absolute path to the recorded audio file.
+        Absolute path to the recorded audio file, or an :class:`AudioStream`
+        instance when ``stream`` is ``True``.
     """
     if format.lower() != "wav":
         raise ValueError("Only 'wav' format is supported")
+
+    if sample is not None:
+        if sample <= 0:
+            raise ValueError("sample must be a positive duration")
+        effective_duration = min(duration, sample)
+    else:
+        effective_duration = duration
+
+    if effective_duration <= 0:
+        raise ValueError("Recording duration must be positive")
 
     if file is None:
         work_dir = gw.resource("work", dir=True)
@@ -55,41 +100,59 @@ def record(
         gw.info("Press Enter to start recording")
         input()
 
-    frames = int(duration * samplerate)
+    frames = int(round(effective_duration * samplerate))
+    if frames <= 0:
+        raise ValueError("Recording duration too short for the given sample rate")
     data = sd.rec(frames, samplerate=samplerate, channels=channels)
     sd.wait()
-    scaled = np.int16(data * 32767)
+    float_data = np.array(data, copy=True)
+    scaled = np.int16(np.clip(float_data, -1, 1) * 32767)
     with wave.open(str(path), "w") as wf:
         wf.setnchannels(channels)
         wf.setsampwidth(2)
         wf.setframerate(samplerate)
         wf.writeframes(scaled.tobytes())
     gw.info(f"Saved recording to {path}")
+    if stream:
+        return AudioStream(
+            data=float_data,
+            samplerate=samplerate,
+            channels=channels,
+            path=path,
+        )
     return str(path)
 
 
-def playback(*, audio: str, loop: bool = False):
+def playback(*, audio: str | AudioStream, loop: bool = False):
     """Play an audio file.
 
     Args:
-        audio: Path to a ``.wav`` file. It can be the result returned by
-            :func:`record` to enable chaining.
+        audio: Path to a ``.wav`` file or an :class:`AudioStream` instance.
+            It can be the result returned by :func:`record` to enable
+            chaining.
         loop: When ``True`` the audio is played continuously in the
             background using Gateway's async thread management.
     """
-    audio = os.path.abspath(audio)
-    if not os.path.isfile(audio):
-        raise FileNotFoundError(audio)
+    if isinstance(audio, AudioStream):
+        samplerate = audio.samplerate
 
-    def _play_once():
-        with wave.open(audio, "rb") as wf:
-            samplerate = wf.getframerate()
-            channels = wf.getnchannels()
-            frames = wf.readframes(wf.getnframes())
-        data = np.frombuffer(frames, dtype=np.int16)
-        data = data.reshape(-1, channels)
-        sd.play(data, samplerate)
-        sd.wait()
+        def _play_once():
+            sd.play(audio.data, samplerate)
+            sd.wait()
+    else:
+        audio = os.path.abspath(audio)
+        if not os.path.isfile(audio):
+            raise FileNotFoundError(audio)
+
+        def _play_once():
+            with wave.open(audio, "rb") as wf:
+                samplerate = wf.getframerate()
+                channels = wf.getnchannels()
+                frames = wf.readframes(wf.getnframes())
+            data = np.frombuffer(frames, dtype=np.int16)
+            data = data.reshape(-1, channels)
+            sd.play(data, samplerate)
+            sd.wait()
 
     if loop:
         def _loop():
@@ -98,9 +161,13 @@ def playback(*, audio: str, loop: bool = False):
         thread = threading.Thread(target=_loop, daemon=True)
         thread.start()
         gw._async_threads.append(thread)
-        gw.info(f"Looping playback of {audio}")
-        return f"Looping playback of {audio}"
+        target = audio.path if isinstance(audio, AudioStream) else audio
+        target_str = str(target)
+        gw.info(f"Looping playback of {target_str}")
+        return f"Looping playback of {target_str}"
     else:
         _play_once()
-        gw.info(f"Played {audio}")
-        return f"Played {audio}"
+        target = audio.path if isinstance(audio, AudioStream) else audio
+        target_str = str(target)
+        gw.info(f"Played {target_str}")
+        return f"Played {target_str}"

--- a/tests/test_audio_record.py
+++ b/tests/test_audio_record.py
@@ -28,7 +28,7 @@ class AudioRecordTests(unittest.TestCase):
 
     def test_record_defaults_to_work_directory(self):
         audio = self._load_audio()
-        fake_data = np.zeros((1, 1), dtype="int16")
+        fake_data = np.zeros((1, 1), dtype="float32")
         with TemporaryDirectory() as tmpdir:
             def fake_resource(*parts, **kwargs):
                 return Path(tmpdir).joinpath(*parts)
@@ -48,7 +48,7 @@ class AudioRecordTests(unittest.TestCase):
 
     def test_record_stores_result_and_playback_injects(self):
         audio = self._load_audio()
-        fake_data = np.zeros((1, 1), dtype="int16")
+        fake_data = np.zeros((1, 1), dtype="float32")
         with TemporaryDirectory() as tmpdir:
             def fake_resource(*parts, **kwargs):
                 return Path(tmpdir).joinpath(*parts)
@@ -68,6 +68,49 @@ class AudioRecordTests(unittest.TestCase):
                 self.assertEqual(gw.results.get('audio'), path)
                 result = playback_wrapped()
                 self.assertEqual(result, path)
+
+    def test_sample_limits_duration(self):
+        audio = self._load_audio()
+        fake_data = np.zeros((441, 1), dtype="float32")
+        with TemporaryDirectory() as tmpdir:
+            def fake_resource(*parts, **kwargs):
+                return Path(tmpdir).joinpath(*parts)
+
+            fake_wave = MagicMock()
+            fake_wave.__enter__.return_value = MagicMock()
+
+            fake_sd = types.SimpleNamespace(rec=MagicMock(return_value=fake_data), wait=MagicMock())
+            with patch.object(gw, 'resource', fake_resource), \
+                 patch.object(audio, 'sd', fake_sd), \
+                 patch.object(audio, 'wave') as wave_mod:
+                wave_mod.open.return_value = fake_wave
+                audio.record(duration=5, sample=0.01, immediate=True)
+
+        expected_frames = int(round(min(5, 0.01) * 44100))
+        fake_sd.rec.assert_called_once_with(expected_frames, samplerate=44100, channels=1)
+
+    def test_stream_returns_audio_stream(self):
+        audio = self._load_audio()
+        fake_data = np.ones((22050, 2), dtype="float32") * 0.5
+        with TemporaryDirectory() as tmpdir:
+            def fake_resource(*parts, **kwargs):
+                return Path(tmpdir).joinpath(*parts)
+
+            fake_wave = MagicMock()
+            fake_wave.__enter__.return_value = MagicMock()
+
+            fake_sd = types.SimpleNamespace(rec=MagicMock(return_value=fake_data), wait=MagicMock())
+            with patch.object(gw, 'resource', fake_resource), \
+                 patch.object(audio, 'sd', fake_sd), \
+                 patch.object(audio, 'wave') as wave_mod:
+                wave_mod.open.return_value = fake_wave
+                result = audio.record(duration=0.5, channels=2, immediate=True, stream=True)
+
+        self.assertIsInstance(result, audio.AudioStream)
+        np.testing.assert_array_equal(result.data, fake_data)
+        self.assertEqual(result.samplerate, 44100)
+        self.assertEqual(result.channels, 2)
+        self.assertTrue(result.path.name.endswith(".wav"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add an AudioStream helper for in-memory capture returned by audio.record when --stream is passed
- support a --sample option to cap audio recording duration and enforce duration validation
- update playback, tests, and docs to understand streamed recordings

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68cb612f1d688326a5c39f7178e5cac1