### PR TITLE
Add LCD fallback to notify builtin

### DIFF
--- a/gway/builtins/utils.py
+++ b/gway/builtins/utils.py
@@ -37,12 +37,21 @@ def random_id(length: int = 8, alphabet: str = _EZ_ALPHABET) -> str:
 
 def notify(message: str, *, title: str = "GWAY Notice", timeout: int = 10):
     from gway import gw
-    """Send a notification via GUI, email or console fallback."""
+
+    """Send a notification via GUI, LCD, email or console fallback."""
     try:
         gw.studio.screen.notify(message, title=title, timeout=timeout)
         return "gui"
     except Exception as e:
         gw.debug(f"GUI notify failed: {e}")
+    try:
+        if hasattr(gw, "lcd"):
+            hold_duration = timeout if timeout and timeout > 0 else 0
+            lcd_text = f"{title}\n{message}" if title else message
+            gw.lcd.show(lcd_text, hold=hold_duration, wrap=True)
+            return "lcd"
+    except Exception as e:
+        gw.debug(f"LCD notify failed: {e}")
     try:
         if hasattr(gw, "mail") and os.environ.get("ADMIN_EMAIL"):
             gw.mail.send(title, body=message, to=os.environ.get("ADMIN_EMAIL"))

--- a/tests/test_notify_builtin.py
+++ b/tests/test_notify_builtin.py
@@ -17,17 +17,35 @@ class NotifyBuiltinTests(unittest.TestCase):
 
     def test_console_fallback(self):
         with patch.object(gw.studio.screen, 'notify', side_effect=Exception('fail')):
-            with patch.object(gw.mail, 'send') as mock_send:
-                gw.notify('hello world', title='T')
-                mock_send.assert_not_called()
+            with patch.object(gw.lcd, 'show', side_effect=Exception('lcd fail')):
+                with patch.object(gw.mail, 'send') as mock_send:
+                    result = gw.notify('hello world', title='T')
+                    mock_send.assert_not_called()
+        self.assertEqual(result, 'console')
         self.assertIn('hello world', self.out.getvalue())
 
     def test_email_fallback(self):
         os.environ['ADMIN_EMAIL'] = 'test@example.com'
         with patch.object(gw.studio.screen, 'notify', side_effect=Exception('fail')):
-            with patch.object(gw.mail, 'send') as mock_send:
-                gw.notify('msg', title='Notice')
-                mock_send.assert_called_once()
+            with patch.object(gw.lcd, 'show', side_effect=Exception('lcd fail')):
+                with patch.object(gw.mail, 'send') as mock_send:
+                    result = gw.notify('msg', title='Notice')
+                    mock_send.assert_called_once()
+        self.assertEqual(result, 'email')
+
+    def test_lcd_fallback(self):
+        with patch.object(gw.studio.screen, 'notify', side_effect=Exception('fail')):
+            with patch.object(gw.lcd, 'show') as mock_lcd:
+                with patch.object(gw.mail, 'send') as mock_send:
+                    result = gw.notify('lcd msg', title='LCD Title', timeout=5)
+                    mock_lcd.assert_called_once()
+                    args, kwargs = mock_lcd.call_args
+                    self.assertIn('LCD Title', args[0])
+                    self.assertIn('lcd msg', args[0])
+                    self.assertEqual(kwargs.get('hold'), 5)
+                    self.assertTrue(kwargs.get('wrap'))
+                    mock_send.assert_not_called()
+        self.assertEqual(result, 'lcd')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add an LCD notification attempt between the GUI and email fallbacks
- send the title and message to the LCD with a configurable hold duration
- expand notify builtin tests to cover the LCD path and updated fallbacks

## Testing
- pytest tests/test_notify_builtin.py

------
https://chatgpt.com/codex/tasks/task_e_68cc5f26dca4832688cd6532c33a9da2