### PR TITLE
Address feedback: ensure RFID scan cleanup on CSV init failure

### DIFF
--- a/projects/rfid.py
+++ b/projects/rfid.py
@@ -607,28 +607,27 @@ def scan(
     if reader is None:
         return
 
-    csv_path = None
     csv_file = None
     csv_writer = None
-    if csv_parts is not None:
-        csv_path = gw.resource("work", *csv_parts)
-        csv_file, csv_writer = _open_csv_writer(csv_path)
-        print(f"Logging scans to {csv_path}")
-
-    if wait_seconds is None:
-        print("Scanning for RFID cards. Press any key to stop.")
-    else:
-        formatted_wait = f"{wait_seconds:g}"
-        print(
-            "Scanning for RFID cards. Press any key to stop. "
-            "Automatically stopping after {seconds} seconds.".format(
-                seconds=formatted_wait
-            )
-        )
-
-    seen_counts: dict[object, int] = {}
     detected_uid = None
     try:
+        if csv_parts is not None:
+            csv_path = gw.resource("work", *csv_parts)
+            csv_file, csv_writer = _open_csv_writer(csv_path)
+            print(f"Logging scans to {csv_path}")
+
+        if wait_seconds is None:
+            print("Scanning for RFID cards. Press any key to stop.")
+        else:
+            formatted_wait = f"{wait_seconds:g}"
+            print(
+                "Scanning for RFID cards. Press any key to stop. "
+                "Automatically stopping after {seconds} seconds.".format(
+                    seconds=formatted_wait
+                )
+            )
+
+        seen_counts: dict[object, int] = {}
         deadline = None
         if wait_seconds is not None:
             deadline = time.monotonic() + wait_seconds


### PR DESCRIPTION
## Summary
- move CSV writer initialization inside the scan loop's try/finally guard
- ensure GPIO and reader cleanup still run even when CSV setup raises

## Testing
- pytest tests/test_rfid.py

------
https://chatgpt.com/codex/tasks/task_e_68cd5aa212e883269e5f030806578804