### PR TITLE
Set argparse program name to gway

### DIFF
--- a/gway/console.py
+++ b/gway/console.py
@@ -114,7 +114,7 @@ def _format_unused_context(unused: dict[str, object]) -> str:
 
 def cli_main():
     """Main CLI entry point."""
-    parser = argparse.ArgumentParser(description="Dynamic Project CLI")
+    parser = argparse.ArgumentParser(prog="gway", description="Dynamic Project CLI")
 
     # Primary behavior flags
     add = parser.add_argument


### PR DESCRIPTION
## Summary
- set the CLI parser's program name to `gway` so the usage banner matches the executable

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `gway test --coverage` *(fails: ModuleNotFoundError: No module named 'tests.djproj')*

------
https://chatgpt.com/codex/tasks/task_e_68cddc17e6f08326bc6fc0fee120115e