### PR TITLE
Add utility to annotate CSVs with Odoo quotation IDs

### DIFF
--- a/projects/odoo.py
+++ b/projects/odoo.py
@@ -1,8 +1,228 @@
 # file: projects/odoo.py
 
+import csv
+import re
+import unicodedata
+from pathlib import Path
 from xmlrpc import client
 from datetime import datetime, timedelta
 from gway import gw
+
+
+_TOKEN_RE = re.compile(r"[A-Za-zÀ-ÖØ-öø-ÿ0-9']+")
+
+
+def _strip_accents(value: str) -> str:
+    if not value:
+        return ""
+    normalized = unicodedata.normalize('NFKD', value)
+    return ''.join(ch for ch in normalized if not unicodedata.combining(ch))
+
+
+def _tokenize_name(name: str) -> list[str]:
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for match in _TOKEN_RE.finditer(name or ""):
+        token = match.group(0).strip()
+        if not token:
+            continue
+        canonical = _strip_accents(token).lower()
+        if len(canonical) <= 1:
+            continue
+        if canonical in seen:
+            continue
+        seen.add(canonical)
+        tokens.append(token)
+    return tokens
+
+
+def _resolve_csv_path(csvfile: str) -> Path:
+    if not csvfile:
+        gw.abort("A CSV file name is required")
+
+    raw_value = str(csvfile).strip()
+    if not raw_value:
+        gw.abort("A CSV file name is required")
+
+    path = Path(raw_value)
+    if path.suffix.lower() != ".csv":
+        path = path.with_suffix(".csv")
+
+    attempts: list[str] = []
+
+    def _check(candidate: Path) -> Path | None:
+        attempts.append(str(candidate))
+        if candidate.exists():
+            return candidate.resolve()
+        return None
+
+    if path.is_absolute():
+        resolved = _check(path)
+        if resolved:
+            return resolved
+    else:
+        cwd_candidate = Path.cwd() / path
+        resolved = _check(cwd_candidate)
+        if resolved:
+            return resolved
+
+        base_candidate = Path(gw.base_path) / path
+        resolved = _check(base_candidate)
+        if resolved:
+            return resolved
+
+    client_name = gw.find_value('CLIENT', fallback=None)
+    if not client_name:
+        client_name = gw.find_value('client', fallback=None)
+    if not client_name:
+        client_name = gw.context.get('CLIENT') or gw.context.get('client')
+
+    relative_target = Path(*[part for part in path.parts if part not in ('..', '.')])
+    work_root = Path(gw.base_path) / "work"
+    if client_name:
+        client_candidate = work_root / str(client_name) / relative_target
+        resolved = _check(client_candidate)
+        if resolved:
+            return resolved
+
+    work_candidate = work_root / relative_target
+    resolved = _check(work_candidate)
+    if resolved:
+        return resolved
+
+    gw.abort(
+        "CSV file not found. Checked: " + ", ".join(attempts)
+    )
+
+
+
+def _quote_sort_key(quote: dict) -> tuple[str, str]:
+    create_date = quote.get('create_date') or ""
+    name = quote.get('name') or ""
+    return (create_date, name)
+
+
+def _find_quotes_for_customer(name: str) -> list[str]:
+    normalized_name = (name or "").strip()
+    if not normalized_name:
+        return []
+
+    tokens = _tokenize_name(normalized_name)
+    canonical_tokens = {_strip_accents(token).lower() for token in tokens}
+    if not canonical_tokens and normalized_name:
+        canonical_tokens = {_strip_accents(normalized_name).lower()}
+
+    search_terms: list[str] = []
+    seen_terms: set[str] = set()
+
+    for candidate in (normalized_name, _strip_accents(normalized_name)):
+        candidate = candidate.strip()
+        if not candidate:
+            continue
+        canonical = _strip_accents(candidate).lower()
+        if canonical in seen_terms:
+            continue
+        seen_terms.add(canonical)
+        search_terms.append(candidate)
+
+    for token in tokens:
+        for variant in (token, _strip_accents(token)):
+            if not variant:
+                continue
+            canonical = _strip_accents(variant).lower()
+            if len(canonical) <= 1 or canonical in seen_terms:
+                continue
+            seen_terms.add(canonical)
+            search_terms.append(variant)
+
+    fields = ['id', 'name', 'state', 'partner_id', 'create_date']
+    domain_base = [('state', '!=', 'cancel')]
+    quotes_by_id: dict[int, dict] = {}
+
+    for term in search_terms:
+        domain = domain_base + [('partner_id.name', 'ilike', term)]
+        results = execute_kw(
+            [domain], {'fields': fields},
+            model='sale.order', method='search_read'
+        )
+        for quote in results:
+            quote_id = quote.get('id')
+            if not quote_id:
+                continue
+            stored = quotes_by_id.get(quote_id)
+            if stored is None:
+                partner_field = quote.get('partner_id') or []
+                partner_id = None
+                partner_name = ""
+                if isinstance(partner_field, (list, tuple)) and partner_field:
+                    partner_id = partner_field[0]
+                    if len(partner_field) > 1 and isinstance(partner_field[1], str):
+                        partner_name = partner_field[1]
+                elif isinstance(partner_field, int):
+                    partner_id = partner_field
+                stored = dict(quote)
+                stored['_partner_id'] = partner_id
+                stored['_partner_name'] = partner_name
+                stored['_matched_terms'] = set()
+                quotes_by_id[quote_id] = stored
+            stored['_matched_terms'].add(term)
+
+    if not quotes_by_id:
+        return []
+
+    partners: dict[object, dict] = {}
+    for quote in quotes_by_id.values():
+        partner_key = quote.get('_partner_id')
+        partner_name = quote.get('_partner_name') or ""
+        if partner_key is None:
+            partner_key = partner_name
+        group = partners.setdefault(partner_key, {
+            'partner_name': partner_name,
+            'quotes': [],
+            'matched_terms': set(),
+            'latest_date': "",
+            'sent_count': 0,
+        })
+        group['quotes'].append(quote)
+        group['matched_terms'].update(
+            _strip_accents(term).lower()
+            for term in quote.get('_matched_terms', set())
+        )
+        quote_date = quote.get('create_date') or ""
+        if quote_date > group['latest_date']:
+            group['latest_date'] = quote_date
+        if quote.get('state') == 'sent':
+            group['sent_count'] += 1
+
+    for group in partners.values():
+        partner_tokens = {
+            _strip_accents(token).lower()
+            for token in _tokenize_name(group.get('partner_name') or "")
+        }
+        group['token_overlap'] = len(canonical_tokens & partner_tokens)
+
+    best_group = max(
+        partners.values(),
+        key=lambda grp: (
+            grp.get('token_overlap', 0),
+            len(grp.get('matched_terms', set())),
+            grp.get('sent_count', 0),
+            grp.get('latest_date', ""),
+            grp.get('partner_name') or "",
+        )
+    )
+
+    quotes = best_group['quotes']
+    sent_quotes = [quote for quote in quotes if quote.get('state') == 'sent']
+    if len(sent_quotes) == 1:
+        quotes_to_use = sent_quotes
+    elif len(sent_quotes) > 1:
+        quotes_to_use = sent_quotes
+    else:
+        quotes_to_use = quotes
+
+    ordered = sorted(quotes_to_use, key=_quote_sort_key, reverse=True)
+    return [quote.get('name', '') for quote in ordered if quote.get('name')]
 
 
 def execute_kw(*args, model: str, method: str, **kwargs) -> dict:
@@ -524,6 +744,179 @@ def find_quotes(
         quote['matching_lines'] = quote_lines_by_order.get(quote['id'], [])
 
     return quotes
+
+
+def add_quote_ids(
+    *,
+    csvfile: str,
+    name_col: str | int | None = None,
+    quote_col: str = "Quotation",
+) -> dict:
+    """Add quotation identifiers to a CSV file based on customer names.
+
+    Parameters:
+        csvfile (str): Path or name of the CSV file to update.
+        name_col (str | int | None): Column containing customer names. Accepts
+            a header label or a 1-based column number. Defaults to the first
+            column when omitted.
+        quote_col (str): Header to use for the quotation column. Defaults to
+            ``"Quotation"``.
+
+    Returns:
+        dict: Summary including counts of processed rows and matched quotations.
+    """
+    csv_path = _resolve_csv_path(csvfile)
+    gw.info(f"Annotating {csv_path} with quotation identifiers")
+
+    with csv_path.open('r', newline='', encoding='utf-8-sig') as handle:
+        sample = handle.read(2048)
+        handle.seek(0)
+        try:
+            dialect = csv.Sniffer().sniff(sample)
+        except csv.Error:
+            dialect = csv.excel
+        try:
+            has_header = csv.Sniffer().has_header(sample)
+        except csv.Error:
+            has_header = False
+        reader = csv.reader(handle, dialect)
+        rows = [list(row) for row in reader]
+
+    quote_column_name = str(quote_col).strip() if quote_col is not None else ""
+    if not quote_column_name:
+        quote_column_name = "Quotation"
+
+    if not rows:
+        gw.warning(f"CSV file {csv_path} is empty; nothing to annotate")
+        return {
+            'csv_path': str(csv_path),
+            'rows': 0,
+            'matched_rows': 0,
+            'quotes_added': 0,
+            'quote_column': quote_column_name,
+        }
+
+    def _string_to_int(value: str) -> int | None:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    force_header = False
+    if isinstance(name_col, str):
+        stripped = name_col.strip()
+        if stripped:
+            force_header = _string_to_int(stripped) is None
+
+    if rows and force_header:
+        has_header = True
+
+    if has_header and rows:
+        header_row = rows[0][:]
+        data_rows = [row[:] for row in rows[1:]]
+    else:
+        header_row = None
+        data_rows = [row[:] for row in rows]
+
+    def resolve_name_index(value) -> int:
+        if value is None:
+            return 0
+        if isinstance(value, str):
+            stripped = value.strip()
+            if not stripped:
+                return 0
+            numeric = _string_to_int(stripped)
+            if numeric is None:
+                if header_row is None:
+                    gw.abort(
+                        "name_col expects a header label but the CSV has no header row"
+                    )
+                lowered = [(col or "").strip().lower() for col in header_row]
+                target = stripped.lower()
+                if target in lowered:
+                    return lowered.index(target)
+                gw.abort(f"Column '{stripped}' not found in CSV header")
+            value = numeric
+        try:
+            index = int(value)
+        except (TypeError, ValueError):
+            gw.abort(f"Invalid name_col value: {value}")
+        if index < 0:
+            gw.abort("name_col cannot be negative")
+        return index - 1 if index > 0 else 0
+
+    name_index = resolve_name_index(name_col)
+
+    if header_row is not None and name_index >= len(header_row):
+        gw.abort(
+            f"name_col index {name_index} is outside the header range ({len(header_row)} columns)"
+        )
+
+    if header_row is not None:
+        normalized_header = [(col or "").strip().lower() for col in header_row]
+        try:
+            quote_index = normalized_header.index(quote_column_name.lower())
+            header_row[quote_index] = quote_column_name
+        except ValueError:
+            header_row.append(quote_column_name)
+            quote_index = len(header_row) - 1
+    else:
+        quote_index = max((len(row) for row in data_rows), default=0)
+
+    processed_rows: list[list[str]] = []
+    if header_row is not None:
+        processed_rows.append(header_row)
+
+    quote_cache: dict[str, list[str]] = {}
+    matched_rows = 0
+    quotes_added = 0
+
+    for row in data_rows:
+        row_data = list(row)
+        raw_name = row_data[name_index] if name_index < len(row_data) else ""
+        customer_name = str(raw_name).strip() if raw_name is not None else ""
+        if customer_name:
+            cache_key = _strip_accents(customer_name).lower() or customer_name.lower()
+            cached = quote_cache.get(cache_key)
+            if cached is None:
+                cached = _find_quotes_for_customer(customer_name)
+                quote_cache[cache_key] = cached
+            quotes = cached
+        else:
+            quotes = []
+
+        if quotes:
+            matched_rows += 1
+            quotes_added += len(quotes)
+            quote_value = " ".join(quotes)
+        else:
+            quote_value = ""
+
+        target_index = quote_index if quote_index is not None else len(row_data)
+        while len(row_data) <= target_index:
+            row_data.append("")
+        row_data[target_index] = quote_value
+        processed_rows.append(row_data)
+
+    with csv_path.open('w', newline='', encoding='utf-8') as handle:
+        writer = csv.writer(handle, dialect)
+        writer.writerows(processed_rows)
+
+    total_rows = len(data_rows)
+    gw.info(
+        f"Updated {csv_path}: matched {matched_rows}/{total_rows} rows, "
+        f"recorded {quotes_added} quotations in column '{quote_column_name}'"
+    )
+
+    return {
+        'csv_path': str(csv_path),
+        'rows': total_rows,
+        'matched_rows': matched_rows,
+        'quotes_added': quotes_added,
+        'quote_column': quote_column_name,
+        'name_column_index': name_index,
+        'quote_column_index': quote_index,
+    }
 
 
 def fetch_projects(*, name=None):


### PR DESCRIPTION
## Summary
- add helper utilities to locate CSV files and normalize customer name tokens when searching for quotes
- implement quote matching that filters out cancelled orders, prefers sent quotes, and supports accent-insensitive name searches
- create add_quote_ids command to append quotation identifiers to CSV rows and reuse lookups via caching

## Testing
- python -m compileall projects/odoo.py

------
https://chatgpt.com/codex/tasks/task_e_68df279ede308326ba6376bf155c1eb9