### PR TITLE
Add GitHub issue watcher monitor

### DIFF
--- a/projects/monitor/github_issue.py
+++ b/projects/monitor/github_issue.py
@@ -1,0 +1,201 @@
+# file: projects/monitor/github_issue.py
+
+"""Monitor helpers for tracking GitHub issue closures."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import requests
+
+from gway import gw
+
+API_ROOT = "https://api.github.com"
+
+
+def _now_iso() -> str:
+    """Return the current time as an ISO-8601 string (seconds precision)."""
+
+    return datetime.now().isoformat(timespec="seconds")
+
+
+def _normalize_issue(issue: int | str | None) -> int:
+    """Return the numeric issue identifier from user input."""
+
+    if issue is None:
+        raise ValueError("issue number is required")
+    if isinstance(issue, int):
+        if issue <= 0:
+            raise ValueError("issue number must be positive")
+        return issue
+    cleaned = str(issue).strip().lstrip("#")
+    if not cleaned.isdigit():
+        raise ValueError(f"invalid issue number: {issue}")
+    number = int(cleaned)
+    if number <= 0:
+        raise ValueError("issue number must be positive")
+    return number
+
+
+def _github_headers(token: str | None) -> dict[str, str]:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "User-Agent": "gway-monitor",
+    }
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return headers
+
+
+def _fetch_issue(
+    repo: str,
+    issue: int,
+    *,
+    session: Any | None = None,
+    token: str | None = None,
+    timeout: float = 10.0,
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Return ``(payload, error)`` from the GitHub API."""
+
+    auth_token = token if token is not None else gw.hub.get_token(default=None)
+    headers = _github_headers(auth_token)
+    url = f"{API_ROOT}/repos/{repo}/issues/{issue}"
+    getter = session.get if session is not None else requests.get
+    try:
+        response = getter(url, headers=headers, timeout=timeout)
+    except requests.RequestException as exc:  # pragma: no cover - network failure
+        return None, f"GitHub request failed: {exc}"
+    except Exception as exc:  # pragma: no cover - unexpected failure
+        return None, f"GitHub request error: {exc}"
+
+    if response.status_code != 200:
+        message = (response.text or "").strip() or getattr(response, "reason", "") or "unknown"
+        if response.status_code == 404:
+            message = f"Issue #{issue} not found in {repo}"
+        else:
+            message = f"GitHub API error {response.status_code}: {message}"
+        return None, message
+
+    try:
+        return response.json(), None
+    except ValueError:
+        return None, "Invalid JSON response from GitHub"
+
+
+def _issue_state(payload: dict[str, Any], repo: str, checked_at: str) -> dict[str, Any]:
+    """Extract relevant fields from the GitHub payload."""
+
+    closed = (payload.get("state") == "closed")
+    user = payload.get("user") or {}
+    closed_by = payload.get("closed_by") or {}
+    labels = [lbl.get("name") for lbl in payload.get("labels") or [] if isinstance(lbl, dict)]
+    return {
+        "repo": repo,
+        "number": payload.get("number"),
+        "title": payload.get("title"),
+        "state": payload.get("state"),
+        "closed": closed,
+        "closed_at": payload.get("closed_at"),
+        "updated_at": payload.get("updated_at"),
+        "url": payload.get("html_url"),
+        "user": user.get("login"),
+        "closed_by": closed_by.get("login") if closed else None,
+        "labels": [label for label in labels if label],
+        "checked_at": checked_at,
+    }
+
+
+def monitor_github_issue(
+    issue: int | str | None = None,
+    *,
+    repo: str = "arthexis/gway",
+    session: Any | None = None,
+    token: str | None = None,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Update monitor state for a GitHub issue and report its closure."""
+
+    issue_number = _normalize_issue(issue)
+    checked_at = _now_iso()
+    payload, error = _fetch_issue(repo, issue_number, session=session, token=token, timeout=timeout)
+
+    state = gw.monitor.get_state("github_issue")
+    issues = dict(state.get("issues") or {})
+    issue_key = str(issue_number)
+
+    update = {
+        "issues": issues,
+        "last_monitor_check": checked_at,
+        "last_issue_checked": issue_key,
+    }
+
+    if error:
+        issues[issue_key] = {
+            "repo": repo,
+            "number": issue_number,
+            "error": error,
+            "closed": None,
+            "checked_at": checked_at,
+        }
+        update["last_error"] = error
+        update["last_closed_issue"] = None
+        update["last_closed_at"] = None
+        gw.monitor.set_states("github_issue", update)
+        return {
+            "issue": issue_number,
+            "repo": repo,
+            "closed": None,
+            "ok": False,
+            "error": error,
+        }
+
+    issue_state = _issue_state(payload, repo, checked_at)
+    issues[issue_key] = issue_state
+
+    update["last_error"] = None
+    if issue_state["closed"]:
+        update["last_closed_issue"] = issue_key
+        update["last_closed_at"] = issue_state.get("closed_at")
+    else:
+        update["last_closed_issue"] = None
+        update["last_closed_at"] = None
+
+    gw.monitor.set_states("github_issue", update)
+
+    return {
+        "issue": issue_number,
+        "repo": repo,
+        "title": issue_state.get("title"),
+        "url": issue_state.get("url"),
+        "state": issue_state.get("state"),
+        "closed": issue_state["closed"],
+        "ok": issue_state["closed"],
+    }
+
+
+def render_github_issue(issue: int | str | None = None) -> str:
+    """Return an HTML fragment showing the state of the requested issue."""
+
+    issue_number = _normalize_issue(issue)
+    state = gw.monitor.get_state("github_issue")
+    data = (state.get("issues") or {}).get(str(issue_number))
+    if not data:
+        return f"<div>No data for issue #{issue_number}.</div>"
+    status = "closed" if data.get("closed") else "open"
+    title = data.get("title") or "(no title)"
+    url = data.get("url")
+    repo = data.get("repo")
+    checked = data.get("checked_at") or "-"
+    closed_at = data.get("closed_at") or "-"
+    parts = [
+        f"<div class='github-issue'><strong>{repo}#{issue_number}</strong>: {title}</div>",
+        f"<div>Status: <b>{status}</b></div>",
+        f"<div>Last checked: {checked}</div>",
+    ]
+    if url:
+        parts.append(f"<div><a href='{url}'>View on GitHub</a></div>")
+    if data.get("closed"):
+        parts.append(f"<div>Closed at: {closed_at}</div>")
+    return "".join(parts)
+

--- a/tests/test_monitor_github_issue.py
+++ b/tests/test_monitor_github_issue.py
@@ -1,0 +1,129 @@
+import unittest
+
+from gway import gw
+
+
+class DummyResponse:
+    def __init__(self, *, status_code=200, json_data=None, text="", reason=""):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.text = text
+        self.reason = reason
+
+    def json(self):
+        if self._json_data is None:
+            raise ValueError("No JSON payload")
+        return self._json_data
+
+
+class DummySession:
+    def __init__(self, response):
+        self.response = response
+        self.calls = []
+
+    def get(self, url, *, headers=None, timeout=None):
+        self.calls.append({
+            "url": url,
+            "headers": headers,
+            "timeout": timeout,
+        })
+        return self.response
+
+
+class MonitorGithubIssueTests(unittest.TestCase):
+    def setUp(self):
+        gw.monitor.get_state("github_issue").clear()
+
+    def test_monitor_updates_state_for_open_issue(self):
+        payload = {
+            "number": 42,
+            "state": "open",
+            "title": "Add docs",
+            "html_url": "https://github.com/example/repo/issues/42",
+            "updated_at": "2023-08-01T12:00:00Z",
+            "user": {"login": "alice"},
+        }
+        session = DummySession(DummyResponse(json_data=payload))
+
+        result = gw.monitor.github_issue.monitor_github_issue(
+            issue=42,
+            repo="example/repo",
+            session=session,
+            token="abc123",
+            timeout=1,
+        )
+
+        self.assertFalse(result["closed"])
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["issue"], 42)
+
+        state = gw.monitor.get_state("github_issue")
+        self.assertIn("last_monitor_check", state)
+        self.assertEqual(state["last_issue_checked"], "42")
+        issue_state = state["issues"]["42"]
+        self.assertEqual(issue_state["title"], "Add docs")
+        self.assertEqual(issue_state["state"], "open")
+        self.assertFalse(issue_state["closed"])
+        self.assertEqual(issue_state["url"], payload["html_url"])
+
+        call = session.calls[0]
+        self.assertEqual(
+            call["url"],
+            "https://api.github.com/repos/example/repo/issues/42",
+        )
+        self.assertEqual(call["headers"].get("Authorization"), "token abc123")
+
+    def test_monitor_marks_issue_closed(self):
+        payload = {
+            "number": 55,
+            "state": "closed",
+            "title": "Fix bug",
+            "html_url": "https://github.com/example/repo/issues/55",
+            "closed_at": "2023-08-01T12:10:00Z",
+            "closed_by": {"login": "bob"},
+        }
+        session = DummySession(DummyResponse(json_data=payload))
+
+        result = gw.monitor.github_issue.monitor_github_issue(
+            issue="#55",
+            repo="example/repo",
+            session=session,
+        )
+
+        self.assertTrue(result["closed"])
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["issue"], 55)
+
+        state = gw.monitor.get_state("github_issue")
+        self.assertEqual(state["last_closed_issue"], "55")
+        self.assertEqual(state["last_closed_at"], payload["closed_at"])
+        issue_state = state["issues"]["55"]
+        self.assertTrue(issue_state["closed"])
+        self.assertEqual(issue_state["closed_by"], "bob")
+
+    def test_monitor_records_error_for_missing_issue(self):
+        session = DummySession(
+            DummyResponse(status_code=404, json_data={}, text="Not Found", reason="Not Found")
+        )
+
+        result = gw.monitor.github_issue.monitor_github_issue(
+            issue=7,
+            repo="example/repo",
+            session=session,
+        )
+
+        self.assertIsNone(result["closed"])
+        self.assertFalse(result["ok"])
+        self.assertIn("not found", result["error"].lower())
+
+        state = gw.monitor.get_state("github_issue")
+        self.assertEqual(state["last_error"], result["error"])
+        self.assertIsNone(state["last_closed_issue"])
+        issue_state = state["issues"]["7"]
+        self.assertEqual(issue_state["error"], result["error"])
+        self.assertIsNone(issue_state["closed"])
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- add a `monitor.github_issue` watcher that polls GitHub for an issue's status, updates shared state, and renders a quick HTML summary
- support custom session/token injection, error handling, and closure tracking in the monitor state
- cover the watcher with unit tests for open, closed, and missing issue responses

## Testing
- python -m pytest tests/test_monitor_github_issue.py
- gway test --coverage *(fails: relies on auto_upgrade.log_upgrade and Django test fixtures that are absent in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d08d4b4728832691d132d7c38b21a1