### PR TITLE
Fix CLI project listings returning empty output

### DIFF
--- a/gway/structs.py
+++ b/gway/structs.py
@@ -79,7 +79,7 @@ class Project(SimpleNamespace):
         }
 
         # Display available functions to the user
-        show_functions(functions)
+        return show_functions(functions)
 
     def __getattr__(self, name):
         """Fallback to ``<verb>_<project>`` or delegate to custom handler.


### PR DESCRIPTION
## Summary
- ensure project listings return a formatted summary instead of printing nothing
- print the formatted summary when resolving non-callable project containers

## Testing
- pytest tests/test_gateway.py -k project

------
https://chatgpt.com/codex/tasks/task_e_68ccb30c076c83269efd58bf099f98fc