### PR TITLE
Fix fallback handling for sigil defaults

### DIFF
--- a/tests/test_sigils.py
+++ b/tests/test_sigils.py
@@ -36,6 +36,18 @@ class SigilTests(unittest.TestCase):
         s = Sigil('Key is ["LITERAL"]')
         self.assertEqual(s % {}, 'Key is LITERAL')
 
+    def test_fallback_literal_is_used_when_missing(self):
+        s = Sigil("%[user|Guest]")
+        self.assertEqual(s % {}, "Guest")
+
+    def test_fallback_prefers_resolved_value(self):
+        s = Sigil("%[user|Guest]")
+        self.assertEqual(s % {"user": "Alice"}, "Alice")
+
+    def test_fallback_supports_nested_sigils(self):
+        self._set_context("FALLBACK", "Alt")
+        self.assertEqual(gw.resolve("%[unknown|[FALLBACK]]"), "Alt")
+
     def test_unresolved_unquoted_raises(self):
         s = Sigil("Oops [nope]")
         with self.assertRaises(KeyError):


### PR DESCRIPTION
## Summary
- add fallback handling to `_resolve_single` so `%[key|default]` expressions resolve to a default value when the key is absent
- treat eager sigils that wrap a single placeholder as a unit, allowing nested fallbacks to resolve correctly
- expand the sigil test suite to cover literal defaults, overriding values, and nested fallback resolution

## Testing
- pytest tests/test_sigils.py

------
https://chatgpt.com/codex/tasks/task_e_68e32b20cdb483269692f482ef9f6362