### PR TITLE
Add pip mode to install builtin for auto-upgrade recipe

### DIFF
--- a/recipes/auto_upgrade.gwr
+++ b/recipes/auto_upgrade.gwr
@@ -13,6 +13,7 @@
 # temporary directory automatically when the test succeeds.
 auto-upgrade log-cycle
 temp_env --pip-args=--quiet gway test --on-failure abort
-auto-upgrade install
+install gway --mode pip
 auto-upgrade log-upgrade
+auto-upgrade notify-upgrade
 until --abort --pypi

--- a/tests/test_auto_upgrade_project.py
+++ b/tests/test_auto_upgrade_project.py
@@ -1,6 +1,7 @@
 import os
 import tempfile
 import unittest
+from datetime import datetime
 from pathlib import Path
 from unittest import mock
 
@@ -31,19 +32,17 @@ class AutoUpgradeProjectTests(unittest.TestCase):
         self.assertIn("CHECK", contents)
         self.assertIn("latest=true", contents)
 
-    def test_install_honours_latest_flag(self):
-        result = mock.Mock(returncode=0)
-        with mock.patch.object(auto_upgrade.subprocess, "run", return_value=result) as run_mock:
+    def test_install_delegates_to_builtin(self):
+        with mock.patch.object(gw, "install", return_value=0) as install_mock:
             auto_upgrade.install(latest=True)
 
-        called_args = run_mock.call_args[0][0]
-        self.assertIn("--force-reinstall", called_args)
+        install_mock.assert_called_once_with("gway", mode="pip", latest=True)
 
-        with mock.patch.object(auto_upgrade.subprocess, "run", return_value=result) as run_mock:
-            auto_upgrade.install(latest=False)
+        gw.context["auto_upgrade_latest"] = True
+        with mock.patch.object(gw, "install", return_value=0) as install_mock:
+            auto_upgrade.install()
 
-        called_args = run_mock.call_args[0][0]
-        self.assertNotIn("--force-reinstall", called_args)
+        install_mock.assert_called_once_with("gway", mode="pip", latest=True)
 
     def test_log_upgrade_records_change_and_notifies(self):
         gw.context["auto_upgrade_previous_version"] = "1.0.0"
@@ -70,6 +69,44 @@ class AutoUpgradeProjectTests(unittest.TestCase):
         self.addCleanup(lambda: Path(result["log"]).unlink(missing_ok=True))
         self.assertIn("UPGRADE-SKIPPED | version=2.0.0", contents)
         broadcast_mock.assert_not_called()
+
+    def test_notify_upgrade_emits_gui_or_lcd_message(self):
+        gw.context.update(
+            {
+                "auto_upgrade_previous_version": "1.0.0",
+                "auto_upgrade_current_version": "1.2.3",
+                "auto_upgrade_latest": False,
+            }
+        )
+        fixed_time = datetime(2024, 2, 3, 14, 15)
+
+        with mock.patch.object(auto_upgrade, "_current_release", return_value="27AACE"), mock.patch.object(
+            auto_upgrade.gw, "notify", return_value="lcd"
+        ) as notify_mock:
+            result = auto_upgrade.notify_upgrade(timestamp=fixed_time)
+
+        notify_mock.assert_called_once_with("20240203 14:15", title="gway v1.2.3 r27AACE", timeout=20)
+        self.assertEqual(result["status"], "notified")
+        self.assertEqual(result["channel"], "lcd")
+        self.assertEqual(result["release"], "27AACE")
+        self.assertEqual(result["message"], "20240203 14:15")
+        self.assertIn("auto_upgrade_notification", gw.context)
+
+    def test_notify_upgrade_skips_when_version_unchanged(self):
+        gw.context.update(
+            {
+                "auto_upgrade_previous_version": "2.5.0",
+                "auto_upgrade_current_version": "2.5.0",
+                "auto_upgrade_latest": False,
+            }
+        )
+
+        with mock.patch.object(auto_upgrade.gw, "notify") as notify_mock:
+            result = auto_upgrade.notify_upgrade()
+
+        notify_mock.assert_not_called()
+        self.assertEqual(result["status"], "skipped")
+        self.assertEqual(result["reason"], "version-unchanged")
 
 
 if __name__ == "__main__":  # pragma: no cover - direct execution support


### PR DESCRIPTION
## Summary
- extend the gw.install builtin with a pip mode that upgrades packages, honours --latest, and keeps script behaviour intact
- refactor auto_upgrade.install and recipe execution to rely on the new builtin mode instead of a bespoke pip wrapper
- expand install and auto_upgrade tests to cover the new pip mode behaviour and delegation

## Testing
- gway test --coverage *(fails: ModuleNotFoundError: No module named 'tests.djproj')*
- pytest tests/test_install_builtin.py tests/test_auto_upgrade_project.py


------
https://chatgpt.com/codex/tasks/task_e_68d021ae74d0832699d5a33f5c6c58e8