### PR TITLE
Fix Windows upgrade script selection

### DIFF
--- a/projects/package/gway.py
+++ b/projects/package/gway.py
@@ -368,11 +368,16 @@ def upgrade_builtin(*args, _temp_env=None):
                     pass
                 return 1
 
-    script = gw.resource("upgrade.sh", check=True)
-    script_path = os.fspath(script)
+    script_name = "upgrade.sh"
+    runner: list[str] = ["bash"]
+
     if os.name == "nt":  # pragma: no cover - exercised via unit test patching
-        script_path = script.as_posix()
-    cmd = ["bash", script_path, *forwarded_args]
+        script_name = "upgrade.bat"
+        runner = ["cmd", "/c"]
+
+    script = gw.resource(script_name, check=True)
+    script_path = os.fspath(script)
+    cmd = [*runner, script_path, *forwarded_args]
 
     def _stream(src, dst):
         for line in src:

--- a/tests/test_upgrade_builtin.py
+++ b/tests/test_upgrade_builtin.py
@@ -138,8 +138,8 @@ class UpgradeBuiltinTests(unittest.TestCase):
         mock_popen.assert_not_called()
         self.assertNotIn("should-not-run", self.stdout.getvalue())
 
-    def test_upgrade_normalizes_windows_path_for_bash(self):
-        win_path = pathlib.PureWindowsPath("C:/Users/test/gway/upgrade.sh")
+    def test_upgrade_uses_windows_batch_script(self):
+        win_path = pathlib.PureWindowsPath("C:/Users/test/gway/upgrade.bat")
 
         class ImmediateThread:
             def __init__(self, target=None, args=None, **_kwargs):
@@ -173,8 +173,9 @@ class UpgradeBuiltinTests(unittest.TestCase):
 
         self.assertEqual(rc, 0)
         called_cmd = mock_popen.call_args[0][0]
-        self.assertEqual(called_cmd[0], "bash")
-        self.assertEqual(called_cmd[1], "C:/Users/test/gway/upgrade.sh")
+        self.assertEqual(called_cmd[0], "cmd")
+        self.assertEqual(called_cmd[1], "/c")
+        self.assertEqual(called_cmd[2], os.fspath(win_path))
         self.assertIn("--force", called_cmd)
 
 


### PR DESCRIPTION
## Summary
- invoke `upgrade.bat` via `cmd /c` when running `gway upgrade` on Windows
- update the upgrade builtin test to cover the Windows batch invocation

## Testing
- pytest tests/test_upgrade_builtin.py

------
https://chatgpt.com/codex/tasks/task_e_68e43eb5a7148326a54db347110ee4e6