### PR TITLE
Add block reading options to RFID scan

### DIFF
--- a/data/static/rfid/README.rst
+++ b/data/static/rfid/README.rst
@@ -5,7 +5,11 @@ RFID Utilities
 
 ``scan`` – wait for a card to be scanned and print its information. Press any
 key to stop scanning or pass ``--wait`` to exit automatically after the
-specified number of seconds.
+specified number of seconds. Provide ``--block`` to read a specific block or
+``--deep`` to iterate through the first 64 blocks of a MIFARE Classic card.
+Authentication keys may be supplied via ``--key-a`` or ``--key-b``; when
+neither is provided the tool automatically tries common manufacturer defaults
+and reports which one worked.
 
 ``pinout`` – return the expected wiring between the MFRC522 board and a
 Raspberry Pi.


### PR DESCRIPTION
## Summary
- add helpers to read arbitrary blocks from the MFRC522 reader and extend `rfid.scan` with `--block`, `--deep`, `--key-a`, and `--key-b`
- teach `rfid.scan` to guess default keys when deep scanning and surface formatted block output
- document the new options and cover them with additional unit tests

## Testing
- pytest tests/test_rfid.py

------
https://chatgpt.com/codex/tasks/task_e_68cc8f95db408326984421a8a6ed7019