### PR TITLE
Add temp env smoke test workflow

### DIFF
--- a/.github/workflows/temp-env-smoke.yml
+++ b/.github/workflows/temp-env-smoke.yml
@@ -1,0 +1,21 @@
+name: Temp Env Smoke Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  temp-env-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install gway CLI
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Smoke test PyPI installation
+        run: gway temp-env gway test --filter smoke


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that exercises `gway temp-env` to smoke test the PyPI package on pushes to `main` and pull requests

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e5995fe3348326b4c7bab883f4df24