### PR TITLE
Fix auto-upgrade shim regressions and stabilise Django settings import

### DIFF
--- a/projects/auto_upgrade.py
+++ b/projects/auto_upgrade.py
@@ -2,7 +2,7 @@
 
 The Gateway-specific implementation now lives in :mod:`projects.package.gway` so
 other packages can reuse the shared upgrade plumbing exposed by
-:mod:`projects.package`.  This module simply re-exports the ``gway`` sub-project
+:mod:`projects.package`. This module simply re-exports the ``gway`` sub-project
 for backwards compatibility with existing recipes and imports.
 """
 
@@ -11,6 +11,17 @@ from __future__ import annotations
 from gway import gw
 from gway.projects import package
 from gway.projects.package import gway as _gway
+
+__all__ = [
+    "LOG_NAME",
+    "CONFIG",
+    "CycleState",
+    "log_cycle",
+    "install",
+    "log_upgrade",
+    "_current_release",
+    "notify_upgrade",
+]
 
 LOG_NAME = _gway.LOG_NAME
 CONFIG = _gway.CONFIG
@@ -32,26 +43,26 @@ def install(*, latest: bool | str | None = None) -> int:
     """Install or upgrade ``gway`` using the install builtin."""
 
     return package.install(CONFIG, latest=latest)
-  
 
-def notify_upgrade(
+
+def log_upgrade(
     *,
     version: str | None = None,
-    release: str | None = None,
     latest: bool | str | None = None,
-    timestamp: datetime | None = None,
-    timeout: int = 20,
+    log_name: str = LOG_NAME,
+    notify: bool = True,
+    broadcaster=None,
 ) -> dict:
-    """Display a toast/LCD message summarising a successful upgrade."""
+    """Record the outcome of an applied upgrade and optionally notify users."""
 
-    broadcaster = _broadcast if notify else None
+    active = broadcaster if broadcaster is not None else (_broadcast if notify else None)
     return package.log_upgrade(
         CONFIG,
         version=version,
         latest=latest,
         log_name=log_name,
         notify=notify,
-        broadcaster=broadcaster,
+        broadcaster=active,
     )
 
 
@@ -78,13 +89,6 @@ def notify_upgrade(
         latest=latest,
         timestamp=timestamp,
         timeout=timeout,
+        release_lookup=_current_release,
     )
-
-    gw.context["auto_upgrade_notification"] = summary
-    gw.info(
-        "[auto-upgrade] Sent upgrade notification"
-        f" (channel={channel}, version={current_version}, release={release_id})"
-    )
-
-    return summary
 


### PR DESCRIPTION
## Summary
- restore the auto-upgrade shim so log upgrades re-expose the broadcast hook and notify helpers
- ensure the Django model project can load test settings by teaching it to seed namespace packages when needed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68df1d9c787083269b4b9c15904b4211