### PR TITLE
Add sense alias for pir motion helper

### DIFF
--- a/projects/pir.py
+++ b/projects/pir.py
@@ -58,3 +58,7 @@ def sense_motion(
         print("Exiting...")
     finally:
         GPIO.cleanup(pin)
+
+
+# Backwards-compatible alias to align with CLI naming conventions
+sense = sense_motion


### PR DESCRIPTION
## Summary
- add a simple `sense` alias for the PIR motion helper so it can be invoked with a shorter CLI verb

## Testing
- gway test --coverage

------
https://chatgpt.com/codex/tasks/task_e_68cc2f58b148832695bf0318da84b394