### PR TITLE
Add buffering and looping controls to speech-cog recipe

### DIFF
--- a/recipes/speech-cog.gwr
+++ b/recipes/speech-cog.gwr
@@ -1,10 +1,12 @@
 # file: recipes/speech-cog.gwr
 #
 # Capture a short audio sample and transcribe it using the speech recognition
-# helpers. The first step records a snippet, and the second step transcribes the
-# saved file. Finally the transcript is echoed via the built-in hello_world
-# helper for quick confirmation.
+# helpers. ``--buffer`` records that many seconds of pre-roll before the main
+# clip. ``--loop`` repeats the capture/transcribe cycle until interrupted (use
+# ``--loop N`` to rest ``N`` seconds between cycles).
 
-audio record --duration 5 --immediate
-audio transcribe --source %[audio] --engine auto
+audio configure-loop --loop %[loop|] --rest %[loop_rest|0]
+audio record --duration %[duration|5] --buffer %[buffer|0] --immediate
+audio transcribe --source %[audio] --engine %[engine|auto]
 hello-world --greeting Transcript %[audio_transcript]
+repeat %[speech_cog_repeat_args|--times 0] --rest %[speech_cog_repeat_rest|0]


### PR DESCRIPTION
## Summary
- add an optional buffer parameter to `audio.record` and expose a loop configuration helper
- update the `speech-cog` recipe to accept `--buffer`/`--loop` options and drive `gw.repeat`
- cover the new helpers with unit tests, including buffer frame expectations

## Testing
- python -m pytest tests/test_audio_record.py

------
https://chatgpt.com/codex/tasks/task_e_68d0766a51d083269bcf19865e356598