### PR TITLE
Add evennia dependency to installation requirements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ description = "Software Project Infrastructure by https://www.gelectriic.com"
 requires-python = ">=3.10"
 license = "MIT"
 classifiers = [ "Programming Language :: Python :: 3", "Operating System :: OS Independent",]
-dependencies = [ "toml", "setuptools", "twine", "build", "colorama", "requests", "dateparser", "django", "docutils", "croniter", "qrcode[pil]", "cryptography", "jinja2", "pygame", "httpx", "pyperclip; platform_system == \"Windows\"", "plyer", "numpy", "pygetwindow; platform_system == \"Windows\"", "duckdb", "pywin32; platform_system == \"Windows\"", "selenium", "webdriver-manager", "bs4", "markdown", "pandas", "openpyxl", "coverage", "argcomplete", "PyJWT", "SpeechRecognition", "sounddevice", "PyYAML", "pywebview",]
+dependencies = [ "toml", "setuptools", "twine", "build", "colorama", "requests", "dateparser", "django", "docutils", "evennia", "croniter", "qrcode[pil]", "cryptography", "jinja2", "pygame", "httpx", "pyperclip; platform_system == \"Windows\"", "plyer", "numpy", "pygetwindow; platform_system == \"Windows\"", "duckdb", "pywin32; platform_system == \"Windows\"", "selenium", "webdriver-manager", "bs4", "markdown", "pandas", "openpyxl", "coverage", "argcomplete", "PyJWT", "SpeechRecognition", "sounddevice", "PyYAML", "pywebview",]
 [[project.authors]]
 name = "Rafael J. Guillén-Osorio"
 email = "tecnologia@gelectriic.com"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ requests
 dateparser
 django
 docutils
+evennia
 croniter
 qrcode[pil]
 cryptography


### PR DESCRIPTION
## Summary
- add evennia to requirements.txt so `gway evennia` commands can install their dependencies
- include evennia in the project dependency list to keep editable installs consistent

## Testing
- pip install -r requirements.txt
- pip install -e .
- gway test --coverage *(fails: ModuleNotFoundError: No module named 'tests.djproj')*


------
https://chatgpt.com/codex/tasks/task_e_68cf26f3d84c83268cb511b3a327041d