### PR TITLE
Enhance recipe comments and RFID trigger workflow

### DIFF
--- a/gway/builtins/recipes.py
+++ b/gway/builtins/recipes.py
@@ -57,7 +57,7 @@ def recipes(*, include_extensions: bool = False) -> list[str]:
     return results
 
 
-def run_recipe(*scripts: str, **context):
+def run_recipe(*scripts: str, section: str | None = None, **context):
     from gway import gw
     """Run commands parsed from .gwr files, falling back to the recipes bundle."""
     from .console import load_recipe, process
@@ -68,7 +68,7 @@ def run_recipe(*scripts: str, **context):
 
     results = []
     for script in scripts:
-        command_sources, comments = load_recipe(script)
+        command_sources, comments = load_recipe(script, section=section)
         if comments:
             gw.debug("Recipe comments:\n" + "\n".join(comments))
         result = process(command_sources, origin="recipe", **context)

--- a/recipes/rfid_trigger.gwr
+++ b/recipes/rfid_trigger.gwr
@@ -1,0 +1,2 @@
+# RFID Trigger
+# Detected RFID UID: [RFID_UID]


### PR DESCRIPTION
## Summary
- print recipe comments with resolved sigils and allow running specific sections, including handling preludes
- add an RFID start_trigger helper that runs a recipe on scans and provide a default recipe that reports the UID
- extend console and RFID tests to cover the new behaviors

## Testing
- pytest tests/test_console.py tests/test_rfid.py

------
https://chatgpt.com/codex/tasks/task_e_68cf3af6c6b0832686c1f3dad8fd67cb