### PR TITLE
Rename speech recipe and fix hello-world usage

### DIFF
--- a/recipes/speech-cog.gwr
+++ b/recipes/speech-cog.gwr
@@ -1,4 +1,4 @@
-# file: recipes/speech-recognition.gwr
+# file: recipes/speech-cog.gwr
 #
 # Capture a short audio sample and transcribe it using the speech recognition
 # helpers. The first step records a snippet, and the second step transcribes the
@@ -7,4 +7,4 @@
 
 audio record --duration 5 --immediate
 audio transcribe --source %[audio] --engine auto
-hello-world --greeting Transcript --name %[audio_transcript]
+hello-world --greeting Transcript %[audio_transcript]


### PR DESCRIPTION
## Summary
- rename the speech transcription recipe to `speech-cog`
- pass the audio transcript to `hello-world` as a positional argument to avoid argparse errors

## Testing
- `gway test --coverage` *(fails: existing errors in auto_upgrade.log_upgrade and missing tests.djproj module)*

------
https://chatgpt.com/codex/tasks/task_e_68d06ec6d6b08326988c837880833b4c