### PR TITLE
Document LCD Linux dependencies

### DIFF
--- a/data/static/lcd/README.rst
+++ b/data/static/lcd/README.rst
@@ -31,6 +31,20 @@ Setup
 Wire the backpack's ``VCC`` to 5V, ``GND`` to ground, ``SDA`` to GPIO2 and
 ``SCL`` to GPIO3.
 
+Troubleshooting
+===============
+
+If running ``gway lcd show`` prints ``smbus module not found`` the I²C driver
+or the required Linux packages are missing.  Enable I²C and install the
+dependencies with::
+
+    sudo raspi-config  # Interface Options → I2C → Enable
+    sudo apt-get update && sudo apt-get install -y i2c-tools python3-smbus
+
+As an alternative to the system package, install the pure Python fallback::
+
+    pip install smbus2
+
 Usage
 =====
 

--- a/projects/lcd.py
+++ b/projects/lcd.py
@@ -172,8 +172,12 @@ def _import_smbus() -> types.ModuleType | types.SimpleNamespace | None:
             smbus = types.SimpleNamespace(SMBus=SMBus)
         except ModuleNotFoundError:  # pragma: no cover - import error path
             msg = (
-                "smbus module not found. Enable I2C and install 'i2c-tools' and "
-                "'python3-smbus' or 'smbus2'."
+                "smbus module not found. Enable I2C support and install the "
+                "Linux packages before retrying:\n"
+                "  sudo raspi-config  # Interface Options → I2C → Enable\n"
+                "  sudo apt-get update && sudo apt-get install -y i2c-tools python3-smbus\n"
+                "or install the Python fallback module:\n"
+                "  pip install smbus2"
             )
             gw.error(msg)
             print(msg)


### PR DESCRIPTION
## Summary
- expand the LCD troubleshooting guidance with Linux package requirements
- include command-line steps in the runtime error message when smbus is missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dafedde7708326a9a793ac2332cc06