### PR TITLE
Fix Windows upgrade path handling

### DIFF
--- a/projects/package/gway.py
+++ b/projects/package/gway.py
@@ -369,7 +369,10 @@ def upgrade_builtin(*args, _temp_env=None):
                 return 1
 
     script = gw.resource("upgrade.sh", check=True)
-    cmd = ["bash", os.fspath(script), *forwarded_args]
+    script_path = os.fspath(script)
+    if os.name == "nt":  # pragma: no cover - exercised via unit test patching
+        script_path = script.as_posix()
+    cmd = ["bash", script_path, *forwarded_args]
 
     def _stream(src, dst):
         for line in src:

--- a/tests/test_upgrade_builtin.py
+++ b/tests/test_upgrade_builtin.py
@@ -7,6 +7,7 @@ import time
 import subprocess
 from io import StringIO
 from unittest.mock import patch
+import pathlib
 from gway import gw
 
 
@@ -26,7 +27,6 @@ class UpgradeBuiltinTests(unittest.TestCase):
                 f.write("#!/usr/bin/env bash\n")
                 f.write("echo \"called with: $@\"\n")
             os.chmod(script, 0o755)
-            import pathlib
             with patch.object(gw, "resource", return_value=pathlib.Path(script)):
                 rc = gw.upgrade("--force", "--latest", "--no-test")
         self.assertEqual(rc, 0)
@@ -56,7 +56,6 @@ class UpgradeBuiltinTests(unittest.TestCase):
                 f.write("sleep 1\n")
                 f.write("echo end\n")
             os.chmod(script, 0o755)
-            import pathlib
             with patch.object(gw, "resource", return_value=pathlib.Path(script)):
                 t = threading.Thread(target=gw.upgrade)
                 t.start()
@@ -72,7 +71,6 @@ class UpgradeBuiltinTests(unittest.TestCase):
                 f.write("#!/usr/bin/env bash\n")
                 f.write("echo \"called with: $@\"\n")
             os.chmod(script, 0o755)
-            import pathlib
             with patch.object(gw, "resource", return_value=pathlib.Path(script)):
                 with patch("gway.builtins.core.temp_env") as mock_temp_env:
                     rc = gw.upgrade("--safe", "--force")
@@ -97,7 +95,6 @@ class UpgradeBuiltinTests(unittest.TestCase):
                 f.write("#!/usr/bin/env bash\n")
                 f.write("echo \"called with: $@\"\n")
             os.chmod(script, 0o755)
-            import pathlib
             with patch.object(gw, "resource", return_value=pathlib.Path(script)):
                 with patch("gway.builtins.core.temp_env") as mock_temp_env:
                     rc = gw.upgrade("--safe", "--test")
@@ -116,7 +113,6 @@ class UpgradeBuiltinTests(unittest.TestCase):
                 f.write("#!/usr/bin/env bash\n")
                 f.write("echo \"called with: $@\"\n")
             os.chmod(script, 0o755)
-            import pathlib
             with patch.object(gw, "resource", return_value=pathlib.Path(script)):
                 with patch("gway.builtins.core.temp_env") as mock_temp_env:
                     rc = gw.upgrade("--safe", "--no-test")
@@ -134,7 +130,6 @@ class UpgradeBuiltinTests(unittest.TestCase):
                 f.write("#!/usr/bin/env bash\n")
                 f.write("echo should-not-run\n")
             os.chmod(script, 0o755)
-            import pathlib
             with patch.object(gw, "resource", return_value=pathlib.Path(script)):
                 with patch("gway.builtins.core.temp_env", side_effect=failure):
                     with patch("subprocess.Popen") as mock_popen:
@@ -142,6 +137,45 @@ class UpgradeBuiltinTests(unittest.TestCase):
         self.assertEqual(rc, 5)
         mock_popen.assert_not_called()
         self.assertNotIn("should-not-run", self.stdout.getvalue())
+
+    def test_upgrade_normalizes_windows_path_for_bash(self):
+        win_path = pathlib.PureWindowsPath("C:/Users/test/gway/upgrade.sh")
+
+        class ImmediateThread:
+            def __init__(self, target=None, args=None, **_kwargs):
+                self._target = target
+                self._args = args or ()
+
+            def start(self):
+                if self._target:
+                    self._target(*self._args)
+
+            def join(self):
+                return None
+
+        class DummyProcess:
+            def __init__(self):
+                self.stdout = StringIO("")
+                self.stderr = StringIO("")
+                self.returncode = 0
+
+            def wait(self):
+                return None
+
+        fake_process = DummyProcess()
+
+        with patch("os.name", "nt"), patch.object(
+            gw, "resource", return_value=win_path
+        ), patch("threading.Thread", ImmediateThread), patch(
+            "gway.projects.package.gway.subprocess.Popen", return_value=fake_process
+        ) as mock_popen:
+            rc = gw.upgrade("--force")
+
+        self.assertEqual(rc, 0)
+        called_cmd = mock_popen.call_args[0][0]
+        self.assertEqual(called_cmd[0], "bash")
+        self.assertEqual(called_cmd[1], "C:/Users/test/gway/upgrade.sh")
+        self.assertIn("--force", called_cmd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- ensure the upgrade shim converts Windows paths to POSIX form before passing them to bash
- cover the Windows path normalization logic with a new unit test

## Testing
- pytest tests/test_upgrade_builtin.py

------
https://chatgpt.com/codex/tasks/task_e_68e436510d0083268c0aad0a198dbc0c