### PR TITLE
Handle context-only CLI calls

### DIFF
--- a/tests/test_console.py
+++ b/tests/test_console.py
@@ -342,6 +342,54 @@ class TestRecipeCliContext(unittest.TestCase):
         finally:
             sys.argv = original_argv
 
+    def test_context_only_arguments_report_nothing_to_do(self):
+        original_argv = sys.argv
+
+        class DummyGateway:
+            def __init__(self, **kwargs):
+                pass
+
+            def verbose(self, *args, **kwargs):
+                pass
+
+        try:
+            with patch('gway.console.argcomplete.autocomplete', lambda *a, **k: None), \
+                 patch('gway.console.setup_logging', lambda *a, **k: None), \
+                 patch('gway.console.Gateway', DummyGateway), \
+                 patch('gway.console.process') as mock_process, \
+                 patch('builtins.print') as mock_print:
+                sys.argv = ['gway', '--upgrade']
+                console.cli_main()
+                mock_process.assert_not_called()
+                messages = [call.args[0] for call in mock_print.call_args_list]
+                self.assertIn('Nothing to do. -> --upgrade', messages)
+        finally:
+            sys.argv = original_argv
+
+    def test_context_only_arguments_with_values_supported(self):
+        original_argv = sys.argv
+
+        class DummyGateway:
+            def __init__(self, **kwargs):
+                pass
+
+            def verbose(self, *args, **kwargs):
+                pass
+
+        try:
+            with patch('gway.console.argcomplete.autocomplete', lambda *a, **k: None), \
+                 patch('gway.console.setup_logging', lambda *a, **k: None), \
+                 patch('gway.console.Gateway', DummyGateway), \
+                 patch('gway.console.process') as mock_process, \
+                 patch('builtins.print') as mock_print:
+                sys.argv = ['gway', '--tag', 'alpha']
+                console.cli_main()
+                mock_process.assert_not_called()
+                messages = [call.args[0] for call in mock_print.call_args_list]
+                self.assertIn('Nothing to do. -> --tag=alpha', messages)
+        finally:
+            sys.argv = original_argv
+
 
 class TestProcessChaining(unittest.TestCase):
     def test_reuses_project_for_chained_calls(self):


### PR DESCRIPTION
## Summary
- detect context-only CLI invocations and report an explicit "Nothing to do." message listing the unused flags
- add console tests covering flag-only and flagged value inputs to ensure the helper path emits the notification

## Testing
- gway test --coverage (fails: missing tests.djproj module)
- python -m pytest tests/test_console.py::TestRecipeCliContext -q


------
https://chatgpt.com/codex/tasks/task_e_68cd60432d2c8326a8ca3f060dd6be49