### PR TITLE
Add PIR calibration helper and improve sensing setup

### DIFF
--- a/projects/pir.py
+++ b/projects/pir.py
@@ -39,8 +39,18 @@ def sense_motion(
     GPIO = _resolve_gpio(gpio_module)
     if GPIO is None:
         return
-    GPIO.setmode(getattr(GPIO, "BCM", GPIO.BOARD))
-    GPIO.setup(pin, getattr(GPIO, "IN"))
+
+    mode = getattr(GPIO, "BCM", None)
+    if mode is None:
+        mode = getattr(GPIO, "BOARD", None)
+    if mode is None:
+        mode = "BCM"
+    GPIO.setmode(mode)
+    setup_kwargs = {}
+    pull_down = getattr(GPIO, "PUD_DOWN", None)
+    if pull_down is not None:
+        setup_kwargs["pull_up_down"] = pull_down
+    GPIO.setup(pin, getattr(GPIO, "IN"), **setup_kwargs)
     print("PIR Sensor Test (CTRL+C to exit)")
     if settle_time > 0:
         time.sleep(settle_time)
@@ -56,6 +66,108 @@ def sense_motion(
                 time.sleep(interval)
     except KeyboardInterrupt:  # pragma: no cover - user interrupt
         print("Exiting...")
+    finally:
+        GPIO.cleanup(pin)
+
+
+def calibrate(
+    *,
+    pin: int = 17,
+    gpio_module=None,
+    warmup_time: float = 60.0,
+    sample_interval: float = 0.02,
+    max_transitions: int | None = None,
+    max_runtime: float | None = None,
+) -> None:
+    """Interactively tune a PIR sensor by reporting edge transitions.
+
+    The helper mirrors the advice from Raspberry Pi community experts:
+
+    * enable the built-in pull-down resistor so the ``LOW`` state stays stable
+      during calibration,
+    * let the sensor warm up to avoid spurious oscillations, and
+    * watch for actual state changes instead of repeatedly polling the same
+      value so you can correlate dial adjustments with motion events.
+
+    Parameters
+    ----------
+    pin:
+        BCM pin number connected to the sensor's digital output. Defaults to
+        ``17`` (``IO17``).
+    gpio_module:
+        Optional GPIO-like module providing ``setmode``, ``setup``, ``input``,
+        ``cleanup`` and, ideally, ``PUD_DOWN``. Defaults to :mod:`RPi.GPIO`
+        (or :mod:`RPIO`) when available.
+    warmup_time:
+        Seconds to let the sensor stabilise after powering on. Most PIR modules
+        need 30–60 seconds; the default uses 60 seconds to avoid false pulses.
+    sample_interval:
+        Seconds to wait between sensor polls once calibration begins. Defaults
+        to ``0.02`` seconds, mirroring the lightweight loop in the reference
+        calibration script.
+    max_transitions:
+        Maximum number of state changes to report before returning. ``None``
+        means run until interrupted. This parameter is intended for testing.
+    max_runtime:
+        Maximum number of seconds to watch before automatically exiting. Use
+        this for scripted runs where ``KeyboardInterrupt`` is not convenient.
+    """
+
+    GPIO = _resolve_gpio(gpio_module)
+    if GPIO is None:
+        return
+
+    mode = getattr(GPIO, "BCM", None)
+    if mode is None:
+        mode = getattr(GPIO, "BOARD", None)
+    if mode is None:
+        mode = "BCM"
+    GPIO.setmode(mode)
+    setup_kwargs = {}
+    pull_down = getattr(GPIO, "PUD_DOWN", None)
+    if pull_down is not None:
+        setup_kwargs["pull_up_down"] = pull_down
+    GPIO.setup(pin, getattr(GPIO, "IN"), **setup_kwargs)
+
+    print("PIR Calibration (CTRL+C to exit)")
+    if warmup_time > 0:
+        print(f"Warming up for {warmup_time:.0f}s – keep still.")
+        time.sleep(warmup_time)
+    print("Watching for motion state changes. Adjust TIME and SENS slowly.")
+
+    last_state = GPIO.input(pin)
+    last_change = time.time()
+    start_time = last_change
+    transitions = 0
+    print(f"Initial state: {'MOTION' if last_state else 'no motion'}")
+
+    try:
+        while True:
+            if max_runtime is not None:
+                elapsed = time.time() - start_time
+                if elapsed >= max_runtime:
+                    print("Reached maximum runtime; stopping calibration.")
+                    break
+
+            current_state = GPIO.input(pin)
+            if current_state != last_state:
+                now = time.time()
+                duration = now - last_change
+                timestamp = time.strftime("%H:%M:%S")
+                print(
+                    f"{timestamp}  {'MOTION' if current_state else 'no motion'}  "
+                    f"(state held for {duration:.1f}s)"
+                )
+                last_state = current_state
+                last_change = now
+                transitions += 1
+                if max_transitions is not None and transitions >= max_transitions:
+                    break
+
+            if sample_interval > 0:
+                time.sleep(sample_interval)
+    except KeyboardInterrupt:  # pragma: no cover - user interrupt
+        print("Calibration interrupted")
     finally:
         GPIO.cleanup(pin)
 

--- a/tests/test_pir_sense_motion.py
+++ b/tests/test_pir_sense_motion.py
@@ -80,7 +80,7 @@ def test_sense_motion_handles_keyboard_interrupt(monkeypatch):
     def raising_sleep(seconds):
         raise KeyboardInterrupt
 
-    monkeypatch.setattr("gway.projects.pir.time.sleep", raising_sleep)
+    monkeypatch.setattr("projects.pir.time.sleep", raising_sleep)
 
     gpio = FakeGPIO()
     buf = io.StringIO()
@@ -98,3 +98,73 @@ def test_sense_motion_handles_keyboard_interrupt(monkeypatch):
         "Exiting...",
     ]
     assert gpio.cleaned == [17]
+
+
+@unittest.skipUnless(
+    is_test_flag("sensors"),
+    "Sensor tests disabled (enable with --flags sensors)",
+)
+def test_calibrate_reports_transitions(monkeypatch):
+    class FakeGPIO:
+        BCM = "BCM"
+        IN = "IN"
+        PUD_DOWN = "PUD_DOWN"
+
+        def __init__(self, readings):
+            self.readings = list(readings)
+            self.cleaned = []
+            self.setup_kwargs = None
+            self.last_value = 0
+
+        def setmode(self, mode):
+            self.mode = mode
+
+        def setup(self, pin, mode, **kwargs):
+            self.pin = pin
+            self.mode_set = mode
+            self.setup_kwargs = kwargs
+
+        def input(self, pin):
+            if self.readings:
+                self.last_value = self.readings.pop(0)
+            return self.last_value
+
+        def cleanup(self, pin):
+            self.cleaned.append(pin)
+
+    class FakeTime:
+        def __init__(self):
+            self.current = 0.0
+
+        def time(self):
+            return self.current
+
+        def sleep(self, seconds):
+            self.current += seconds
+
+        def strftime(self, fmt):
+            return "00:00:00"
+
+    fake_time = FakeTime()
+    monkeypatch.setattr("projects.pir.time", fake_time)
+
+    gpio = FakeGPIO([0, 1, 1, 0, 0])
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        gw.pir.calibrate(
+            gpio_module=gpio,
+            warmup_time=0.0,
+            sample_interval=0.02,
+            max_transitions=2,
+        )
+
+    lines = buf.getvalue().splitlines()
+    assert lines[:3] == [
+        "PIR Calibration (CTRL+C to exit)",
+        "Watching for motion state changes. Adjust TIME and SENS slowly.",
+        "Initial state: no motion",
+    ]
+    assert lines[3].endswith("MOTION  (state held for 0.0s)")
+    assert lines[4].endswith("no motion  (state held for 0.0s)")
+    assert gpio.cleaned == [17]
+    assert gpio.setup_kwargs == {"pull_up_down": "PUD_DOWN"}


### PR DESCRIPTION
## Summary
- add a PIR calibration helper that warms the sensor, enables the pull-down, and reports edge durations for dial tuning
- update the existing sense helper to request the internal pull-down when present so idle readings stay low
- cover the new helper with sensor-flagged tests that exercise the edge reporting loop

## Testing
- GW_TEST_FLAGS=sensors pytest tests/test_pir_sense_motion.py

------
https://chatgpt.com/codex/tasks/task_e_68cc3da505008326824dc461a9d7707d