### PR TITLE
Fix bool union detection for CLI flags

### DIFF
--- a/gway/console.py
+++ b/gway/console.py
@@ -883,7 +883,16 @@ def add_func_args(subparser, func_obj, *, interactive=False, wizard=False):
             else:
                 seen_kw_only = True
                 cli_name = f"--{arg_name.replace('_', '-')}"
-                is_bool = param.annotation is bool or isinstance(param.default, bool)
+                annotation_origin = get_origin(param.annotation)
+                is_union_with_bool = False
+                if annotation_origin in (Union, UnionType):
+                    is_union_with_bool = any(arg is bool for arg in get_args(param.annotation))
+
+                is_bool = (
+                    param.annotation is bool
+                    or isinstance(param.default, bool)
+                    or is_union_with_bool
+                )
                 if is_bool:
                     grp = subparser.add_mutually_exclusive_group(required=False)
                     grp.add_argument(


### PR DESCRIPTION
## Summary
- update CLI argument inference to treat Union annotations containing bool as boolean flags
- ensures flags such as --latest no longer require a value when invoked

## Testing
- pytest tests/test_console.py::TestPrepareKwargParsing::test_optional_positional_precedes_varargs

------
https://chatgpt.com/codex/tasks/task_e_68d044bbf7688326854ea7e0ee562294