### PR TITLE
Add coverage builtin and README badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,11 @@
 GWAY
 ====
 
+|coverage_badge|
+
+.. |coverage_badge| image:: https://img.shields.io/badge/Coverage-0%25-lightgrey
+   :alt: Test coverage status
+
 Gateway (``gw``) is a lightweight dispatcher that turns every Python function
 into a command line entry.  It includes a recipe
 runner so you can compose automations with only functions


### PR DESCRIPTION
## Summary
- introduce a coverage builtin that reports core and per-project metrics with optional filters
- refresh the test helper to reuse the builtin and keep the README coverage badge in sync
- add a coverage badge placeholder to the README

## Testing
- python -m compileall gway/builtins/testing.py

------
https://chatgpt.com/codex/tasks/task_e_68dc958df3308326a8d0d85f32d7e000