### PR TITLE
Add interactive Evennia shell with Gateway command support

### DIFF
--- a/projects/evennia.py
+++ b/projects/evennia.py
@@ -1,0 +1,521 @@
+# file: projects/evennia.py
+"""Helpers for working with Evennia game servers.
+
+The functions here wrap the Evennia command line utilities so the
+``gway`` CLI can bootstrap and manage game instances.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shlex
+import shutil
+import subprocess
+import sys
+import telnetlib
+from pathlib import Path
+from typing import Iterable, TextIO
+
+import gway.console as gway_console
+from gway import gw
+
+
+def _resolve_evennia_command(*, python: str | None = None) -> list[str]:
+    """Return the command sequence to invoke Evennia.
+
+    Preference order:
+    1. Explicit ``python`` interpreter provided by the caller.
+    2. The ``evennia`` executable available on ``PATH``.
+    3. ``python -m evennia`` using the current interpreter, if the module
+       is importable.
+    """
+
+    if python:
+        return [python, "-m", "evennia"]
+
+    executable = shutil.which("evennia")
+    if executable:
+        return [executable]
+
+    if importlib.util.find_spec("evennia") is not None:
+        return [sys.executable, "-m", "evennia"]
+
+    raise RuntimeError(
+        "Evennia is not installed. Install it with 'pip install evennia' first."
+    )
+
+
+def install(path: str, *, python: str | None = None) -> dict[str, object]:
+    """Initialize a new Evennia game in ``path`` relative to the CWD."""
+
+    target = Path(path)
+    if not target.is_absolute():
+        target = Path.cwd() / target
+    target = target.resolve()
+
+    if target.exists():
+        raise FileExistsError(f"Target already exists: {target}")
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    command = _resolve_evennia_command(python=python) + ["--init", str(target)]
+    completed = subprocess.run(command, check=True)
+
+    return {
+        "command": command,
+        "path": str(target),
+        "returncode": completed.returncode,
+    }
+
+
+def _drain_output(stream: Iterable[str]) -> None:
+    """Print each line coming from ``stream`` as it arrives."""
+
+    for line in stream:
+        print(line, end="", flush=True)
+
+
+def _realize_result(value: object) -> object:
+    """Materialize iterable results into lists for stable presentation."""
+
+    if isinstance(value, (str, bytes, dict)) or value is None:
+        return value
+    if hasattr(value, "__iter__"):
+        try:
+            return list(value)
+        except Exception:
+            return value
+    return value
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 4000
+DEFAULT_TIMEOUT = 5.0
+
+
+def _create_telnet(host: str, port: int, timeout: float) -> telnetlib.Telnet:
+    """Factory for ``telnetlib.Telnet`` so tests can stub it easily."""
+
+    return telnetlib.Telnet(host=host, port=port, timeout=timeout)
+
+
+class EvenniaSession:
+    """Manage a telnet connection for a specific Evennia character."""
+
+    def __init__(
+        self,
+        login: str,
+        *,
+        host: str = DEFAULT_HOST,
+        port: int = DEFAULT_PORT,
+        password: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> None:
+        self.login = login
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.password = password if password is not None else login
+        self.inputs: list[str] = []
+        self.outputs: list[str] = []
+        self._telnet: telnetlib.Telnet | None = None
+        self._ever_connected = False
+
+        self._connect(create=True)
+
+    def close(self) -> None:
+        """Close the underlying telnet connection."""
+
+        self._disconnect()
+
+    def send_line(self, command: str) -> None:
+        """Send ``command`` to the server, adding a newline automatically."""
+
+        line = command.rstrip("\n") + "\n"
+        self._perform_write(line, log=True)
+
+    def collect(self) -> str:
+        """Gather all available output from the server."""
+
+        data: list[str] = []
+        while True:
+            chunk = self._perform_read()
+            if not chunk:
+                break
+            data.append(chunk)
+
+        combined = "".join(data)
+        if combined:
+            self.outputs.append(combined)
+        return combined
+
+    def _connect(self, *, create: bool) -> None:
+        self._telnet = _create_telnet(self.host, self.port, self.timeout)
+        self._ever_connected = True
+        self._login(create=create)
+
+    def _disconnect(self) -> None:
+        telnet = self._telnet
+        if telnet is not None:
+            try:
+                telnet.close()
+            finally:
+                self._telnet = None
+
+    def _login(self, *, create: bool) -> None:
+        if create:
+            self._perform_write(
+                f"create {self.login} {self.password}\n",
+                log=True,
+            )
+        self._perform_write(
+            f"connect {self.login} {self.password}\n",
+            log=True,
+        )
+
+    def _perform_write(self, message: str, *, log: bool) -> None:
+        attempts = 0
+        while True:
+            attempts += 1
+            if self._telnet is None:
+                self._connect(create=not self._ever_connected)
+            assert self._telnet is not None  # mypy appeasement, covered by connect above
+            try:
+                self._telnet.write(message.encode("utf-8"))
+                if log:
+                    self.inputs.append(message.rstrip("\n"))
+                return
+            except (EOFError, ConnectionResetError, OSError):
+                self._disconnect()
+                if attempts >= 3:
+                    raise
+                self._connect(create=False)
+
+    def _perform_read(self) -> str:
+        attempts = 0
+        while True:
+            attempts += 1
+            if self._telnet is None:
+                self._connect(create=not self._ever_connected)
+            assert self._telnet is not None
+            try:
+                raw = self._telnet.read_very_eager()
+            except (EOFError, ConnectionResetError, OSError):
+                self._disconnect()
+                if attempts >= 3:
+                    raise
+                self._connect(create=False)
+                continue
+            if not raw:
+                return ""
+            decoded = raw.decode("utf-8", errors="replace")
+            return decoded
+
+
+_sessions: dict[str, EvenniaSession] = {}
+_default_login: str | None = None
+
+
+def _obtain_session(
+    login: str | None,
+    *,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    password: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    create: bool,
+    replace: bool = False,
+) -> EvenniaSession:
+    """Return the ``EvenniaSession`` associated with ``login``."""
+
+    global _default_login
+
+    key = login if login is not None else _default_login
+    if key is None:
+        raise RuntimeError("No Evennia session is active. Provide --login to create one.")
+
+    session = _sessions.get(key)
+    if session is not None and replace:
+        session.close()
+        session = None
+
+    if session is None:
+        if not create:
+            raise RuntimeError(
+                f"No Evennia session for login {key!r}. Provide --login to create it first."
+            )
+        session = EvenniaSession(
+            key,
+            host=host,
+            port=port,
+            password=password,
+            timeout=timeout,
+        )
+        _sessions[key] = session
+
+    if _default_login is None:
+        _default_login = session.login
+
+    return session
+
+
+def start(
+    *,
+    python: str | None = None,
+    login: str | None = None,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    password: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, object]:
+    """Start the Evennia instance in the current working directory.
+
+    The call blocks while the server is running and mirrors the output so the
+    CLI stays attached to the process.
+    """
+
+    command = _resolve_evennia_command(python=python) + ["start"]
+    session: EvenniaSession | None = None
+    if login:
+        session = _obtain_session(
+            login,
+            host=host,
+            port=port,
+            password=password,
+            timeout=timeout,
+            create=True,
+            replace=True,
+        )
+
+    process = subprocess.Popen(  # noqa: S603
+        command,
+        cwd=str(Path.cwd()),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+
+    stdout = process.stdout
+
+    try:
+        if stdout is not None:
+            _drain_output(stdout)
+        returncode = process.wait()
+    except KeyboardInterrupt:  # pragma: no cover - exercised manually
+        process.terminate()
+        try:
+            process.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait()
+        raise
+    finally:
+        if stdout is not None:
+            stdout.close()
+
+    result: dict[str, object] = {
+        "command": command,
+        "returncode": returncode,
+        "login": login,
+        "inputs": session.inputs.copy() if session else [],
+        "outputs": session.outputs.copy() if session else [],
+    }
+    return result
+
+
+def read(
+    *,
+    login: str | None = None,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    password: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, object]:
+    """Fetch buffered output for ``login`` or the default session."""
+
+    session = _obtain_session(
+        login,
+        host=host,
+        port=port,
+        password=password,
+        timeout=timeout,
+        create=login is not None,
+    )
+    buffer = session.collect()
+    return {
+        "login": session.login,
+        "buffer": buffer,
+        "inputs": session.inputs.copy(),
+        "outputs": session.outputs.copy(),
+    }
+
+
+def write(
+    command: str,
+    *,
+    login: str | None = None,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    password: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, object]:
+    """Send ``command`` to ``login``'s session and return captured output."""
+
+    session = _obtain_session(
+        login,
+        host=host,
+        port=port,
+        password=password,
+        timeout=timeout,
+        create=login is not None,
+    )
+    session.send_line(command)
+    buffer = session.collect()
+    return {
+        "login": session.login,
+        "command": command,
+        "buffer": buffer,
+        "inputs": session.inputs.copy(),
+        "outputs": session.outputs.copy(),
+    }
+
+
+def shell(
+    *,
+    login: str | None = None,
+    host: str = DEFAULT_HOST,
+    port: int = DEFAULT_PORT,
+    password: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT,
+    prompt: str = "evennia> ",
+    gway_prefix: str = ">",
+    input_stream: TextIO | None = None,
+    output_stream: TextIO | None = None,
+) -> dict[str, object]:
+    """Run an interactive Evennia session with optional Gateway command support."""
+
+    if not gw.interactive_enabled:
+        raise RuntimeError("Evennia shell requires interactive mode. Run with `-i`.")
+
+    session = _obtain_session(
+        login,
+        host=host,
+        port=port,
+        password=password,
+        timeout=timeout,
+        create=login is not None,
+    )
+
+    stdin = input_stream if input_stream is not None else sys.stdin
+    stdout = output_stream if output_stream is not None else sys.stdout
+
+    def write_output(text: str) -> None:
+        stdout.write(text)
+        stdout.flush()
+
+    def resolve_text(text: str) -> str:
+        if text and "[" in text and "]" in text:
+            resolved = gw.resolve(text)
+            return resolved if isinstance(resolved, str) else str(resolved)
+        return text
+
+    exit_reason = "eof"
+    user_commands: list[str] = []
+    gway_results: list[dict[str, object]] = []
+
+    while True:
+        buffer = session.collect()
+        if buffer:
+            write_output(buffer)
+
+        if prompt:
+            write_output(prompt)
+
+        try:
+            line = stdin.readline()
+        except KeyboardInterrupt:
+            exit_reason = "interrupt"
+            write_output("\n")
+            break
+
+        if line == "":
+            if prompt:
+                write_output("\n")
+            break
+
+        line = line.rstrip("\r\n")
+        if not line.strip():
+            continue
+
+        stripped = line.lstrip()
+        is_gway_command = gway_prefix and stripped.startswith(gway_prefix)
+
+        if is_gway_command:
+            command_text = stripped[len(gway_prefix) :].lstrip()
+            if not command_text:
+                continue
+            try:
+                command_text = resolve_text(command_text)
+            except KeyError as exc:
+                write_output(f"{exc}\n")
+                continue
+            try:
+                tokens = shlex.split(command_text)
+            except ValueError as exc:
+                write_output(f"Error parsing gway command: {exc}\n")
+                continue
+            if not tokens:
+                continue
+            try:
+                _, last_result = gway_console.process(
+                    [tokens],
+                    origin="line",
+                    gw_instance=gw,
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                write_output(f"Error running gway command: {exc}\n")
+                continue
+
+            realized = _realize_result(last_result)
+            if realized is not None:
+                display = realized if isinstance(realized, str) else str(realized)
+                if display:
+                    write_output(display)
+                    if not display.endswith("\n"):
+                        write_output("\n")
+
+            gway_results.append(
+                {
+                    "command": command_text,
+                    "tokens": tokens.copy(),
+                    "result": realized,
+                }
+            )
+            continue
+
+        try:
+            resolved_command = resolve_text(line)
+        except KeyError as exc:
+            write_output(f"{exc}\n")
+            continue
+
+        if not resolved_command:
+            continue
+
+        session.send_line(resolved_command)
+        user_commands.append(resolved_command)
+
+        buffer = session.collect()
+        if buffer:
+            write_output(buffer)
+
+    return {
+        "login": session.login,
+        "commands": user_commands,
+        "gway_results": gway_results,
+        "inputs": session.inputs.copy(),
+        "outputs": session.outputs.copy(),
+        "reason": exit_reason,
+    }
+

--- a/tests/test_evennia_project.py
+++ b/tests/test_evennia_project.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import io
+import types
+
+import pytest
+
+from gway import gw
+from gway.projects import evennia
+
+
+class DummyStdout:
+    def __init__(self, lines: list[str]):
+        self._iterator = iter(lines)
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        return next(self._iterator)
+
+    def close(self):
+        self.closed = True
+
+
+class DummyProcess:
+    def __init__(self, lines: list[str]):
+        self.stdout = DummyStdout(lines)
+        self._waits = 0
+        self.terminated = False
+        self.killed = False
+
+    def wait(self, timeout: float | None = None):
+        self._waits += 1
+        return 0
+
+    def terminate(self):
+        self.terminated = True
+
+    def kill(self):
+        self.killed = True
+
+
+class DummyTelnet:
+    def __init__(self, *, outputs: list[bytes] | None = None, fail_first_write: bool = False):
+        self.outputs = outputs or []
+        self.fail_first_write = fail_first_write
+        self.writes: list[bytes] = []
+        self.closed = False
+        self._read_calls = 0
+
+    def queue_output(self, text: str) -> None:
+        self.outputs.append(text.encode("utf-8"))
+
+    def write(self, data: bytes) -> None:
+        if self.fail_first_write:
+            self.fail_first_write = False
+            raise EOFError("connection dropped")
+        self.writes.append(data)
+
+    def read_very_eager(self) -> bytes:
+        self._read_calls += 1
+        if self.outputs:
+            return self.outputs.pop(0)
+        return b""
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_install_runs_evennia(tmp_path, monkeypatch):
+    called = {}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(evennia.shutil, "which", lambda _: "/usr/bin/evennia")
+    monkeypatch.setattr(evennia.importlib.util, "find_spec", lambda _: None)
+
+    def fake_run(command, *, check):
+        called["command"] = command
+        called["check"] = check
+
+        class Completed:
+            returncode = 0
+
+        return Completed()
+
+    monkeypatch.setattr(evennia.subprocess, "run", fake_run)
+
+    result = evennia.install("funtown")
+
+    expected_target = tmp_path / "funtown"
+    assert called["command"] == ["/usr/bin/evennia", "--init", str(expected_target)]
+    assert called["check"] is True
+    assert result == {
+        "command": ["/usr/bin/evennia", "--init", str(expected_target)],
+        "path": str(expected_target),
+        "returncode": 0,
+    }
+
+
+def test_install_fails_when_target_exists(tmp_path, monkeypatch):
+    target = tmp_path / "exists"
+    target.mkdir()
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(evennia.shutil, "which", lambda _: "/usr/bin/evennia")
+    monkeypatch.setattr(evennia.importlib.util, "find_spec", lambda _: None)
+
+    with pytest.raises(FileExistsError):
+        evennia.install("exists")
+
+
+def _install_telnet_factory(monkeypatch, factory):
+    monkeypatch.setattr(evennia, "_create_telnet", factory)
+
+
+def _reset_sessions(monkeypatch):
+    monkeypatch.setattr(evennia, "_sessions", {})
+    monkeypatch.setattr(evennia, "_default_login", None)
+
+
+def test_start_streams_output(tmp_path, monkeypatch, capsys):
+    lines = ["Starting server\n", "Server ready\n"]
+    spawned = {}
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(evennia.shutil, "which", lambda _: "/usr/bin/evennia")
+    monkeypatch.setattr(evennia.importlib.util, "find_spec", lambda _: None)
+    _reset_sessions(monkeypatch)
+
+    telnet_instances: list[DummyTelnet] = []
+
+    def fake_telnet(host, port, timeout):
+        telnet = DummyTelnet()
+        telnet_instances.append(telnet)
+        return telnet
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    def fake_popen(command, *, cwd, stdout, stderr, text, bufsize):
+        spawned.update(
+            {
+                "command": command,
+                "cwd": cwd,
+                "stdout": stdout,
+                "stderr": stderr,
+                "text": text,
+                "bufsize": bufsize,
+            }
+        )
+        return DummyProcess(lines)
+
+    monkeypatch.setattr(evennia.subprocess, "Popen", fake_popen)
+
+    result = evennia.start()
+
+    captured = capsys.readouterr()
+    assert captured.out == "".join(lines)
+    assert result == {
+        "command": ["/usr/bin/evennia", "start"],
+        "returncode": 0,
+        "login": None,
+        "inputs": [],
+        "outputs": [],
+    }
+    assert spawned["cwd"] == str(tmp_path)
+    assert spawned["stdout"] is evennia.subprocess.PIPE
+    assert spawned["stderr"] is evennia.subprocess.STDOUT
+    assert spawned["text"] is True
+    assert spawned["bufsize"] == 1
+    assert telnet_instances == []
+
+
+def test_evennia_command_requires_install(monkeypatch):
+    monkeypatch.setattr(evennia.shutil, "which", lambda _: None)
+    monkeypatch.setattr(evennia.importlib.util, "find_spec", lambda _: None)
+
+    with pytest.raises(RuntimeError):
+        evennia._resolve_evennia_command()
+
+
+def test_start_with_login_creates_session(tmp_path, monkeypatch):
+    lines = ["Booting\n"]
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(evennia.shutil, "which", lambda _: "/usr/bin/evennia")
+    monkeypatch.setattr(evennia.importlib.util, "find_spec", lambda _: None)
+    _reset_sessions(monkeypatch)
+
+    telnet_instances: list[DummyTelnet] = []
+
+    def fake_telnet(host, port, timeout):
+        telnet = DummyTelnet()
+        telnet_instances.append(telnet)
+        return telnet
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    monkeypatch.setattr(evennia.subprocess, "Popen", lambda *a, **k: DummyProcess(lines))
+
+    result = evennia.start(login="tester")
+
+    assert result["login"] == "tester"
+    assert result["inputs"][:2] == ["create tester tester", "connect tester tester"]
+    assert len(telnet_instances) == 1
+    assert telnet_instances[0].writes[:2] == [
+        b"create tester tester\n",
+        b"connect tester tester\n",
+    ]
+    assert evennia._default_login == "tester"
+
+
+def test_read_returns_buffer(monkeypatch):
+    _reset_sessions(monkeypatch)
+
+    telnet = DummyTelnet(outputs=[b"Welcome adventurer\n"])
+
+    def fake_telnet(host, port, timeout):
+        return telnet
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    session = evennia.EvenniaSession("hero")
+    evennia._sessions["hero"] = session
+    evennia._default_login = "hero"
+
+    result = evennia.read()
+
+    assert result["login"] == "hero"
+    assert result["buffer"] == "Welcome adventurer\n"
+    assert result["outputs"][-1] == "Welcome adventurer\n"
+
+
+def test_write_sends_command(monkeypatch):
+    _reset_sessions(monkeypatch)
+
+    telnet = DummyTelnet(outputs=[b"You see nothing special.\n"])
+
+    def fake_telnet(host, port, timeout):
+        return telnet
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    session = evennia.EvenniaSession("hero")
+    evennia._sessions["hero"] = session
+    evennia._default_login = "hero"
+
+    result = evennia.write("look")
+
+    assert telnet.writes[-1] == b"look\n"
+    assert "look" in result["inputs"]
+    assert result["buffer"] == "You see nothing special.\n"
+
+
+def test_read_with_new_login_creates_session(monkeypatch):
+    _reset_sessions(monkeypatch)
+
+    telnet_instances: list[DummyTelnet] = []
+
+    def fake_telnet(host, port, timeout):
+        telnet = DummyTelnet()
+        telnet_instances.append(telnet)
+        return telnet
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    result = evennia.read(login="alt")
+
+    assert result["login"] == "alt"
+    assert evennia._default_login == "alt"
+    assert len(telnet_instances) == 1
+    assert telnet_instances[0].writes[:2] == [
+        b"create alt alt\n",
+        b"connect alt alt\n",
+    ]
+
+
+def test_write_reconnects_on_disconnect(monkeypatch):
+    _reset_sessions(monkeypatch)
+
+    telnet_first = DummyTelnet(fail_first_write=True)
+    telnet_second = DummyTelnet(outputs=[b"Reconnected.\n"])
+    created = iter([telnet_first, telnet_second])
+
+    def fake_telnet(host, port, timeout):
+        return next(created)
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    session = evennia.EvenniaSession("hero")
+    evennia._sessions["hero"] = session
+    evennia._default_login = "hero"
+
+    result = evennia.write("look")
+
+    assert telnet_first.closed is True
+    assert telnet_second.writes[0] == b"connect hero hero\n"
+    assert telnet_second.writes[-1] == b"look\n"
+    assert "look" in result["inputs"]
+    assert result["buffer"] == "Reconnected.\n"
+
+
+def test_shell_requires_interactive(monkeypatch):
+    _reset_sessions(monkeypatch)
+
+    telnet = DummyTelnet()
+
+    def fake_telnet(host, port, timeout):
+        return telnet
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    monkeypatch.setattr(gw, "interactive_enabled", False)
+
+    with pytest.raises(RuntimeError):
+        evennia.shell(login="hero", input_stream=io.StringIO(""), output_stream=io.StringIO())
+
+
+def test_shell_sends_commands_and_reads_output(monkeypatch):
+    _reset_sessions(monkeypatch)
+
+    telnet = DummyTelnet(outputs=[b"Welcome!\n"])
+
+    def write_with_response(self, data: bytes) -> None:
+        self.writes.append(data)
+        if data == b"look\n":
+            self.outputs.append(b"You see nothing special.\n")
+
+    telnet.write = types.MethodType(write_with_response, telnet)
+
+    def fake_telnet(host, port, timeout):
+        return telnet
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    monkeypatch.setattr(gw, "interactive_enabled", True)
+
+    input_stream = io.StringIO("look\n")
+    output_stream = io.StringIO()
+
+    result = evennia.shell(
+        login="hero",
+        input_stream=input_stream,
+        output_stream=output_stream,
+        prompt="> ",
+    )
+
+    assert telnet.writes[-1] == b"look\n"
+    assert "You see nothing special.\n" in output_stream.getvalue()
+    assert result["commands"] == ["look"]
+    assert result["gway_results"] == []
+    assert result["reason"] == "eof"
+
+
+def test_shell_runs_gway_command(monkeypatch):
+    _reset_sessions(monkeypatch)
+
+    telnet = DummyTelnet()
+
+    def fake_telnet(host, port, timeout):
+        return telnet
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    monkeypatch.setattr(gw, "interactive_enabled", True)
+
+    captured: dict[str, object] = {}
+
+    def fake_process(command_sources, *, origin, gw_instance, **context):
+        captured["command_sources"] = command_sources
+        captured["gw_instance"] = gw_instance
+        return ["ignored"], "Hello world"
+
+    monkeypatch.setattr(evennia.gway_console, "process", fake_process)
+
+    output_stream = io.StringIO()
+
+    result = evennia.shell(
+        login="hero",
+        input_stream=io.StringIO(">clock.now\n"),
+        output_stream=output_stream,
+        prompt="",
+    )
+
+    assert captured["command_sources"] == [["clock.now"]]
+    assert captured["gw_instance"] is gw
+    assert "Hello world" in output_stream.getvalue()
+    assert result["commands"] == []
+    assert result["gway_results"] == [
+        {"command": "clock.now", "tokens": ["clock.now"], "result": "Hello world"}
+    ]
+
+
+def test_shell_resolves_sigils_in_commands(monkeypatch):
+    _reset_sessions(monkeypatch)
+
+    telnet = DummyTelnet()
+
+    def fake_telnet(host, port, timeout):
+        return telnet
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    monkeypatch.setattr(gw, "interactive_enabled", True)
+    gw.results.clear()
+    gw.results.update({"direction": "north"})
+
+    evennia.shell(
+        login="hero",
+        input_stream=io.StringIO("go [direction]\n"),
+        output_stream=io.StringIO(),
+        prompt="",
+    )
+
+    assert telnet.writes[-1] == b"go north\n"
+    gw.results.clear()
+
+
+def test_shell_resolves_sigils_in_gway_commands(monkeypatch):
+    _reset_sessions(monkeypatch)
+
+    telnet = DummyTelnet()
+
+    def fake_telnet(host, port, timeout):
+        return telnet
+
+    _install_telnet_factory(monkeypatch, fake_telnet)
+
+    monkeypatch.setattr(gw, "interactive_enabled", True)
+    gw.results.clear()
+    gw.results.update({"task": "status"})
+
+    captured: dict[str, object] = {}
+
+    def fake_process(command_sources, *, origin, gw_instance, **context):
+        captured["command_sources"] = command_sources
+        captured["gw_instance"] = gw_instance
+        return [], "ok"
+
+    monkeypatch.setattr(evennia.gway_console, "process", fake_process)
+
+    evennia.shell(
+        login="hero",
+        input_stream=io.StringIO(">[task]\n"),
+        output_stream=io.StringIO(),
+        prompt="",
+    )
+
+    assert captured["command_sources"] == [["status"]]
+    assert captured["gw_instance"] is gw
+    gw.results.clear()
+


### PR DESCRIPTION
## Summary
- add an interactive Evennia shell that reuses login sessions, resolves sigils, and can dispatch Gateway commands prefixed with `>`
- surface shell history and Gateway results while guarding against non-interactive execution
- extend the Evennia project tests to cover shell I/O, sigil resolution, and delegated Gateway commands

## Testing
- pytest tests/test_evennia_project.py

------
https://chatgpt.com/codex/tasks/task_e_68cef4691c88832690f6034e789ddabf